### PR TITLE
Fixed bug (crash) when call to cc_flww32_get_bitmap() fails

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,4 +1,9 @@
-New in Coin v4.0.0 (so far):
+New in Coin v4.1.0 (so far):
+* bugfixes:
+  - fixed crash when reading font glyphs fails
+  - use font base line as bearing point for default font
+
+New in Coin v4.0.0 (2019-12-23):
 * new:
   - Kongsberg Oil & Gas Technologies AS ended Coin as a commercial product
     and re-licensed it under the BSD 3-clause license as a service to the

--- a/RELNOTES
+++ b/RELNOTES
@@ -8,6 +8,16 @@ The changes described here are issues that might have an effect on the
 compatibility of your source code when upgrading the library.
 
 
+Coin 4.1.0 (so far)
+==========
+
+Reference line for text rendered with the built-in default font was changed
+(before: descender line, now: base line). Thus text rendered with default
+font will appear a few pixels lower than before, but now consistent
+with text using non-default fonts.
+(see https://github.com/coin3d/coin/pull/368)
+
+
 Coin 4.0.0
 ==========
 

--- a/src/fonts/builtin2dfonts.icc
+++ b/src/fonts/builtin2dfonts.icc
@@ -11,6 +11,11 @@
 #define COIN_FONT_25_HEIGHT (27)
 #define COIN_FONT_33_HEIGHT (36)
 
+#define COIN_FONT_13_BEARING (12)
+#define COIN_FONT_17_BEARING (15)
+#define COIN_FONT_25_BEARING (21)
+#define COIN_FONT_33_BEARING (28)
+
 static uint8_t font_data_13[256][COIN_FONT_13_HEIGHT*4] = {
 #include "font13.icc"
 };

--- a/src/fonts/default2dfont.cpp
+++ b/src/fonts/default2dfont.cpp
@@ -229,6 +229,15 @@ coin_default2dfont_get_width(float size)
   else { return COIN_FONT_33_WIDTH; }
 }
 
+int
+coin_default2dfont_get_bearing(float size)
+{
+  if ( size < 14.0f ) { return COIN_FONT_13_BEARING; }
+  else if ( size < 18.0f ) { return COIN_FONT_17_BEARING; }
+  else if ( size < 26.0f ) { return COIN_FONT_25_BEARING; }
+  else { return COIN_FONT_33_BEARING; }
+}
+
 const unsigned char *
 coin_default2dfont_get_data(float size)
 {

--- a/src/fonts/defaultfonts.h
+++ b/src/fonts/defaultfonts.h
@@ -47,6 +47,7 @@ extern "C" {
 
 int coin_default2dfont_get_height(float size);
 int coin_default2dfont_get_width(float size);
+int coin_default2dfont_get_bearing(float size);
 const unsigned char * coin_default2dfont_get_data(float size);
 
 const float ** coin_default3dfont_get_coords(void);

--- a/src/fonts/fontlib_wrapper.cpp
+++ b/src/fonts/fontlib_wrapper.cpp
@@ -263,7 +263,7 @@ get_default_bitmap(unsigned int character, float wantedsize)
     bm = (struct cc_font_bitmap *) malloc(sizeof(struct cc_font_bitmap));
     bm->buffer = fontdata + fontheight * 4 * character;
     bm->bearingX = 0;
-    bm->bearingY = fontheight;
+    bm->bearingY = coin_default2dfont_get_bearing(wantedsize);
     bm->rows = fontheight;
     bm->width = coin_default2dfont_get_width(wantedsize);
     bm->pitch = 4;
@@ -881,6 +881,7 @@ cc_flw_get_bitmap(int font, unsigned int glyph)
       /* glyph handle == char value in default font. &255 to avoid
          index out of range. */
       bm = get_default_bitmap(gs->nativeglyphidx & 0xff, (float)fs->sizey);
+      gs->fromdefaultfont = TRUE;
     }
     else if (bm && bm->buffer) {
       buf = (unsigned char *)malloc(bm->pitch * bm->rows);


### PR DESCRIPTION
I would like to ask you to review a change in the Coin font handling.

Currently, Coin will crash when it fails to read a glyph either from the freetype library or from Win32. Although there is some error handling in place (Coin reads the glyph from the built-in default font), there are two problems:
- it does not mark the glyph as "fromdefaultfont", which causes several functions to fail (e.g. cc_flw_get_bitmap_advance() will return invalid information about how to advance to the next glyph in a text) and it will crash when it tries to free the glyph bitmap memory (fontstruct_rmglyph)
- glyphs from the default font use a different reference line than other fonts. The default font uses the descender line, while other fonts usually use the base line.

The first problem can be solved by properly setting the "fromdefaultfont" flag. I did quite some code review and testing, and I think that setting this flag truely solves the problem.

The second problem can be solved by setting the "bearing" for the default font in the same way as for fonts that use the freetype library or Win32 API. Note that this change will change the rendering output of any Coin program that uses the default font. However, I think it makes sense to have consistent behavior of all fonts.

Here is some Illustration, how text will be rendered before and after my fix (default font is rendered on the left, while "Times New Roman" is rendered on the Right).

![old](https://user-images.githubusercontent.com/58134572/72750999-a8cc2e80-3bbe-11ea-9cab-f2e198c9215b.png)
![new](https://user-images.githubusercontent.com/58134572/72751004-ac5fb580-3bbe-11ea-99f4-0df25558ecd2.png)

P.S. The reason why I need this fix is that in my project we observe sporadic issues with the GetGlyphOutline Win32 function, which fails sporadically. I'm still trying to find the root cause for the failure of this function, but I think it still makes sense to fix the issues with the Coin font handling.

