### PR TITLE
Fix for improper comparison of parameter type in SoGLSLShaderParameter

### DIFF
--- a/src/shaders/SoGLSLShaderParameter.h
+++ b/src/shaders/SoGLSLShaderParameter.h
@@ -88,6 +88,7 @@ private:
   SbBool isActive;
   int32_t programid;
 
+  SbBool isEqual(GLenum type1, GLenum type2);
   SbBool isValid(const SoGLShaderObject * shader, const char * name,
                  GLenum type, int * num = NULL);
 };


### PR DESCRIPTION
Rather than setting the cacheType explicitly as proposed in issue #389 the isEqual method has been implemented as in class SoGLCgShaderParameter.