### PR TITLE
Do not disable VBO rendering for Intel graphics drivers anymore. Fixe…

### DIFF
--- a/src/glue/gl.cpp
+++ b/src/glue/gl.cpp
@@ -1332,25 +1332,6 @@ glglue_resolve_symbols(cc_glglue * w)
     if (env && (atoi(env) > 0)) { w->glBindBuffer = NULL; }
   }
 
-
-  /*
-    All Intel drivers usually crash when we try to use VBO. This might be a bug in
-    our VBO code, but we choose to disable VBO rendering for all Intel cards until
-    we have time to look into this. pederb, 2007-08-16
-  */
-
-  if (w->glBindBuffer) {
-    if (coin_runtime_os() != COIN_OS_X) { /* Apple has proper drivers */
-      /* Enable users to override this workaround by setting COIN_VBO=1 */
-      const char * env = coin_getenv("COIN_VBO");
-      if (!env || (atoi(env) > 0)) {
-        if (w->vendor_is_intel) {
-          w->glBindBuffer = NULL;
-        }
-      }
-    }
-  }
-
   /*
     Sylvain Carette reported problems with some old 3DLabs drivers and VBO rendering.
     The drivers were from 2006, so we disable VBO rendering if 3DLabs and that driver


### PR DESCRIPTION
…d #406

Recent Intel graphics hardware is known to properly support VBO rendering. So we remove the code for disabling it by default.