### PR TITLE
Fix various typos

### DIFF
--- a/build/Xcode/src/setup.h
+++ b/build/Xcode/src/setup.h
@@ -56,7 +56,7 @@
  * define.
  *
  * Default is to not have this define set, as the import code has not been
- * thoroughty tested and robustified by the main Coin developers yet.
+ * thoroughly tested and robustified by the main Coin developers yet.
  */
 
 /* #undef HAVE_3DS_IMPORT_CAPABILITIES */
@@ -67,7 +67,7 @@
  * All the SpiderMonkey javascript code is wrapped in this
  * define. This is done to make sure the code in Coin-2 and Coin-dev
  * is as equal as possible, making it easier to port fixes and
- * enchancements.
+ * enhancements.
  *
  * Default is to have this define set.
  * If VRML97 is disabled, JavaScript support is also disabled.

--- a/build/msvc10/src/setup.h
+++ b/build/msvc10/src/setup.h
@@ -103,7 +103,7 @@
  * define.
  *
  * Default is to not have this define set, as the import code has not been
- * thoroughty tested and robustified by the main Coin developers yet.
+ * thoroughly tested and robustified by the main Coin developers yet.
  */
 
 #define HAVE_3DS_IMPORT_CAPABILITIES 
@@ -114,7 +114,7 @@
  * All the SpiderMonkey javascript code is wrapped in this
  * define. This is done to make sure the code in Coin-2 and Coin-dev
  * is as equal as possible, making it easier to port fixes and
- * enchancements.
+ * enhancements.
  *
  * Default is to have this define set.
  * If VRML97 is disabled, JavaScript support is also disabled.

--- a/build/msvc6/src/setup.h
+++ b/build/msvc6/src/setup.h
@@ -103,7 +103,7 @@
  * define.
  *
  * Default is to not have this define set, as the import code has not been
- * thoroughty tested and robustified by the main Coin developers yet.
+ * thoroughly tested and robustified by the main Coin developers yet.
  */
 
 #define HAVE_3DS_IMPORT_CAPABILITIES 
@@ -114,7 +114,7 @@
  * All the SpiderMonkey javascript code is wrapped in this
  * define. This is done to make sure the code in Coin-2 and Coin-dev
  * is as equal as possible, making it easier to port fixes and
- * enchancements.
+ * enhancements.
  *
  * Default is to have this define set.
  * If VRML97 is disabled, JavaScript support is also disabled.

--- a/build/msvc7/src/setup.h
+++ b/build/msvc7/src/setup.h
@@ -103,7 +103,7 @@
  * define.
  *
  * Default is to not have this define set, as the import code has not been
- * thoroughty tested and robustified by the main Coin developers yet.
+ * thoroughly tested and robustified by the main Coin developers yet.
  */
 
 #define HAVE_3DS_IMPORT_CAPABILITIES 
@@ -114,7 +114,7 @@
  * All the SpiderMonkey javascript code is wrapped in this
  * define. This is done to make sure the code in Coin-2 and Coin-dev
  * is as equal as possible, making it easier to port fixes and
- * enchancements.
+ * enhancements.
  *
  * Default is to have this define set.
  * If VRML97 is disabled, JavaScript support is also disabled.

--- a/build/msvc8/src/setup.h
+++ b/build/msvc8/src/setup.h
@@ -103,7 +103,7 @@
  * define.
  *
  * Default is to not have this define set, as the import code has not been
- * thoroughty tested and robustified by the main Coin developers yet.
+ * thoroughly tested and robustified by the main Coin developers yet.
  */
 
 #define HAVE_3DS_IMPORT_CAPABILITIES 
@@ -114,7 +114,7 @@
  * All the SpiderMonkey javascript code is wrapped in this
  * define. This is done to make sure the code in Coin-2 and Coin-dev
  * is as equal as possible, making it easier to port fixes and
- * enchancements.
+ * enhancements.
  *
  * Default is to have this define set.
  * If VRML97 is disabled, JavaScript support is also disabled.

--- a/build/msvc9/src/setup.h
+++ b/build/msvc9/src/setup.h
@@ -103,7 +103,7 @@
  * define.
  *
  * Default is to not have this define set, as the import code has not been
- * thoroughty tested and robustified by the main Coin developers yet.
+ * thoroughly tested and robustified by the main Coin developers yet.
  */
 
 #define HAVE_3DS_IMPORT_CAPABILITIES 
@@ -114,7 +114,7 @@
  * All the SpiderMonkey javascript code is wrapped in this
  * define. This is done to make sure the code in Coin-2 and Coin-dev
  * is as equal as possible, making it easier to port fixes and
- * enchancements.
+ * enhancements.
  *
  * Default is to have this define set.
  * If VRML97 is disabled, JavaScript support is also disabled.

--- a/cfg/config.guess
+++ b/cfg/config.guess
@@ -145,7 +145,7 @@ UNAME_VERSION=`(uname -v) 2>/dev/null` || UNAME_VERSION=unknown
 case "${UNAME_MACHINE}:${UNAME_SYSTEM}:${UNAME_RELEASE}:${UNAME_VERSION}" in
     *:NetBSD:*:*)
 	# NetBSD (nbsd) targets should (where applicable) match one or
-	# more of the tupples: *-*-netbsdelf*, *-*-netbsdaout*,
+	# more of the tuples: *-*-netbsdelf*, *-*-netbsdaout*,
 	# *-*-netbsdecoff* and *-*-netbsd*.  For targets that recently
 	# switched to ELF, *-*-netbsd* would select the old
 	# object file format.  This provides both forward

--- a/docs/oiki-launch.txt
+++ b/docs/oiki-launch.txt
@@ -11,7 +11,7 @@ Common Lisp community.
 The site is a Wiki authored web site.  It was therefore named OIki.
 If it has to be an acronym (it has, hasn't it?), let's say it is
 "Open Inventor knowledge index".  The name choice was done just to
-get the pronounciation pun, but don't tell anyone...
+get the pronunciation pun, but don't tell anyone...
 
 Anyways, the main point is that editing is open for everyone.  Amazingly,
 this seems to generally work fine (as in no abuse) for other open Wiki

--- a/include/Inventor/SbByteBuffer.h
+++ b/include/Inventor/SbByteBuffer.h
@@ -73,7 +73,7 @@ class COIN_DLL_API SbByteBuffer {
 
 #endif // !COIN_SBBYTEBUFFER_H
 
-//The SBBYTEBUFFER_PRIVATE_VARIABLES must service an inclusion from the .icc file
+//The SBBYTEBUFFER_PRIVATE_VARIABLES must survive an inclusion from the .icc file
 #ifndef COIN_ICC_INCLUDE
 #undef SBBYTEBUFFER_PRIVATE_VARIABLES
 #endif //COIN_ICC_INCLUDE

--- a/include/Inventor/SbByteBuffer.h
+++ b/include/Inventor/SbByteBuffer.h
@@ -73,7 +73,7 @@ class COIN_DLL_API SbByteBuffer {
 
 #endif // !COIN_SBBYTEBUFFER_H
 
-//The SBBYTEBUFFER_PRIVATE_VARIABLES must survice an inclusion from the .icc file
+//The SBBYTEBUFFER_PRIVATE_VARIABLES must service an inclusion from the .icc file
 #ifndef COIN_ICC_INCLUDE
 #undef SBBYTEBUFFER_PRIVATE_VARIABLES
 #endif //COIN_ICC_INCLUDE

--- a/models/coin_features/texture3.iv
+++ b/models/coin_features/texture3.iv
@@ -213,7 +213,7 @@ Separator {
       }
    }
 
-   # (ROW 3) Check how texure quality setting influences rendering
+   # (ROW 3) Check how texture quality setting influences rendering
    Translation { translation 0 +4 0 }
    Separator {
       USE stdtex

--- a/models/oiv_compliance/texture2.iv
+++ b/models/oiv_compliance/texture2.iv
@@ -166,7 +166,7 @@ Separator {
       }
    }
 
-   # (ROW 2) Check texure/material combination models
+   # (ROW 2) Check texture/material combination models
    Translation { translation 0 +4 0 }
    Separator {
       Texture2 {
@@ -269,7 +269,7 @@ Separator {
    }
 
 
-   # (ROW 3) Check how texure quality setting influences rendering
+   # (ROW 3) Check how texture quality setting influences rendering
    Translation { translation 0 +4 0 }
    Separator {
       Texture2 {

--- a/packaging/macosx/makecointoolspkg.sh.in
+++ b/packaging/macosx/makecointoolspkg.sh.in
@@ -7,7 +7,7 @@
 # 
 # Usage: makecointoolspkg.sh [-v] -r /path/to/coin/prefix
 #  -v   verbose
-#  -r   Location of tools intallation dir (coin configure prefix)
+#  -r   Location of tools installation dir (coin configure prefix)
 #
 # Authors:
 #   Marius Kintel <kintel@sim.no>

--- a/scripts/README
+++ b/scripts/README
@@ -1,5 +1,5 @@
 gpp
-    - rudimentory pre-processor for multi-version doc-files.
+    - rudimentary pre-processor for multi-version doc-files.
 
 templant
     - C++ source modifying tool.  in-file macro expansion through templates.

--- a/src/actions/SoGLRenderAction.cpp
+++ b/src/actions/SoGLRenderAction.cpp
@@ -600,11 +600,11 @@ public:
   void texgenEnable(SbBool enable);
   void eyeLinearTexgen();
 
-  // NVIDIA spesific methods for sorted layers blend
+  // NVIDIA specific methods for sorted layers blend
   void setupRegisterCombinersNV();
   void renderSortedLayersNV(const SoState * state);
 
-  // ARB_fragment_program spesific methods for sorted layers blend
+  // ARB_fragment_program specific methods for sorted layers blend
   void setupFragmentProgram();
   void renderSortedLayersFP(const SoState * state);
 

--- a/src/geo/SoGeoCoordinate.cpp
+++ b/src/geo/SoGeoCoordinate.cpp
@@ -218,7 +218,7 @@ SoGeoCoordinate::getTransform(SoGeoOrigin * origin, const int idx) const
 BOOST_AUTO_TEST_CASE(initialized)
 {
   BOOST_CHECK_MESSAGE(SoGeoCoordinate::getClassTypeId() != SoType::badType(),
-                      "SoGeoCoordinate class not initializated");
+                      "SoGeoCoordinate class not initialized");
   boost::intrusive_ptr<SoGeoCoordinate> node(new SoGeoCoordinate);
   BOOST_CHECK_MESSAGE(node->getTypeId() != SoType::badType(),
                       "missing class initialization");

--- a/src/nodekits/SoNodeKitPath.cpp
+++ b/src/nodekits/SoNodeKitPath.cpp
@@ -294,7 +294,7 @@ SoNodeKitPath::clean(void)
 }
 
 //
-// returns a search action to be used while serching for nodes
+// returns a search action to be used while searching for nodes
 //
 SoSearchAction *
 SoNodeKitPath::getSearchAction(void)

--- a/src/nodes/SoExtSelection.cpp
+++ b/src/nodes/SoExtSelection.cpp
@@ -231,7 +231,7 @@
     drivers. 2002-08-02 handegar.
 
     UPDATE 2004-10-27 mortene: I found a grave overflow error in the
-    calculation of maximumcolorcounter from the values returned fom
+    calculation of maximumcolorcounter from the values returned from
     glGetInteger() -- could the problem mentioned above actually be
     due to this? The explanation given above doesn't seem very
     likely...

--- a/src/nodes/SoFrustumCamera.cpp
+++ b/src/nodes/SoFrustumCamera.cpp
@@ -169,7 +169,7 @@ SoFrustumCamera::viewBoundingBox(const SbBox3f & box, float aspect, float slack)
 
   // First, we want to move the camera in such a way that it is
   // pointing straight at the center of the scene bounding box -- but
-  // without modifiying the rotation value (so we can't use
+  // without modifying the rotation value (so we can't use
   // SoCamera::pointAt()).
   SbVec3f cameradirection;
   this->orientation.getValue().multVec(SbVec3f(0, 0, -1), cameradirection);

--- a/src/nodes/SoOrthographicCamera.cpp
+++ b/src/nodes/SoOrthographicCamera.cpp
@@ -179,7 +179,7 @@ SoOrthographicCamera::viewBoundingBox(const SbBox3f & box,
 
   // We want to move the camera in such a way that it is pointing
   // straight at the center of the scene bounding box -- but without
-  // modifiying the rotation value (so we can't use SoCamera::pointAt()),
+  // modifying the rotation value (so we can't use SoCamera::pointAt()),
   // and positioned at the edge of the bounding sphere.
   SbVec3f cameradirection;
   this->orientation.getValue().multVec(SbVec3f(0, 0, -1), cameradirection);

--- a/src/nodes/SoPerspectiveCamera.cpp
+++ b/src/nodes/SoPerspectiveCamera.cpp
@@ -71,7 +71,7 @@
   \var SoSFFloat SoPerspectiveCamera::heightAngle
 
   The vertical angle of the viewport, also known as "field of view".
-  Default value is 45� (note: value is specified in radians).
+  Default value is 45 degrees (note: value is specified in radians).
 */
 
 // *************************************************************************
@@ -85,7 +85,7 @@ SoPerspectiveCamera::SoPerspectiveCamera()
 {
   SO_NODE_INTERNAL_CONSTRUCTOR(SoPerspectiveCamera);
 
-  SO_NODE_ADD_FIELD(heightAngle, (float(M_PI)/4.0f));  // 45�.
+  SO_NODE_ADD_FIELD(heightAngle, (float(M_PI)/4.0f));  // 45 degrees.
 }
 
 /*!

--- a/src/nodes/SoPerspectiveCamera.cpp
+++ b/src/nodes/SoPerspectiveCamera.cpp
@@ -71,7 +71,7 @@
   \var SoSFFloat SoPerspectiveCamera::heightAngle
 
   The vertical angle of the viewport, also known as "field of view".
-  Default value is 45° (note: value is specified in radians).
+  Default value is 45ï¿½ (note: value is specified in radians).
 */
 
 // *************************************************************************
@@ -85,7 +85,7 @@ SoPerspectiveCamera::SoPerspectiveCamera()
 {
   SO_NODE_INTERNAL_CONSTRUCTOR(SoPerspectiveCamera);
 
-  SO_NODE_ADD_FIELD(heightAngle, (float(M_PI)/4.0f));  // 45°.
+  SO_NODE_ADD_FIELD(heightAngle, (float(M_PI)/4.0f));  // 45ï¿½.
 }
 
 /*!
@@ -148,7 +148,7 @@ SoPerspectiveCamera::viewBoundingBox(const SbBox3f & box, float aspect,
 
   // First, we want to move the camera in such a way that it is
   // pointing straight at the center of the scene bounding box -- but
-  // without modifiying the rotation value (so we can't use
+  // without modifying the rotation value (so we can't use
   // SoCamera::pointAt()).
   SbVec3f cameradirection;
   this->orientation.getValue().multVec(SbVec3f(0, 0, -1), cameradirection);

--- a/src/nodes/SoTextureCoordinate2.cpp
+++ b/src/nodes/SoTextureCoordinate2.cpp
@@ -135,7 +135,7 @@ Separator {
   outside the [0, 1] range can be used to repeat the texture across a
   surface.
 
-  \sa SoTexure2::wrapS, SoTexture2::wrapT
+  \sa SoTexture2::wrapS, SoTexture2::wrapT
 */
 
 // *************************************************************************

--- a/src/nodes/SoTextureCoordinate3.cpp
+++ b/src/nodes/SoTextureCoordinate3.cpp
@@ -91,7 +91,7 @@
   i.e. in the range [0, 1]. Coordinates outside the [0, 1] range can be
   used to repeat the texture across a surface.
 
-  \sa SoTexture3::wrapR, SoTexure3::wrapS, SoTexture3::wrapT 
+  \sa SoTexture3::wrapR, SoTexture3::wrapS, SoTexture3::wrapT 
 */
 
 // *************************************************************************

--- a/src/setup.h.in
+++ b/src/setup.h.in
@@ -102,7 +102,7 @@
  * define.
  *
  * Default is to not have this define set, as the import code has not been
- * thoroughty tested and robustified by the main Coin developers yet.
+ * thoroughly tested and robustified by the main Coin developers yet.
  */
 
 #undef HAVE_3DS_IMPORT_CAPABILITIES

--- a/src/shapenodes/SoAsciiText.cpp
+++ b/src/shapenodes/SoAsciiText.cpp
@@ -565,7 +565,7 @@ void SoAsciiTextP::calculateStringStretch(const int i, const cc_font_specificati
       originalxpos += kerningx * fontspec->size;
     }
 
-    // Find the maxmimum endposition in the x-direction
+    // Find the maximum endposition in the x-direction
     float endx = originalxpos * stretchfactor + glyphwidth;
     if (endx > maxx) {
       originalmaxxpos = originalxpos;

--- a/src/vrml97/Texture.cpp
+++ b/src/vrml97/Texture.cpp
@@ -43,12 +43,12 @@
 
 /*!
   \var SoSFBool SoVRMLTexture::repeatS
-  TRUE if texure should be repeated in the S direction. Default is TRUE.
+  TRUE if texture should be repeated in the S direction. Default is TRUE.
 */
 
 /*!
   \var SoSFBool SoVRMLTexture::repeatT
-  TRUE if texure should be repeated in the T direction. Default is TRUE.
+  TRUE if texture should be repeated in the T direction. Default is TRUE.
 */
 
 #include <Inventor/VRMLnodes/SoVRMLTexture.h>

--- a/src/xml/expat/xmlparse.c
+++ b/src/xml/expat/xmlparse.c
@@ -3789,7 +3789,7 @@ initializeEncoding(XML_Parser parser) {
   const char *s;
 #ifdef XML_UNICODE
   char encodingBuf[128];
-  /* See comments abount `protoclEncodingName` in parserInit() */
+  /* See comments about `protoclEncodingName` in parserInit() */
   if (! parser->m_protocolEncodingName)
     s = NULL;
   else {


### PR DESCRIPTION
Found via `codespell -q 3 -S "./docs/ChangeLog.*" -L aswell,ba,gord,ifset,iif,inout,invokation,lod,msdos,pard,reenable,ro,siz,tesselator`