### PR TITLE
Introduced new COIN_DEBUG_CHECK_THREAD option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,7 @@ set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake" "${CMAKE_MODULE_PATH}")
 include(CheckCSourceRuns)
 include(CheckCXXSourceCompiles)
 include(CheckIncludeFile)
+include(CheckIncludeFileCXX)
 include(CheckIncludeFiles)
 include(CheckLibraryExists)
 include(CheckSymbolExists)
@@ -100,6 +101,9 @@ option(COIN_USE_CPACK "If enabled the cpack subrepo is mandatory" OFF)
 cmake_dependent_option(COIN_BUILD_MAC_FRAMEWORK "Build framework instead of dylib on Mac OS X when ON. Only valid if COIN_BUILD_SHARED_LIBS is ON." OFF "APPLE;NOT IOS;COIN_BUILD_SHARED_LIBS" OFF)
 cmake_dependent_option(COIN_BUILD_MAC_X11 "Build for X11 on Mac OS X when ON. Default is OFF." OFF "APPLE" OFF)
 cmake_dependent_option(COIN_BUILD_MAC_AGL "Build for AGL on Mac OS X when ON. Default is OFF." OFF "APPLE" OFF)
+
+check_include_file_cxx(thread HAVE_STD_THREAD)
+cmake_dependent_option(COIN_DEBUG_CHECK_THREAD "Enable thread check in several central Coin functions." OFF "HAVE_STD_THREAD" OFF)
 
 report_prepare(
   COIN_BUILD_SHARED_LIBS

--- a/src/coindefs.h
+++ b/src/coindefs.h
@@ -204,4 +204,37 @@ static void inline COIN_CONCAT(compile_only_before_nofunction,__LINE__) () { \
 #endif /* !unlikely */
 #endif /* !HAVE___BUILTIN_EXPECT */
 
+#ifdef COIN_DEBUG_CHECK_THREAD
+
+#include <thread>
+
+inline std::thread::id& coin_get_thread()
+{
+  static std::thread::id tid;
+  return tid;
+}
+
+#define COIN_INIT_CHECK_THREAD() \
+  do { \
+    coin_get_thread() = std::this_thread::get_id(); \
+  } while (0)
+
+#define COIN_CHECK_THREAD() \
+  do { \
+    if (coin_get_thread() != std::this_thread::get_id()) { \
+      SbString s; \
+      s.sprintf("%s:%u:%s", \
+                COIN_STUB_FILE ? COIN_STUB_FILE : "<>", \
+                COIN_STUB_LINE, \
+                COIN_STUB_FUNC_STRING); \
+      SoDebugError::post(s.getString(), \
+                         "Inventor access from wrong thread."); \
+    } \
+  } while (0)
+
+#else /* COIN_DEBUG_CHECK_THREAD */
+#define COIN_INIT_CHECK_THREAD() do { } while (0)
+#define COIN_CHECK_THREAD()      do { } while (0)
+#endif /* COIN_DEBUG_CHECK_THREAD */
+
 #endif /* !COIN_DEFS_H */

--- a/src/config.h.cmake.in
+++ b/src/config.h.cmake.in
@@ -480,3 +480,6 @@
 
 /* define Coin DATADIR for resource access */
 #define COIN_DATADIR    "@CMAKE_INSTALL_DATADIR@"
+
+/* Enable thread check in several central Coin functions. */
+#cmakedefine COIN_DEBUG_CHECK_THREAD

--- a/src/fields/SoField.cpp
+++ b/src/fields/SoField.cpp
@@ -143,7 +143,7 @@ inline unsigned int SbHashFunc(const void * key)
 {
   return SbHashFunc(reinterpret_cast<size_t>(key));
 }
-#include "coindefs.h" // COIN_STUB()
+#include "coindefs.h" // COIN_STUB(), COIN_CHECK_THREAD()
 
 #ifdef COIN_THREADSAFE
 #include "threads/recmutexp.h"
@@ -2223,6 +2223,7 @@ SoField::getDirty(void) const
 void
 SoField::setDirty(SbBool dirty)
 {
+  COIN_CHECK_THREAD();
   (void) this->changeStatusBits(FLAG_NEEDEVALUATION, dirty);
 }
 

--- a/src/misc/SoBase.cpp
+++ b/src/misc/SoBase.cpp
@@ -93,6 +93,7 @@
 #include "tidbitsp.h"
 #include "io/SoInputP.h"
 #include "io/SoWriterefCounter.h"
+#include "coindefs.h"
 
 #ifdef HAVE_CONFIG_H
 #include <config.h>
@@ -188,6 +189,8 @@ unsigned int SbHashFunc(const SoBase * key) {
  */
 SoBase::SoBase(void)
 {
+  COIN_CHECK_THREAD();
+
   // It is a common mistake to place e.g. nodes as static member
   // variables, or on the main()-function's stack-frame. This catches
   // some (but not all) of those cases.
@@ -474,6 +477,8 @@ SoBase::assertAlive(void) const
 void
 SoBase::ref(void) const
 {
+  COIN_CHECK_THREAD();
+
   if (COIN_DEBUG) this->assertAlive();
 
   CC_MUTEX_LOCK(SoBase::PImpl::mutex);
@@ -524,6 +529,8 @@ SoBase::ref(void) const
 void
 SoBase::unref(void) const
 {
+  COIN_CHECK_THREAD();
+
   if (COIN_DEBUG) this->assertAlive();
 
   CC_MUTEX_LOCK(SoBase::PImpl::mutex);
@@ -563,6 +570,8 @@ SoBase::unref(void) const
 void
 SoBase::unrefNoDelete(void) const
 {
+  COIN_CHECK_THREAD();
+
   if (COIN_DEBUG) this->assertAlive();
 
   this->objdata.referencecount--;

--- a/src/misc/SoDB.cpp
+++ b/src/misc/SoDB.cpp
@@ -108,7 +108,7 @@
 #include <Inventor/annex/ForeignFiles/SoForeignFileKit.h>
 #endif // HAVE_NODEKITS
 
-#include "coindefs.h" // COIN_STUB()
+#include "coindefs.h" // COIN_STUB(), COIN_INIT_CHECK_THREAD()
 #include "shaders/SoShader.h"
 #include "tidbitsp.h"
 #include "fields/SoGlobalField.h"
@@ -199,6 +199,8 @@ static uint32_t a_static_variable = 0xdeadbeef;
 void
 SoDB::init(void)
 {
+  COIN_INIT_CHECK_THREAD();
+
   // This is to catch the (unlikely) event that the C++ compiler adds
   // padding or rtti information to the SbVec3f (or similar) base classes.
   // We assume this isn't done several places in Coin, so the best thing to

--- a/src/nodes/SoNode.cpp
+++ b/src/nodes/SoNode.cpp
@@ -222,6 +222,7 @@ SbUniqueId is not really a class, just a \c typedef.
 #include "threads/threadsutilp.h"
 #include "glue/glp.h"
 #include "misc/SoDBP.h" // for global envvar COIN_PROFILER
+#include "coindefs.h"   // COIN_CHECK_THREAD
 
 // *************************************************************************
 
@@ -504,6 +505,8 @@ SoNode::startNotify(void)
 void
 SoNode::notify(SoNotList * l)
 {
+  COIN_CHECK_THREAD();
+
 #if COIN_DEBUG && 0 // debug
   SoDebugError::postInfo("SoNode::notify", "node %p (%s \"%s\"), list %p",
                          this, this->getTypeId().getName().getString(),


### PR DESCRIPTION
This pull request fixes issue #497 by introducing a new build option for a runtime thread check.

If the option is active, Coin will log an error when scene graph objects are accessed / modified from a thread different from the thread that called SoDB::init(). This can help to find bugs in multithreaded environments earlier, because the faulty code will trigger the error message immediately, instead of causing reference counting or memory issues later on.