### PR TITLE
Adding environment variable COIN_GLX_PIXMAP_DIRECT_RENDERING to control direct rendering option for offscreen contexts

### DIFF
--- a/src/doc/Coin_environment.dox
+++ b/src/doc/Coin_environment.dox
@@ -268,6 +268,7 @@
   \li \ref COIN_CGLGLUE_NO_PBUFFERS
   \li \ref COIN_GLXGLUE_NO_PBUFFERS
   \li \ref COIN_GLXGLUE_NO_GLX13_PBUFFERS
+  \li \ref COIN_GLX_PIXMAP_DIRECT_RENDERING
   \li \ref COIN_WGLGLUE_NO_PBUFFERS
 
   \li \ref COIN_ALLOW_SPIDERMONKEY
@@ -439,6 +440,7 @@ EnvironmentVariable COIN_GLU_LIBNAME;
 EnvironmentVariable COIN_GLU_SILENCE_TESS_COMBINE_WARNING;
 EnvironmentVariable COIN_GLXGLUE_NO_GLX13_PBUFFERS;
 EnvironmentVariable COIN_GLXGLUE_NO_PBUFFERS;
+EnvironmentVariable COIN_GLX_PIXMAP_DIRECT_RENDERING;
 EnvironmentVariable COIN_GL_DISABLE_VBO;
 EnvironmentVariable COIN_GL_NO_CURRENT_CONTEXT_CHECK;
 EnvironmentVariable COIN_HANDLE_STACK_OVERFLOW;
@@ -769,6 +771,17 @@ EnvironmentVariable WINDIR;
 
   \ingroup coin_envvars
 */
+
+/*!
+  \var EnvironmentVariable COIN_GLX_PIXMAP_DIRECT_RENDERING
+
+  If this environment variable is used to control direct rendering in GLX for
+  offscreen contexts. If the value is set to a value &gt; 0, direct rendering is
+  forced.
+
+  \ingroup coin_envvars
+*/
+
 
 /*!
   \var EnvironmentVariable COIN_WGLGLUE_NO_PBUFFERS

--- a/src/glue/gl_glx.cpp
+++ b/src/glue/gl_glx.cpp
@@ -698,19 +698,27 @@ glxglue_contextdata_cleanup(struct glxglue_contextdata * ctx)
 static SbBool
 glxglue_context_create_software(struct glxglue_contextdata * context)
 {
-  /* Note that the value of the last argument (which indicates whether
-     or not we're asking for a DRI-capable context) is "False" on
-     purpose, as the man pages for glXCreateContext() says:
+  /* Note that the value of the last argument was "False" on
+     purpose, as the man pages for glXCreateContext() where saying:
 
           [...] direct rendering contexts [...] may be unable to
           render to GLX pixmaps [...]
 
-     Rendering to a GLX pixmap is of course exactly what we want to be
-     able to do. */
+     However, it still mentions:
+
+          It may not be possible to render to a GLX pixmap with a 
+	  direct rendering context.
+
+     But in for example in RHEL8 indirect rendering has been disabled
+     following X.Org Secutiry Advisory:
+     https://www.x.org/wiki/Development/Security/Advisory-2014-12-09/
+
+     This has now been changed to "True" to force direct rendering.
+     */
 
   Display * display = glxglue_get_display(NULL);
   context->glxcontext = glXCreateContext(display, context->visinfo, 0,
-                                         False);
+                                         True);
 
   if (context->glxcontext == NULL) {
     cc_debugerror_postwarning("glxglue_context_create_software",


### PR DESCRIPTION
Proposed fix for #505
Probably needs more testing on various systems and configurations