### PR TITLE
Improve auto clipping

### DIFF
--- a/include/Inventor/SoRenderManager.h
+++ b/include/Inventor/SoRenderManager.h
@@ -220,9 +220,7 @@ protected:
 
 private:
   void attachRootSensor(SoNode * const sceneroot);
-  void attachClipSensor(SoNode * const sceneroot);
   void detachRootSensor(void);
-  void detachClipSensor(void);
   static void nodesensorCB(void * data, SoSensor *);
   static void prerendercb(void * userdata, SoGLRenderAction * action);
 

--- a/src/rendering/SoRenderManager.cpp
+++ b/src/rendering/SoRenderManager.cpp
@@ -779,6 +779,11 @@ SoRenderManager::renderScene( SoGLRenderAction * action,
     // This callback is removed again in the prerendercb function
     action->addPreRenderCallback(this->prerendercb, (void*) (uintptr_t) clearmask);
   }
+
+  if (PRIVATE(this)->autoclipping != SoRenderManager::NO_AUTO_CLIPPING) {
+    PRIVATE(this)->setClippingPlanes();
+  }
+
   action->apply(scene);
 }
 

--- a/src/rendering/SoRenderManagerP.cpp
+++ b/src/rendering/SoRenderManagerP.cpp
@@ -93,15 +93,6 @@ SoRenderManagerP::cleanup(void)
 }
 
 void
-SoRenderManagerP::updateClippingPlanesCB(void * closure, SoSensor * COIN_UNUSED_ARG(sensor))
-{
-  SoRenderManagerP * thisp = (SoRenderManagerP *) closure;
-  if (thisp->autoclipping != SoRenderManager::NO_AUTO_CLIPPING) {
-    thisp->setClippingPlanes();
-  }
-}
-
-void
 SoRenderManagerP::setClippingPlanes(void)
 {
   SoCamera * camera = this->camera;

--- a/src/rendering/SoRenderManagerP.h
+++ b/src/rendering/SoRenderManagerP.h
@@ -66,7 +66,6 @@ public:
   ~SoRenderManagerP();
 
   void setClippingPlanes(void);
-  static void updateClippingPlanesCB(void * closure, SoSensor * sensor);
   void getCameraCoordinateSystem(SbMatrix & matrix,
                                  SbMatrix & inverse);
   static void redrawshotTriggeredCB(void * data, SoSensor * sensor);
@@ -101,7 +100,6 @@ public:
   SbBool texturesenabled;
   SbBool isrgbmode;
   uint32_t redrawpri;
-  SoNodeSensor * clipsensor;
 
   SoGetBoundingBoxAction * getbboxaction;
   SoAudioRenderAction * audiorenderaction;


### PR DESCRIPTION
While trying to fix an orthographic camera auto clipping problem in FreeCAD, I noticed that during camera motions, for both orthographic and perspective camera, the corners of a part are sometimes cut. See the attached video which is running at 5% the original speed.

https://github.com/coin3d/coin/assets/14298143/f2594dd8-e7a9-4223-9957-d32b4201d308

I think what happens is this: first the camera orientation and/or position is changed, then the scene is rendered, then the auto clipping runs. After the camera moved, the scene may no longer be completely in the viewing frustum. So there is maybe one frame that shows the cut corner before the auto clipping runs and renders the scene again. But if the camera is in motion then there are multiple consecutive frames and the cut corners are noticeable.

To fix this, I created 2 commits. The first commit runs the auto clipping before rendering the scene and this fixes the cut corner problem. Then I thought: if the auto clipping runs before rendering then it is no longer needed to use a clip sensor. So I removed the clip sensor and related methods in the second commit. I am not sure if I can just do that without breaking something for someone. Please let me know what you think :smiley: 

