### PR TITLE
Rotate a VRMLBackground node with its ancestors' rotations

### DIFF
--- a/src/vrml97/Background.cpp
+++ b/src/vrml97/Background.cpp
@@ -181,6 +181,8 @@
 #include <Inventor/VRMLnodes/SoVRMLMacros.h>
 #include <Inventor/actions/SoGLRenderAction.h>
 #include <Inventor/actions/SoGetBoundingBoxAction.h>
+#include <Inventor/actions/SoGetMatrixAction.h>
+#include <Inventor/actions/SoSearchAction.h>
 #include <Inventor/elements/SoCacheElement.h>
 #include <Inventor/elements/SoModelMatrixElement.h>
 #include <Inventor/elements/SoProjectionMatrixElement.h>
@@ -348,6 +350,9 @@ public:
   SbStringList directoryList; // used for searching for textures
   SbBool geometrybuilt;
 
+  SoSearchAction * searchaction;
+  SoGetMatrixAction * getmatrixaction;
+
   void buildGeometry(void);
   void modifyCubeFace(SoMFString & urls, SoSeparator * facesep, const int32_t * vindices);
   SoSeparator * createCubeFace(const SoMFString & urls, SoSeparator * sep, const int32_t * vindices);
@@ -469,6 +474,11 @@ SoVRMLBackground::SoVRMLBackground(void)
   PRIVATE(this)->geometrybuilt = FALSE;  
   PRIVATE(this)->camera = NULL;
   PRIVATE(this)->rootnode = NULL;
+
+  // actions for ancestors' rotations
+  PRIVATE(this)->searchaction = new SoSearchAction;
+  PRIVATE(this)->searchaction->setNode(this);
+  PRIVATE(this)->getmatrixaction = new SoGetMatrixAction(SbViewportRegion());
 }
 
 /*!
@@ -497,6 +507,9 @@ SoVRMLBackground::~SoVRMLBackground()
   
   delete PRIVATE(this)->setbindsensor;
   delete PRIVATE(this)->isboundsensor;
+
+  delete PRIVATE(this)->searchaction;
+  delete PRIVATE(this)->getmatrixaction;
   
   delete PRIVATE(this)->children;
   delete PRIVATE(this);
@@ -526,7 +539,34 @@ SoVRMLBackground::GLRender(SoGLRenderAction * action)
     PRIVATE(this)->camera->orientation = r2.inverse();
   }
   else {
-    PRIVATE(this)->camera->orientation = rot.inverse();
+    // get the path from the scene graph root to this node
+    switch(action->getWhatAppliedTo()) {
+      case SoAction::AppliedCode::NODE:
+        PRIVATE(this)->searchaction->apply(action->getNodeAppliedTo());
+        break;
+      case SoAction::AppliedCode::PATH:
+        PRIVATE(this)->searchaction->apply(action->getPathAppliedTo());
+        break;
+      case SoAction::AppliedCode::PATH_LIST:
+        PRIVATE(this)->searchaction->apply(*action->getPathListAppliedTo());
+        break;
+    }
+    SoPath * path = PRIVATE(this)->searchaction->getPath();
+    // get the transformation matrix of this path
+    const SbViewportRegion vpr = action->getViewportRegion();
+    PRIVATE(this)->getmatrixaction->setViewportRegion(vpr);
+    PRIVATE(this)->getmatrixaction->apply(path);
+    SbMatrix transformation = PRIVATE(this)->getmatrixaction->getMatrix();
+    // get the rotation part of the matrix
+    // (note that a SoVRMLBackground node ignores any transformation of ancestors' except rotation)
+    SbVec3f translation;
+    SbRotation rotation;
+    SbVec3f scalevector;
+    SbRotation scaleorientation;
+    transformation.getTransform(translation, rotation, scalevector, scaleorientation);
+    // set camera orientation
+    rotation *= rot;
+    PRIVATE(this)->camera->orientation = rotation.inverse();
   }
 
   // rotate background camera so that it matches the current camera


### PR DESCRIPTION
A VRML Background node must ignore all transformations of its anchestors' except the rotation part of these transformations. See VRML documentation in src/vrml97/Background.cpp.

This fixes issue #516