### PR TITLE
Set minimum C++ standard needed to compile Coin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,12 @@ if(CMAKE_SOURCE_DIR STREQUAL CMAKE_BINARY_DIR)
 endif()
 
 # ############################################################################
+# Set minimum C++ standard needed to compile the Coin code
+# ############################################################################
+set( CMAKE_CXX_STANDARD 11 CACHE STRING "C++ standard used for the build" )
+message( STATUS "Setting C++ standard: '${CMAKE_CXX_STANDARD}', which is the minimum needed to compile Coin.")
+
+# ############################################################################
 # Include necessary submodules
 # ############################################################################
 


### PR DESCRIPTION
The compilation of the Coin 'master' fails out of the box because the minimum C++ standard is not specified in the CMake configuration, and the old standard is picked by CMake by default (at least on macOS).

This PR adds the minimum C++ standard to CMakeLists.txt. 

That fixes the out-of-the-box build of Coin. 

Tested on macOS 13.5.1 + Xcode 15.1

