### PR TITLE
Fix orthographic autoclipping by allowing negative farDistance

### DIFF
--- a/src/rendering/SoRenderManagerP.cpp
+++ b/src/rendering/SoRenderManagerP.cpp
@@ -36,6 +36,7 @@
 #include <Inventor/nodes/SoInfo.h>
 #include <Inventor/nodes/SoCamera.h>
 #include <Inventor/nodes/SoPerspectiveCamera.h>
+#include "Inventor/nodes/SoOrthographicCamera.h"
 #include <Inventor/actions/SoGLRenderAction.h>
 #include <Inventor/actions/SoGetBoundingBoxAction.h>
 #include <Inventor/actions/SoGetMatrixAction.h>
@@ -133,7 +134,12 @@ SoRenderManagerP::setClippingPlanes(void)
   float nearval = -box.getMax()[2];
   float farval = -box.getMin()[2];
 
-  if (farval <= 0.0f) return;
+  if (!camera->isOfType(SoOrthographicCamera::getClassTypeId()) && farval <= 0.0f) return;
+
+  if (box.isEmpty()) {
+    nearval = 1;
+    farval = 10;
+  }
 
   if (camera->isOfType(SoPerspectiveCamera::getClassTypeId())) {
     float nearlimit;
@@ -157,8 +163,8 @@ SoRenderManagerP::setClippingPlanes(void)
   }
 
   const float SLACK = 0.001f;
-  const float newnear = nearval * (1.0f - SLACK);
-  const float newfar = farval * (1.0f + SLACK);
+  const float newnear = nearval >= 0 ? nearval * (1.0f - SLACK) : nearval * (1.0f + SLACK);
+  const float newfar = farval >= 0 ? farval * (1.0f + SLACK) : farval * (1.0f - SLACK);
 
   const float neareps = nearval * SLACK * SLACK;
   const float fareps = farval * SLACK * SLACK;


### PR DESCRIPTION
Replaces #510.  The `SoRenderManagerP::setClippingPlanes` would return if `farval <= 0.0f`. Now it does not return anymore if an orthographic camera is used. This fixes the problem described in #510 in a more simple way.