### PR TITLE
Fix macro handling to avoid conflicts with Win32 API headers

### DIFF
--- a/include/Inventor/errors/SoDebugError.h
+++ b/include/Inventor/errors/SoDebugError.h
@@ -39,7 +39,8 @@
 // Avoid problem with Microsoft Win32 API headers (yes, they actually
 // #define ERROR -- in wingdi.h).
 #if defined(ERROR)
-#define SODEBUGERROR_STORE_ERROR_DEF ERROR
+#define SODEBUGERROR_STORE_ERROR_DEF
+#pragma push_macro("ERROR")
 #undef ERROR
 #endif /* ERROR */
 
@@ -82,7 +83,7 @@ private:
 
 // Avoid problem with Microsoft Win32 API headers (see above).
 #if defined(SODEBUGERROR_STORE_ERROR_DEF)
-#define ERROR SODEBUGERROR_STORE_ERROR_DEF
+#pragma pop_macro("ERROR")
 #undef SODEBUGERROR_STORE_ERROR_DEF
 #endif /* SODEBUGERROR_STORE_ERROR_DEF */
 


### PR DESCRIPTION
Adjust macro definitions to prevent conflicts with Microsoft Win32 API headers by using push and pop macro directives.

Fixes #468