### PR TITLE
Introduce shaded hidden lines visual style

### DIFF
--- a/include/Inventor/SoRenderManager.h
+++ b/include/Inventor/SoRenderManager.h
@@ -84,7 +84,8 @@ public:
     POINTS,
     WIREFRAME_OVERLAY,
     HIDDEN_LINE,
-    BOUNDING_BOX
+    BOUNDING_BOX,
+    SHADED_HIDDEN_LINES
   };
 
   enum StereoMode {


### PR DESCRIPTION
Since we have different visual styles available in coin, but we lack visual style that allows showing hidden edges with solid edges, this patch adds it.

Made on FreeCAD request, this could be done directly in ViewProviders, although every viewprovider is being assigned separately to an object one after another, and since objects are being rendered one after depth buffer of obj1 may not be aware of obj2 being infront of the object, if obj2 was created after obj1. So, the solution was to add it to RenderManager as the scene will be conscious about depth of all objects.

Looks like this on the demo:

https://github.com/user-attachments/assets/342e4663-65d0-4a35-ab5b-937917445420

