### PR TITLE
Issue #556 Only call deleteAll on valid pointers

### DIFF
--- a/src/actions/SoCallbackAction.cpp
+++ b/src/actions/SoCallbackAction.cpp
@@ -462,7 +462,11 @@ static void
 delete_list_elements(SbList<SoCallbackData *> & cl)
 {
   int n = cl.getLength();
-  for (int i = 0; i < n; i++) cl[i]->deleteAll();
+  for (int i = 0; i < n; i++) {
+    if (cl[i] != NULL) {
+      cl[i]->deleteAll();
+    }
+  }
 }
 
 /*!


### PR DESCRIPTION
Adding safety check to only call deleteAll on callback actions that have been registered.