### PR TITLE
Add a clipping offset

### DIFF
--- a/src/rendering/SoRenderManagerP.cpp
+++ b/src/rendering/SoRenderManagerP.cpp
@@ -131,8 +131,9 @@ SoRenderManagerP::setClippingPlanes(void)
   xbox.transform(mat);
   SbBox3f box = xbox.project();
 
-  float nearval = -box.getMax()[2];
-  float farval = -box.getMin()[2];
+  constexpr float clippingOffset = 0.1;
+  float nearval = -box.getMax()[2] - clippingOffset;
+  float farval = -box.getMin()[2] + clippingOffset;
 
   if (!camera->isOfType(SoOrthographicCamera::getClassTypeId()) && farval <= 0.0f) return;
 


### PR DESCRIPTION
When the near and far camera distance are small and close to each other then things may not get rendered properly. For example https://github.com/FreeCAD/FreeCAD/issues/22216, here a sketch is created which is just some stuff on a 2D plane and the near and far distance are very close to each other because the depth is very small. Coin adds some slack, I believe 0.1% which is a multiplication and thus the amount of slack depends on the values of the near and far distance. However, if the near and far distance are close to 0 then effectively no slack is added. This could cause hidden objects and flickering when moving the mouse or camera.

To resolve this I propose we subtract an offset from the near value and add an offset to the far value. This way there is always sufficient distance between the near and far clipping plane.