### PR TITLE
Wayland detection

### DIFF
--- a/examples/glfw/glfw.cpp
+++ b/examples/glfw/glfw.cpp
@@ -14,25 +14,17 @@
 #include <Inventor/nodes/SoCube.h>
 #include <Inventor/nodes/SoLightModel.h>
 #include <Inventor/nodes/SoTexture2.h>
-#include <Inventor/nodes/SoDirectionalLight.h>
 #include <Inventor/nodes/SoSeparator.h>
 #include <Inventor/nodes/SoMaterial.h>
 #include <Inventor/nodes/SoPerspectiveCamera.h>
 #include <Inventor/nodes/SoRotationXYZ.h>
-#include <Inventor/nodes/SoImage.h>
 
 #include <cstdlib>
 #include <functional>
 
-#ifdef HAVE_EGL
-static bool useEGL = true;
-#else
-static bool useEGL = false;
-#endif
 
 #define GL_GLEXT_PROTOTYPES
 #include <GLFW/glfw3.h>
-#include <GLFW/glfw3native.h>
 
 // ----------------------------------------------------------------------
 
@@ -116,19 +108,6 @@ int main(void)
 
     if (!glfwInit())
         return EXIT_FAILURE;
-
-    glfwWindowHint(GLFW_CLIENT_API, GLFW_OPENGL_API);
-
-#ifndef HAVE_EGL
-    if (useEGL) {
-      fprintf(stderr, "Error: EGL support is not compiled in\n");
-    }
-#endif
-
-    if (useEGL) {
-      putenv((char*)"COIN_EGL=1");
-      glfwWindowHint(GLFW_CONTEXT_CREATION_API, GLFW_EGL_CONTEXT_API);
-    }
 
     glfwWindowHint(GLFW_CLIENT_API, GLFW_OPENGL_API);
 

--- a/src/glue/gl.cpp
+++ b/src/glue/gl.cpp
@@ -2211,9 +2211,15 @@ static void check_egl()
     const char * sessionType = coin_getenv("XDG_SESSION_TYPE");
     if (sessionType) {
       if (strcmp(sessionType, "wayland") == 0 && coin_getenv("WAYLAND_DISPLAY")) {
-        EGLContext context = eglGetCurrentContext();
-        if (context != EGL_NO_CONTEXT) {
+        EGLContext eglContext = eglGetCurrentContext();
+        if (eglContext != EGL_NO_CONTEXT) {
           COIN_USE_EGL = 1;
+          return;
+        }
+
+        GLXContext glxContext = glXGetCurrentContext();
+        if (glxContext != nullptr) {
+          COIN_USE_EGL = 0;
           return;
         }
       }


### PR DESCRIPTION
This is my attempt to let coin do automatic Wayland detection and to fix #581. Basically it is checking `XDG_SESSION_TYPE` and `WAYLAND_DISPLAY` to see if a Wayland session is used and then it also checks if there is an EGL or GLX context. Depending on this, `COIN_USE_EGL` is enabled or disabled automatically.

I have tried it with FreeCAD and the GLFW example in a X11 session and a Wayland session. I also tried with `QT_QPA_PLATFORM=xcb` in a Wayland session to force Xwayland. In all cases coin successfully determined whether or not to use EGL.

I would appreciate a review and testing by other people before merging. @tritao do you mind having a look?