### PR TITLE
Fix SoShape::getScreenSize to handle empty bounding box case.

### DIFF
--- a/src/shapenodes/SoShape.cpp
+++ b/src/shapenodes/SoShape.cpp
@@ -478,6 +478,11 @@ SoShape::getScreenSize(SoState * const state, const SbBox3f & boundingbox,
                 SoProjectionMatrixElement::get(state));
 
   SbVec2s vpsize = SoViewportRegionElement::get(state).getViewportSizePixels();
+  if (boundingbox.isEmpty())
+  {
+      rectsize = vpsize * 0.5;
+      return;
+  }
   SbVec3f bmin, bmax;
   boundingbox.getBounds(bmin, bmax);
 


### PR DESCRIPTION
This prevents `SbMin` from being called on NaN, which would halt execution with a Floating Point Invalid Operation error.

We were hit by a case of old code mysteriously starting to fail. The debug build would fail to start, but not the release build, on our machines. On some client machines, the release build would also fail. I traced it back (at least our local debug build problem) to the use of `SmAxisDisplayKit` that was forked off of smallchange in 2009, and has not been touched since 2013. For some reason, it is possible that a render pass happens when its bounding box is still empty -- presumably because the kit was not yet fully set up. This would in turn cause numbers to reach -inf, producing NaN, inside `SoShape::getScreenSize()`, which `SbMin` is unable to handle.

Why some builds and machines were not affected we can only speculate. This is on Windows, using Microsoft Visual Studio Community 2019 Version 16.11.51.

I am not sure whether the returned fall-back screen size is meaningful, but a successive pass seems to follow quickly where the bounding box is non-empty, as the axis display kit does render properly -- there is no visible breakage, not even briefly.