### PR TITLE
Ensure cc_glglue_context_can_render_to_texture() always returns a value

### DIFF
--- a/src/glue/gl.cpp
+++ b/src/glue/gl.cpp
@@ -4787,14 +4787,15 @@ cc_glglue_context_can_render_to_texture(void * COIN_UNUSED_ARG(ctx))
 #endif
 #if defined(HAVE_GLX)
   return FALSE;
-#endif
+#else
 #if defined(HAVE_AGL)
   if (COIN_USE_AGL > 0) return aglglue_context_can_render_to_texture(ctx); else
 #endif
 #if defined(HAVE_CGL)
   return cglglue_context_can_render_to_texture(ctx);
 #else
-  ;
+  return FALSE;
+#endif
 #endif
 #endif
 }


### PR DESCRIPTION
With COIN_BUILD_EGL=ON and COIN_BUILD_GLX=OFF:

coin/src/glue/gl.cpp:4800:1: warning: control reaches end of non-void function [-Wreturn-type]

---

to make sure we don't have 2 `return FALSE;`

```diff
-#endif
+#else
```