### PR TITLE
CMake build fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,10 +27,16 @@ if(POLICY CMP0072)
   cmake_policy(SET CMP0072 NEW)
 endif()
 
+if (POLICY CMP0074)
+    # find_package() uses <PackageName>_ROOT variables (from CMake 3.12)
+    cmake_policy(SET CMP0074 NEW)
+endif()
+
 if(POLICY CMP0075)
   # get rid of CMAKE_REQUIRED_LIBRARIES warning from CMake 3.12.2
   cmake_policy(SET CMP0075 NEW)
 endif()
+
 
 # ############################################################################
 # Prevent in-source builds, as they often cause severe build problems

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -263,7 +263,13 @@ target_include_directories(${PROJECT_NAME}
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
     $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>
 )
-target_link_libraries(${PROJECT_NAME} PRIVATE ${COIN_TARGET_LINK_LIBRARIES})
+
+if (COIN_BUILD_SHARED_LIBS)
+  target_link_libraries(${PROJECT_NAME} PRIVATE ${COIN_TARGET_LINK_LIBRARIES})
+else()
+  target_link_libraries(${PROJECT_NAME} INTERFACE ${COIN_TARGET_LINK_LIBRARIES})
+endif()
+
 if(NOT COIN_BUILD_MAC_FRAMEWORK)
   target_include_directories(${PROJECT_NAME} INTERFACE $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 endif()


### PR DESCRIPTION
## Summary
Build-system-only CMake fixes.

## Changes
- CMake: fix target-specific `COIN_BUILD_SHARED_LIBS` linkage behavior (`src/CMakeLists.txt`).
- CMake: small top-level configuration cleanups.

<!-- AUTOGEN:BEGIN -->
#### Commits
- `bf363f7412`: CMake build fix for target-specific `COIN_BUILD_SHARED_LIBS…
- `e107033c42`: CMake build modernization fixes.

<!-- AUTOGEN:END -->
