### PR TITLE
Portability and warning fixes

### DIFF
--- a/src/base/time.cpp
+++ b/src/base/time.cpp
@@ -106,6 +106,20 @@ cc_internal_queryperformancecounter(cc_time * COIN_UNUSED_ARG(t))
 }
 
 static SbBool
+cc_internal_clock_gettime(cc_time * t)
+{
+#if defined(CLOCK_REALTIME)
+  struct timespec ts;
+  if (clock_gettime(CLOCK_REALTIME, &ts) == 0) {
+    *t = static_cast<double>(ts.tv_sec);
+    *t += static_cast<double>(ts.tv_nsec) / 1000000000.0;
+    return TRUE;
+  }
+#endif /* CLOCK_REALTIME */
+  return FALSE;
+}
+
+static SbBool
 cc_internal_gettimeofday(cc_time * t)
 {
 #ifdef HAVE_GETTIMEOFDAY
@@ -133,7 +147,7 @@ cc_internal_ftime(cc_time * t)
   /* FIXME: should use timezone field of struct _timeb as well. 20011023 mortene. */
   *t = (double)timebuffer.time + (double)timebuffer.millitm / 1000.0;
   return TRUE;
-#elif defined(HAVE_FTIME)
+#elif defined(HAVE_FTIME) && !defined(CLOCK_REALTIME)
   struct timeb timebuffer;
   /* FIXME: should use timezone field of struct _timeb as well. 20011023 mortene. */
   ftime(&timebuffer);
@@ -155,6 +169,7 @@ cc_time_gettimeofday(void)
 {
   cc_time t = 0.0;
   if (cc_internal_queryperformancecounter(&t)) { return t; }
+  if (cc_internal_clock_gettime(&t)) { return t; }
   if (cc_internal_gettimeofday(&t)) { return t; }
   if (cc_internal_ftime(&t)) { return t; }
   /* FIXME: write better debug output. 20011218 mortene. */

--- a/src/xml/element.cpp
+++ b/src/xml/element.cpp
@@ -42,6 +42,11 @@
 #include <cstring>
 #include <cassert>
 
+#ifndef __STDC_FORMAT_MACROS
+#define __STDC_FORMAT_MACROS 1
+#endif
+#include <inttypes.h>
+
 #include <Inventor/C/base/string.h>
 #include <Inventor/lists/SbList.h>
 
@@ -579,7 +584,7 @@ cc_xml_elt_get_uint64(const cc_xml_elt * elt, uint64_t * value)
   const char * data = cc_xml_elt_get_data(elt);
   assert(value != NULL);
   if ( data == NULL ) return FALSE;
-  if ( sscanf(data, "%lld", value) == 1 ) return TRUE; // FIXME: unsigned
+  if ( sscanf(data, "%" SCNu64, value) == 1 ) return TRUE;
   return FALSE;
 }
 
@@ -598,7 +603,7 @@ cc_xml_elt_get_int64(const cc_xml_elt * elt, int64_t * value)
   const char * data = cc_xml_elt_get_data(elt);
   assert(value != NULL);
   if ( data == NULL ) return FALSE;
-  if ( sscanf(data, "%lld", value) == 1 ) return TRUE;
+  if ( sscanf(data, "%" SCNd64, value) == 1 ) return TRUE;
   return FALSE;
 }
 


### PR DESCRIPTION
## Summary
Small portability and warning fixes to keep builds clean and predictable on modern toolchains.

## Why
These are small, low-risk changes that reduce build friction (warnings and portability nits) before the larger rendering work lands.

## Changes
- Portability: prefer `clock_gettime` when available (`src/base/time.cpp`).
- Warnings: fix format specifier issues in `src/xml/element.cpp`.

## Testing
Not run in isolation.

<!-- AUTOGEN:BEGIN -->
#### Commits
- `8c1d4f52a4`: Fix wrong specifier warnings in element.cpp
- `3be632727a`: Use `clock_gettime` when its available instead of deprecate…

<!-- AUTOGEN:END -->
