### PR TITLE
Fix tests when VRML97 is disabled

### DIFF
--- a/src/fields/SoSFNode.cpp
+++ b/src/fields/SoSFNode.cpp
@@ -358,6 +358,7 @@ BOOST_AUTO_TEST_CASE(initialized)
                       "missing class initialization");
 }
 
+#ifdef HAVE_VRML97
 BOOST_AUTO_TEST_CASE(vrml97nullchild)
 {
   // NULL values for children must be allowed, or we break VRML97
@@ -377,5 +378,6 @@ BOOST_AUTO_TEST_CASE(vrml97nullchild)
     g->unref();
   }
 }
+#endif
 
 #endif // COIN_TEST_SUITE

--- a/src/misc/SoBase.cpp
+++ b/src/misc/SoBase.cpp
@@ -1748,6 +1748,8 @@ DEF root Separator {
   }
 }
 */
+
+#ifdef HAVE_VRML97
 	    SoVRMLGroup *newroot;
 	   for(int j=0;j<2;j++) {
 		   if(j==1) {
@@ -1835,6 +1837,7 @@ DEF root Separator {
 	
        root->unref();
 	   newroot->unref();
+#endif
  }
 
 #endif // COIN_TEST_SUITE

--- a/src/misc/SoDB.cpp
+++ b/src/misc/SoDB.cpp
@@ -1724,6 +1724,7 @@ readErrorHandler(const SoError * error, void * data)
 {
 }
 
+#ifdef HAVE_VRML97
 BOOST_AUTO_TEST_CASE(readChildList)
 {
   static const char scene[] = "#VRML V2.0 utf8\n"
@@ -1740,6 +1741,7 @@ BOOST_AUTO_TEST_CASE(readChildList)
   }
   root->unref();
 }
+#endif
 
 BOOST_AUTO_TEST_CASE(readEmptyChildList)
 {

--- a/testsuite/CMakeLists.txt
+++ b/testsuite/CMakeLists.txt
@@ -23,7 +23,19 @@ macro(create_testsuite input)
 endmacro()
 
 macro(create_file_test input testfunc filter)
-	file(GLOB_RECURSE COIN_IV_FILES RELATIVE ${PROJECT_SOURCE_DIR} ../${input}/*.wrl ../${input}/*.vrml ../${input}/*.gz ../${input}/*.iv)
+	file(GLOB_RECURSE COIN_IV_FILES RELATIVE ${PROJECT_SOURCE_DIR}
+		../${input}/*.iv
+		../${input}/*.iv.gz
+	)
+	if (HAVE_VRML97)
+		file(GLOB_RECURSE COIN_WRL_VRML_FILES RELATIVE ${PROJECT_SOURCE_DIR}
+			../${input}/*.wrl
+			../${input}/*.vrml
+			../${input}/*.wrl.gz
+			../${input}/*.vrml.gz
+		)
+		list(APPEND COIN_IV_FILES ${COIN_WRL_VRML_FILES})
+	endif()
 	string(REGEX REPLACE "[\\./\\-]+" "" TESTSUITENAME "${input}")
 	set(COIN_STR_TEST_INCL "")
 	set(COIN_STR_TEST_CODE "const char *readError[] = { \"Coin read error:\", 0 };\n")


### PR DESCRIPTION
## Summary
Make the existing test suite behave correctly when VRML97 support is disabled.

## Why
Some tests and test-data collection were unconditionally VRML97-centric; when `HAVE_VRML97=OFF` they should be skipped rather than failing to build/run. This keeps non-VRML builds (and CI configs that disable VRML) usable.

## Changes
- Guard VRML97-specific `BOOST_AUTO_TEST_CASE`s with `#ifdef HAVE_VRML97`.
- In `testsuite/CMakeLists.txt`, only glob `.wrl`/`.vrml` inputs when `HAVE_VRML97` is enabled.

<!-- AUTOGEN:BEGIN -->
#### Commits
- `1377850825`: Fix tests with disabled VRML97 support.

<!-- AUTOGEN:END -->
