### PR TITLE
SoVertexArrayIndexer render() takes SoState

### DIFF
--- a/src/caches/SoPrimitiveVertexCache.cpp
+++ b/src/caches/SoPrimitiveVertexCache.cpp
@@ -378,13 +378,13 @@ SoPrimitiveVertexCache::renderTriangles(SoState * state, const int arrays) const
     SoPrimitiveVertexCacheP * thisp = const_cast<SoPrimitiveVertexCacheP *>(&PRIVATE(this).get());
 
     thisp->enableVBOs(glue, contextid, color, normal, texture, enabled, lastenabled);
-    PRIVATE(this)->triangleindexer->render(glue, TRUE, contextid);
+    PRIVATE(this)->triangleindexer->render(state, TRUE, contextid);
     thisp->disableVBOs(glue, color, normal, texture, enabled, lastenabled);
   }
   else if (SoGLDriverDatabase::isSupported(glue, SO_GL_VERTEX_ARRAY)) {
     SoPrimitiveVertexCacheP * thisp = const_cast<SoPrimitiveVertexCacheP *>(&PRIVATE(this).get());
     thisp->enableArrays(glue, color, normal, texture, enabled, lastenabled);
-    PRIVATE(this)->triangleindexer->render(glue, FALSE, contextid);
+    PRIVATE(this)->triangleindexer->render(state, FALSE, contextid);
     thisp->disableArrays(glue, color, normal, texture, enabled, lastenabled);
   }
   else {
@@ -425,7 +425,7 @@ SoPrimitiveVertexCache::renderLines(SoState * state, const int arrays) const
   if (SoGLDriverDatabase::isSupported(glue, SO_GL_VERTEX_ARRAY)) {
     SoPrimitiveVertexCacheP * thisp = const_cast<SoPrimitiveVertexCacheP *>(&PRIVATE(this).get());
     thisp->enableArrays(glue, color, normal, texture, enabled, lastenabled);
-    PRIVATE(this)->lineindexer->render(glue, FALSE, contextid);
+    PRIVATE(this)->lineindexer->render(state, FALSE, contextid);
     thisp->disableArrays(glue, color, normal, texture, enabled, lastenabled);
   }
   else {
@@ -465,7 +465,7 @@ SoPrimitiveVertexCache::renderPoints(SoState * state, const int arrays) const
   if (SoGLDriverDatabase::isSupported(glue, SO_GL_VERTEX_ARRAY)) {
     SoPrimitiveVertexCacheP * thisp = const_cast<SoPrimitiveVertexCacheP *>(&PRIVATE(this).get());
     thisp->enableArrays(glue, color, normal, texture, enabled, lastenabled);
-    PRIVATE(this)->pointindexer->render(glue, FALSE, contextid);
+    PRIVATE(this)->pointindexer->render(state, FALSE, contextid);
     thisp->disableArrays(glue, color, normal, texture, enabled, lastenabled);
   }
   else {

--- a/src/rendering/SoVertexArrayIndexer.cpp
+++ b/src/rendering/SoVertexArrayIndexer.cpp
@@ -48,6 +48,7 @@
 
 #include "tidbitsp.h"
 #include "rendering/SoVBO.h"
+#include "rendering/SoGL.h"
 #include "coindefs.h"
 
 #if BOOST_WORKAROUND(COIN_MSVC, <= COIN_MSVC_6_0_VERSION)
@@ -244,8 +245,10 @@ SoVertexArrayIndexer::close(void)
   Render all added targets/indices.
 */
 void
-SoVertexArrayIndexer::render(const cc_glglue * glue, const SbBool renderasvbo, const uint32_t contextid)
+SoVertexArrayIndexer::render(SoState * state, const SbBool renderasvbo, const uint32_t contextid)
 {
+  const cc_glglue * glue = sogl_glue_instance(state);
+
   switch (this->target) {
   case GL_TRIANGLES:
   case GL_QUADS:
@@ -307,7 +310,7 @@ SoVertexArrayIndexer::render(const cc_glglue * glue, const SbBool renderasvbo, c
     break;
   }
 
-  if (this->next) this->next->render(glue, renderasvbo, contextid);
+  if (this->next) this->next->render(state, renderasvbo, contextid);
 }
 
 /*!

--- a/src/rendering/SoVertexArrayIndexer.h
+++ b/src/rendering/SoVertexArrayIndexer.h
@@ -43,6 +43,7 @@
 #include <stdlib.h>
 
 class SoVBO;
+class SoState;
 
 class SoVertexArrayIndexer {
 public:
@@ -67,7 +68,7 @@ public:
   void endTarget(GLenum target);
 
   void close(void);
-  void render(const cc_glglue * glue, const SbBool renderasvbo, const uint32_t vbocontextid);
+  void render(SoState * state, const SbBool renderasvbo, const uint32_t vbocontextid);
 
   int getNumVertices(void);
   int getNumIndices(void) const;

--- a/src/shapenodes/SoIndexedFaceSet.cpp
+++ b/src/shapenodes/SoIndexedFaceSet.cpp
@@ -609,7 +609,7 @@ SoIndexedFaceSet::GLRender(SoGLRenderAction * action)
     }
 
     if (PRIVATE(this)->vaindexer) {
-      PRIVATE(this)->vaindexer->render(sogl_glue_instance(state), dovbo, contextid);
+      PRIVATE(this)->vaindexer->render(state, dovbo, contextid);
     }
     UNLOCK_VAINDEXER(this);
     this->finishVertexArray(action,

--- a/src/shapenodes/SoIndexedLineSet.cpp
+++ b/src/shapenodes/SoIndexedLineSet.cpp
@@ -381,7 +381,7 @@ SoIndexedLineSet::GLRender(SoGLRenderAction * action)
     }
 
     if (PRIVATE(this)->vaindexer) {
-      PRIVATE(this)->vaindexer->render(sogl_glue_instance(state), dovbo, contextid);
+      PRIVATE(this)->vaindexer->render(state, dovbo, contextid);
     }
     UNLOCK_VAINDEXER(this);
 

--- a/src/shapenodes/SoIndexedPointSet.cpp
+++ b/src/shapenodes/SoIndexedPointSet.cpp
@@ -366,7 +366,7 @@ SoIndexedPointSet::GLRender(SoGLRenderAction * action)
     }
 
     if (this->vaindexer) {
-      this->vaindexer->render(sogl_glue_instance(state), vbo, contextid);
+      this->vaindexer->render(state, vbo, contextid);
     }
     UNLOCK_VAINDEXER(this);
     this->finishVertexArray(action, vbo,

--- a/src/vrml97/Extrusion.cpp
+++ b/src/vrml97/Extrusion.cpp
@@ -601,7 +601,7 @@ SoVRMLExtrusion::GLRender(SoGLRenderAction * action)
 
     SoGLVertexAttributeElement::getInstance(state)->enableVBO(action);
 
-    PRIVATE(this)->vbocache->getVertexArrayIndexer()->render(glue, TRUE, contextid);
+    PRIVATE(this)->vbocache->getVertexArrayIndexer()->render(state, TRUE, contextid);
 
     cc_glglue_glBindBuffer(glue, GL_ARRAY_BUFFER, 0); // Reset VBO binding
     cc_glglue_glDisableClientState(glue, GL_NORMAL_ARRAY);

--- a/src/vrml97/IndexedFaceSet.cpp
+++ b/src/vrml97/IndexedFaceSet.cpp
@@ -611,7 +611,7 @@ SoVRMLIndexedFaceSet::GLRender(SoGLRenderAction * action)
     }
 
     if (PRIVATE(this)->vaindexer) {
-      PRIVATE(this)->vaindexer->render(sogl_glue_instance(state), dovbo, contextid);
+      PRIVATE(this)->vaindexer->render(state, dovbo, contextid);
     }
     UNLOCK_VAINDEXER(this);
     this->finishVertexArray(action,

--- a/src/vrml97/IndexedLineSet.cpp
+++ b/src/vrml97/IndexedLineSet.cpp
@@ -386,7 +386,7 @@ SoVRMLIndexedLineSet::GLRender(SoGLRenderAction * action)
     }
     
     if (PRIVATE(this)->vaindexer) {
-      PRIVATE(this)->vaindexer->render(sogl_glue_instance(state), dovbo, contextid);
+      PRIVATE(this)->vaindexer->render(state, dovbo, contextid);
     }
     UNLOCK_VAINDEXER(this);
 


### PR DESCRIPTION
## Summary
Refactor `SoVertexArrayIndexer::render()` to take `SoState*` (derive GL glue from state internally).

## Why
This removes the need to thread `cc_glglue*` through multiple render call sites and makes the API match other state-driven rendering paths (useful for later renderer/GL changes).

## Changes
- Change `SoVertexArrayIndexer::render(...)` signature to `render(SoState*, ...)`.
- Resolve the `cc_glglue*` via `sogl_glue_instance(state)` at the call site.
- Update all callers (shape nodes + VRML97 shapes + primitive cache).

<!-- AUTOGEN:BEGIN -->
#### Commits
- `ad33d2059a`: Refactor SoVertexArrayIndexer render() to take SoState*

<!-- AUTOGEN:END -->
