### PR TITLE
Shader rendering state helpers

### DIFF
--- a/include/Inventor/nodes/SoShaderObject.h
+++ b/include/Inventor/nodes/SoShaderObject.h
@@ -70,6 +70,7 @@ public:
 
   virtual void GLRender(SoGLRenderAction * action);
   virtual void search(SoSearchAction * action);
+  void render(SoState * state);
 
   void updateParameters(SoState * state);
 

--- a/include/Inventor/nodes/SoShaderProgram.h
+++ b/include/Inventor/nodes/SoShaderProgram.h
@@ -62,6 +62,7 @@ public:
 SoEXTENDER public:
   virtual void GLRender(SoGLRenderAction * action);
   virtual void search(SoSearchAction * action);
+  void render(SoState * state);
 
 SoINTERNAL public:
   static void initClass();

--- a/src/shaders/SoShaderObject.cpp
+++ b/src/shaders/SoShaderObject.cpp
@@ -139,6 +139,7 @@ public:
   ~SoShaderObjectP();
 
   void GLRender(SoGLRenderAction *action);
+  void render(SoState * state);
 
   SoGLShaderObject * getGLShaderObject(const uint32_t cachecontext) {
     SoGLShaderObject * obj = NULL;
@@ -391,14 +392,18 @@ SoShaderObjectP::~SoShaderObjectP()
 void
 SoShaderObjectP::GLRender(SoGLRenderAction * action)
 {
-  SbBool isactive = this->owner->isActive.getValue();
-  if (!isactive) return;
+  this->render(action ? action->getState() : NULL);
+}
 
-  SoState * state = action->getState();
+void
+SoShaderObjectP::render(SoState * state)
+{
+  SbBool isactive = this->owner->isActive.getValue();
+  if (!isactive || !state) return;
 
   SoGLShaderProgram * shaderProgram = SoGLShaderProgramElement::get(state);
   if (!shaderProgram) {
-    SoDebugError::postWarning("SoShaderObject::GLRender",
+    SoDebugError::postWarning("SoShaderObject::render",
                               "SoShaderObject seems to not be under a SoShaderProgram node");
     return;
   }
@@ -428,7 +433,7 @@ SoShaderObjectP::GLRender(SoGLRenderAction * action)
       case SoShaderObject::GLSL_PROGRAM: s = "GLSL_PROGRAM"; break;
       default: assert(FALSE && "unknown shader");
       }
-      SoDebugError::postWarning("SoShaderObjectP::GLRender",
+      SoDebugError::postWarning("SoShaderObjectP::render",
                                 "%s is not supported", s.getString());
       return;
     }
@@ -471,6 +476,12 @@ SoShaderObjectP::GLRender(SoGLRenderAction * action)
     shaderProgram->addShaderObject(shaderobject);
     shaderobject->setIsActive(isactive);
   }
+}
+
+void
+SoShaderObject::render(SoState * state)
+{
+  PRIVATE(this)->render(state);
 }
 
 // sets this->cachedSourceType to [ARB|CG|GLSL]_PROGRAM

--- a/src/shaders/SoShaderProgram.cpp
+++ b/src/shaders/SoShaderProgram.cpp
@@ -225,7 +225,7 @@ public:
   SoShaderProgramP(SoShaderProgram * ownerptr);
   ~SoShaderProgramP();
 
-  void GLRender(SoGLRenderAction * action);
+  void render(SoState * state);
 
   SoShaderProgramEnableCB * enablecb;
   void * enablecbclosure;
@@ -288,7 +288,14 @@ SoShaderProgram::~SoShaderProgram()
 void
 SoShaderProgram::GLRender(SoGLRenderAction * action)
 {
-  PRIVATE(this)->GLRender(action);
+  if (!action) return;
+  PRIVATE(this)->render(action->getState());
+}
+
+void
+SoShaderProgram::render(SoState * state)
+{
+  PRIVATE(this)->render(state);
 }
 
 // doc from parent
@@ -349,9 +356,9 @@ SoShaderProgramP::~SoShaderProgramP()
 }
 
 void
-SoShaderProgramP::GLRender(SoGLRenderAction * action)
+SoShaderProgramP::render(SoState * state)
 {
-  SoState *state = action->getState();
+  if (!state) return;
 
   int i, cnt = PUBLIC(this)->shaderObject.getNum();
   if (cnt == 0) {
@@ -371,7 +378,7 @@ SoShaderProgramP::GLRender(SoGLRenderAction * action)
   for (i = 0; i <cnt; i++) {
     SoNode * node = PUBLIC(this)->shaderObject[i];
     if (node->isOfType(SoShaderObject::getClassTypeId())) {
-      ((SoShaderObject *)node)->GLRender(action);
+      ((SoShaderObject *)node)->render(state);
     }
   }
 


### PR DESCRIPTION
## Summary
Extract state-based shader rendering helpers from `SoShaderObject::GLRender()` / `SoShaderProgram::GLRender()`.

## Why
Some consumers (including the render-test harness) want to invoke shader setup using just `SoState*`, without needing to manufacture a full `SoGLRenderAction`.

## Changes
- Add `SoShaderObject::render(SoState*)` and `SoShaderProgram::render(SoState*)`.
- Refactor the existing `GLRender()` implementations to delegate to the new helpers.

<!-- AUTOGEN:BEGIN -->
#### Commits
- `506cbc2835`: Extract shader GLRender logic into helper

<!-- AUTOGEN:END -->
