### PR TITLE
Only search for GcGL/libCgGL in system default dirs

### DIFF
--- a/src/glue/dl.cpp
+++ b/src/glue/dl.cpp
@@ -690,7 +690,7 @@ cc_dl_open(const char * filename)
        somewhere else between us opening it, and until it is used for
        resolving symbols.
     */
-    h->nativehnd = LoadLibrary(filename);
+    h->nativehnd = LoadLibraryEx(filename, NULL, LOAD_LIBRARY_SEARCH_DEFAULT_DIRS);
 
     if (cc_dl_debugging() && (h->nativehnd == NULL)) {
       cc_string funcstr;


### PR DESCRIPTION
Addresses potential vulnerability via DLL injection -- see e.g. [cve-2022-32223](https://www.aquasec.com/blog/cve-2022-32223-dll-hijacking/). Reported downstream in the FreeCAD project as advisory GHSA-2mfq-2h69-c873 (no CVE assigned yet).

See also: https://learn.microsoft.com/en-us/windows/win32/dlls/dynamic-link-library-security