### PR TITLE
Fixes and improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -555,14 +555,18 @@ if(WIN32)
     set(COIN_DEFAULT_POSTFIX ${COIN_DEFAULT_STATIC_POSTFIX})
     set(COIN_LIBRARY_SUFFIX ${CMAKE_STATIC_LIBRARY_SUFFIX})
   endif()
-  set(CMAKE_RELEASE_POSTFIX "${COIN_DEFAULT_POSTFIX}"
-    CACHE STRING "Default filename postfix for libraries under configuration Release")
-  set(CMAKE_MINSIZEREL_POSTFIX "${COIN_DEFAULT_POSTFIX}"
-    CACHE STRING "Default filename postfix for libraries under configuration MinSizeRel")
-  set(CMAKE_RELWITHDEBINFO_POSTFIX "${COIN_DEFAULT_POSTFIX}"
-    CACHE STRING "Default filename postfix for libraries under configuration RelWithDebInfo")
-  set(CMAKE_DEBUG_POSTFIX "${COIN_DEFAULT_POSTFIX}d"
-    CACHE STRING "Default filename postfix for libraries under configuration Debug")
+  # Don't set these if the project is built as cmake a subdirectory
+  if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+    set(CMAKE_RELEASE_POSTFIX "${COIN_DEFAULT_POSTFIX}"
+      CACHE STRING "Default filename postfix for libraries under configuration Release")
+    set(CMAKE_MINSIZEREL_POSTFIX "${COIN_DEFAULT_POSTFIX}"
+      CACHE STRING "Default filename postfix for libraries under configuration MinSizeRel")
+    set(CMAKE_RELWITHDEBINFO_POSTFIX "${COIN_DEFAULT_POSTFIX}"
+      CACHE STRING "Default filename postfix for libraries under configuration RelWithDebInfo")
+    set(CMAKE_DEBUG_POSTFIX "${COIN_DEFAULT_POSTFIX}d"
+      CACHE STRING "Default filename postfix for libraries under configuration Debug")
+  endif()
+
 
   set(COIN_RELEASE_SYSTEM_LIBRARY_NAME Coin${CMAKE_RELEASE_POSTFIX}${COIN_LIBRARY_SUFFIX})
   set(COIN_DEBUG_SYSTEM_LIBRARY_NAME Coin${CMAKE_DEBUG_POSTFIX}${COIN_LIBRARY_SUFFIX})

--- a/include/Inventor/SbByteBufferP.icc
+++ b/include/Inventor/SbByteBufferP.icc
@@ -31,7 +31,7 @@ class SbByteBufferP {
 INLINE void
 SbByteBuffer::makeUnique()
 {
-  if (PRIVATE(this)->size_ && !PRIVATE(this)->buffer.unique()) {
+  if (PRIVATE(this)->size_ && !(PRIVATE(this)->buffer.use_count() == 1)) {
     std::shared_ptr<char> tmp_buffer(new char [PRIVATE(this)->size_], std::default_delete<char[]>());
     memcpy(tmp_buffer.get(),PRIVATE(this)->buffer.get(),PRIVATE(this)->size_);
     PRIVATE(this)->buffer=tmp_buffer;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -205,6 +205,12 @@ else()
   )
 endif()
 
+# Export a Coin::Coin target when the library is built as a cmake subdirectory
+# so that the same target can be linked using find_package and this method
+if(NOT CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+  add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
+endif()
+
 if(WIN32)
   if(COIN_BUILD_SHARED_LIBS)
     configure_file(${PROJECT_NAME}.rc.cmake.in ${PROJECT_NAME}.rc)


### PR DESCRIPTION
This PR is part of the work to vendor coin with FreeCAD and there are three commits that do the following:
1. Introduces a alias target Coin::Coin when building coin in tree as a sub-directory. This allows us to link the same target irrespective of building in tree or through find_package.
2. Fixes compilation with C++ 20 as std::shared_ptr::unique was [removed](https://en.cppreference.com/w/cpp/memory/shared_ptr/unique.html) in C++20 in favour of use_count.
3. Updated the code to explicitly use ASCII versions of winapi functions. So, made GetCurrentDirectory -> GetCurrentDirectoryA. Functions like GetCurrentDirectory are just a macro that either expand to GetCurrentDirectoryA or GetCurrentDirectoryW (the unicode variant). We can undefine the _UNICODE macro in freecad to force the winapi macros to expand to the ASCII variant but I think keeping it explicit is better as the coin code doesn't compile with the unicode variants. I primarily develop on linux so not 100% confident on this change and can revert this commit if requested.