### PR TITLE
Fix cc_string inline buffer size calculation in string.h

### DIFF
--- a/include/Inventor/C/base/string.h
+++ b/include/Inventor/C/base/string.h
@@ -44,7 +44,7 @@ extern "C" {
 /* ********************************************************************** */
 
 enum cc_string_constants {
-  CC_STRING_MIN_SIZE = 128 - sizeof(char *) + sizeof(size_t),
+  CC_STRING_MIN_SIZE = 128 - sizeof(char *) - sizeof(size_t),
   CC_STRING_RESIZE   = 128
 };
 


### PR DESCRIPTION
- Change CC_STRING_MIN_SIZE from `128 - sizeof(char *) + sizeof(size_t)` to `128 - sizeof(char *) - sizeof(size_t)`.
- CC_STRING_MIN_SIZE is intended to reserve inline buffer so that the structure has a stable total capacity (128 bytes). The buffer size should subtract both the pointer and the size_t field sizes. I guess the previous + sizeof(size_t) was a typo.