### PR TITLE
Skip negative indices in SoIndexedPointSet vertex arrays

### DIFF
--- a/src/shapenodes/SoIndexedPointSet.cpp
+++ b/src/shapenodes/SoIndexedPointSet.cpp
@@ -353,7 +353,8 @@ SoIndexedPointSet::GLRender(SoGLRenderAction * action)
     if (this->vaindexer == NULL) {
       SoVertexArrayIndexer * indexer = new SoVertexArrayIndexer;
       for (int i = 0; i < numindices; i++) {
-        int32_t idx = this->coordIndex[i];
+        int32_t idx = cindices[i];
+        if (idx < 0) continue;
         indexer->addPoint(idx);
       }
       indexer->close();


### PR DESCRIPTION
- Skip negative coordinate indices when building the `SoIndexedPointSet` vertex-array indexer.
- Align vertex-array rendering with the immediate-mode and `generatePrimitives` paths, which already ignore negative point indices.

## Why
`SoIndexedPointSet` can receive `coordIndex` arrays containing negative sentinel values. The immediate-mode path filters these out, but the vertex-array path currently forwards them to `SoVertexArrayIndexer`. That can reach OpenGL as `0xffffffff` in `glDrawElements(GL_POINTS, ...)`, which is an invalid vertex index when primitive restart is disabled and can crash some drivers.

This was observed while debugging a FreeCAD crash where the trace contained `glDrawElements(GL_POINTS, 25, GL_UNSIGNED_INT, ...)` with indices `376..399, 0xffffffff`. 

Reference: https://github.com/FreeCAD/FreeCAD/issues/30718