### PR TITLE
Pin Windows CI to windows-2022

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -35,7 +35,7 @@ jobs:
 
   windows-build:
     name: Windows Build
-    runs-on: windows-latest
+    runs-on: windows-2022
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
- Pin the Windows CI job to `windows-2022`.

## Why
The workflow hard-codes the `Visual Studio 17 2022` CMake generator. On `windows-latest`, the hosted image can move independently of this workflow and leave the job without a matching Visual Studio installation.

This currently fails during configure with:

```text
Generator "Visual Studio 17 2022" could not find any instance of Visual Studio.
```

Pinning the runner to `windows-2022` keeps the runner image aligned with the requested Visual Studio 2022 generator.
