### PR TITLE
Fix the SoGroup vulnerability from GHSA-hcqw-f3m9-mq7p

### DIFF
--- a/src/base/SbName.cpp
+++ b/src/base/SbName.cpp
@@ -194,11 +194,21 @@ SbName::isIdentStartChar(const char c)
 SbBool
 SbName::isIdentChar(const char c)
 {
+  // There is an important reason why the cast below is necessary:
+  // isalnum() et al takes an "int" as input argument. A _signed_ char
+  // value for any character above the 127-value ASCII character set
+  // will be promoted to a negative integer, which can cause the
+  // function to make an array reference that's out of bounds.
+  //
+  // FIXME: this needs to be fixed other places isalnum() is used,
+  // as well as for other is*() function. 20021124 mortene / 20260617 veelo.
+  const unsigned char uc = static_cast<unsigned char>(c);
+
   // FIXME: isalnum() takes the current locale into account. This can
   // lead to "interesting" artifacts. We very likely need to audit and
   // fix our isalnum() calls in the Coin sourcecode to behave in the
   // exact manner that we expect them to. 20020319 mortene.
-  return (isalnum(c) || c == '_');
+  return (isalnum(uc) || c == '_');
 }
 
 /*!

--- a/src/misc/SoBaseP.cpp
+++ b/src/misc/SoBaseP.cpp
@@ -517,7 +517,16 @@ SoBase::PImpl::createInstance(SoInput * in, const SbName & classname)
     // search in global PROTO list
     proto = SoProto::findProto(classname);
   }
-  if (proto) return proto->createProtoInstance();
+  if (proto) {
+    if (in->getCurrentProto() == proto) {
+      SoReadError::post(in,
+        "Self-referential PROTO '%s' detected. ",
+        classname.getString());
+      return NULL;   // causes readDefinition() to fail and aborts the load
+    }
+
+    return proto->createProtoInstance();
+  }
 
   if (type == SoType::badType())
     type = SoType::fromName(classname);


### PR DESCRIPTION
Handles non-ASCII identifiers and rejects recursive PROTO definitions.