### PR TITLE
Add pick layer to SoPickStyle for ordered on-top picking

### DIFF
--- a/include/Inventor/elements/SoElements.h
+++ b/include/Inventor/elements/SoElements.h
@@ -64,6 +64,7 @@
 #include <Inventor/elements/SoMaterialBindingElement.h>
 #include <Inventor/elements/SoNormalBindingElement.h>
 #include <Inventor/elements/SoPickStyleElement.h>
+#include <Inventor/elements/SoPickLayerElement.h>
 #include <Inventor/elements/SoSwitchElement.h>
 #include <Inventor/elements/SoTextOutlineEnabledElement.h>
 #include <Inventor/elements/SoTextureCoordinateBindingElement.h>

--- a/include/Inventor/elements/SoPickLayerElement.h
+++ b/include/Inventor/elements/SoPickLayerElement.h
@@ -1,25 +1,25 @@
-#ifndef COIN_SOPICKSTYLE_H
-#define COIN_SOPICKSTYLE_H
+#ifndef COIN_SOPICKLAYERELEMENT_H
+#define COIN_SOPICKLAYERELEMENT_H
 
 /**************************************************************************\
  * Copyright (c) Kongsberg Oil & Gas Technologies AS
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
  * met:
- * 
+ *
  * Redistributions of source code must retain the above copyright notice,
  * this list of conditions and the following disclaimer.
- * 
+ *
  * Redistributions in binary form must reproduce the above copyright
  * notice, this list of conditions and the following disclaimer in the
  * documentation and/or other materials provided with the distribution.
- * 
+ *
  * Neither the name of the copyright holder nor the names of its
  * contributors may be used to endorse or promote products derived from
  * this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
  * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
  * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -33,38 +33,24 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 \**************************************************************************/
 
-#include <Inventor/nodes/SoSubNode.h>
-#include <Inventor/fields/SoSFEnum.h>
-#include <Inventor/fields/SoSFInt32.h>
-#include <Inventor/elements/SoPickStyleElement.h>
+#include <Inventor/elements/SoInt32Element.h>
 
-class COIN_DLL_API SoPickStyle : public SoNode {
-  typedef SoNode inherited;
+class COIN_DLL_API SoPickLayerElement : public SoInt32Element {
+  typedef SoInt32Element inherited;
 
-  SO_NODE_HEADER(SoPickStyle);
-
+  SO_ELEMENT_HEADER(SoPickLayerElement);
 public:
   static void initClass(void);
-  SoPickStyle(void);
-
-  enum Style {
-    SHAPE = SoPickStyleElement::SHAPE,
-    BOUNDING_BOX = SoPickStyleElement::BOUNDING_BOX,
-    UNPICKABLE = SoPickStyleElement::UNPICKABLE,
-    SHAPE_ON_TOP = SoPickStyleElement::SHAPE_ON_TOP,
-    BOUNDING_BOX_ON_TOP = SoPickStyleElement::BOUNDING_BOX_ON_TOP,
-    SHAPE_FRONTFACES = SoPickStyleElement::SHAPE_FRONTFACES
-  };
-
-  SoSFEnum style;
-  SoSFInt32 layer;
-
-  virtual void doAction(SoAction * action);
-  virtual void callback(SoCallbackAction * action);
-  virtual void pick(SoPickAction * action);
-
 protected:
-  virtual ~SoPickStyle();
+  virtual ~SoPickLayerElement();
+
+public:
+  virtual void init(SoState * state);
+  static void set(SoState * const state, SoNode * const node,
+                  const int32_t layer);
+  static void set(SoState * const state, const int32_t layer);
+  static int32_t get(SoState * const state);
+  static int32_t getDefault();
 };
 
-#endif // !COIN_SOPICKSTYLE_H
+#endif // !COIN_SOPICKLAYERELEMENT_H

--- a/src/actions/SoRayPickAction.cpp
+++ b/src/actions/SoRayPickAction.cpp
@@ -130,6 +130,7 @@
 #include <Inventor/actions/SoRayPickAction.h>
 
 #include <cfloat>
+#include <cstdint>
 
 #include <Inventor/SbLine.h>
 #include <Inventor/SoPickedPoint.h>
@@ -139,6 +140,7 @@
 #include <Inventor/elements/SoTextureOverrideElement.h>
 #include <Inventor/elements/SoPickRayElement.h>
 #include <Inventor/elements/SoPickStyleElement.h>
+#include <Inventor/elements/SoPickLayerElement.h>
 #include <Inventor/elements/SoShapeHintsElement.h>
 #include <Inventor/elements/SoViewVolumeElement.h>
 #include <Inventor/elements/SoViewportRegionElement.h>
@@ -169,7 +171,7 @@
 
 class SoRayPickActionP {
 public:
-  SoRayPickActionP(void) : owner(NULL) { }
+  SoRayPickActionP(void) : pickstylelayer(0), owner(NULL) { }
 
   // Hidden private methods.
 
@@ -209,6 +211,11 @@ public:
 
   SoPickedPointList pickedpointlist;
   SbList <double> ppdistance;
+  SbList <int32_t> pplayer;
+
+  // the pick layer for the shape currently being intersected (set in
+  // setPickStyleFlags); on-top picks ignore this and always sort frontmost
+  int32_t pickstylelayer;
 
   unsigned int flags;
   SbBool objectspacevalid; // FIXME: why not a flag?
@@ -437,24 +444,36 @@ SoRayPickAction::getPickedPointList(void) const
   if (!PRIVATE(this)->isFlagSet(SoRayPickActionP::PPLIST_IS_SORTED) && n > 1) {
     SoPickedPoint ** pparray = reinterpret_cast<SoPickedPoint **>(PRIVATE(this)->pickedpointlist.getArrayPtr());
     double * darray = const_cast<double*>(PRIVATE(this)->ppdistance.getArrayPtr());
+    int32_t * larray = const_cast<int32_t*>(PRIVATE(this)->pplayer.getArrayPtr());
 
     int i, j, distance;
     SoPickedPoint * pptmp;
     double dtmp;
+    int32_t ltmp;
+
+    // a point sorts in front of another when it is in a higher layer, or in the
+    // same layer but closer; on-top picks carry the maximum layer and thus stay
+    // frontmost regardless of depth
+    auto sortsBefore = [](int32_t layerA, double distA, int32_t layerB, double distB) {
+      return layerA > layerB || (layerA == layerB && distA < distB);
+    };
 
     // shell sort algorithm (O(nlog(n))
     for (distance = 1; distance <= n/9; distance = 3*distance + 1) ;
     for (; distance > 0; distance /= 3) {
       for (i = distance; i < n; i++) {
         dtmp = darray[i];
+        ltmp = larray[i];
         pptmp = pparray[i];
         j = i;
-        while (j >= distance && darray[j-distance] > dtmp) {
+        while (j >= distance && sortsBefore(ltmp, dtmp, larray[j-distance], darray[j-distance])) {
           darray[j] = darray[j-distance];
+          larray[j] = larray[j-distance];
           pparray[j] = pparray[j-distance];
           j -= distance;
         }
         darray[j] = dtmp;
+        larray[j] = ltmp;
         pparray[j] = pptmp;
       }
     }
@@ -1018,13 +1037,22 @@ SoRayPickAction::addIntersection(const SbVec3f & objectspacepoint_in, SbBool fro
   PRIVATE(this)->obj2world.multVecMatrix(objectspacepoint, worldpoint);
   double dist = PRIVATE(this)->isFlagSet(SoRayPickActionP::PUSH_PICK_TO_FRONT) ?
     0.0 : PRIVATE(this)->nearplane.getDistance(worldpoint);
+  // on-top picks ignore their layer and always sort frontmost
+  int32_t layer = PRIVATE(this)->isFlagSet(SoRayPickActionP::PUSH_PICK_TO_FRONT) ?
+    INT32_MAX : PRIVATE(this)->pickstylelayer;
 
   if (!PRIVATE(this)->isFlagSet(SoRayPickActionP::PICK_ALL) && PRIVATE(this)->pickedpointlist.getLength()) {
-    // got to test if new candidate is closer than old one
-    if (dist >= PRIVATE(this)->ppdistance[0]) return NULL; // farther
+    // got to test if new candidate sorts in front of the old one: higher layer
+    // wins, and within a layer the closer point wins
+    const int32_t prevlayer = PRIVATE(this)->pplayer[0];
+    const double prevdist = PRIVATE(this)->ppdistance[0];
+    if (layer < prevlayer || (layer == prevlayer && dist >= prevdist)) {
+      return NULL; // behind
+    }
     // remove old point
     PRIVATE(this)->pickedpointlist.truncate(0);
     PRIVATE(this)->ppdistance.truncate(0);
+    PRIVATE(this)->pplayer.truncate(0);
   }
 
   // create the new picked point
@@ -1032,6 +1060,7 @@ SoRayPickAction::addIntersection(const SbVec3f & objectspacepoint_in, SbBool fro
                                          this->state, objectspacepoint_in);
   PRIVATE(this)->pickedpointlist.append(pp);
   PRIVATE(this)->ppdistance.append(dist);
+  PRIVATE(this)->pplayer.append(layer);
   PRIVATE(this)->clearFlag(SoRayPickActionP::PPLIST_IS_SORTED);
   return pp;
 }
@@ -1091,6 +1120,7 @@ SoRayPickActionP::cleanupPickedPoints(void)
 {
   this->pickedpointlist.truncate(0); // this will delete all SoPickedPoint instances in the list
   this->ppdistance.truncate(0);
+  this->pplayer.truncate(0);
   this->clearFlag(PPLIST_IS_SORTED);
 }
 
@@ -1153,7 +1183,10 @@ void
 SoRayPickActionP::setPickStyleFlags(SoState * state)
 {
   assert(state->isElementEnabled(SoPickStyleElement::getClassStackIndex()));
+  assert(state->isElementEnabled(SoPickLayerElement::getClassStackIndex()));
   assert(state->isElementEnabled(SoShapeHintsElement::getClassStackIndex()));
+
+  this->pickstylelayer = SoPickLayerElement::get(state);
 
   SoPickStyleElement::Style style = SoPickStyleElement::get(state);
   SoShapeHintsElement::ShapeType type = SoShapeHintsElement::getShapeType(state);

--- a/src/elements/CMakeLists.txt
+++ b/src/elements/CMakeLists.txt
@@ -52,6 +52,7 @@ set(COIN_ELEMENTS_FILES
 	SoOverrideElement.cpp
 	SoPickRayElement.cpp
 	SoPickStyleElement.cpp
+	SoPickLayerElement.cpp
 	SoPointSizeElement.cpp
 	SoPolygonOffsetElement.cpp
 	SoProfileCoordinateElement.cpp

--- a/src/elements/SoElement.cpp
+++ b/src/elements/SoElement.cpp
@@ -400,6 +400,7 @@ SoElement::initElements(void)
   SoMaterialBindingElement::initClass();
   SoNormalBindingElement::initClass();
   SoPickStyleElement::initClass();
+  SoPickLayerElement::initClass();
   SoSwitchElement::initClass();
   SoTextOutlineEnabledElement::initClass();
   SoTextureCoordinateBindingElement::initClass();

--- a/src/elements/SoPickLayerElement.cpp
+++ b/src/elements/SoPickLayerElement.cpp
@@ -1,25 +1,22 @@
-#ifndef COIN_SOPICKSTYLE_H
-#define COIN_SOPICKSTYLE_H
-
 /**************************************************************************\
  * Copyright (c) Kongsberg Oil & Gas Technologies AS
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
  * met:
- * 
+ *
  * Redistributions of source code must retain the above copyright notice,
  * this list of conditions and the following disclaimer.
- * 
+ *
  * Redistributions in binary form must reproduce the above copyright
  * notice, this list of conditions and the following disclaimer in the
  * documentation and/or other materials provided with the distribution.
- * 
+ *
  * Neither the name of the copyright holder nor the names of its
  * contributors may be used to endorse or promote products derived from
  * this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
  * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
  * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -33,38 +30,85 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 \**************************************************************************/
 
-#include <Inventor/nodes/SoSubNode.h>
-#include <Inventor/fields/SoSFEnum.h>
-#include <Inventor/fields/SoSFInt32.h>
-#include <Inventor/elements/SoPickStyleElement.h>
+/*!
+  \class SoPickLayerElement Inventor/elements/SoPickLayerElement.h
+  \brief The SoPickLayerElement holds the current pick layer.
 
-class COIN_DLL_API SoPickStyle : public SoNode {
-  typedef SoNode inherited;
+  \ingroup coin_elements
 
-  SO_NODE_HEADER(SoPickStyle);
+  The pick layer orders picked points across the scene graph. Picked points
+  in a higher layer sort in front of those in a lower layer, independent of
+  their depth. It is paired with SoPickStyleElement: on-top pick styles ignore
+  the layer and always sort frontmost. The default layer is 0.
+*/
 
-public:
-  static void initClass(void);
-  SoPickStyle(void);
+#include <Inventor/elements/SoPickLayerElement.h>
 
-  enum Style {
-    SHAPE = SoPickStyleElement::SHAPE,
-    BOUNDING_BOX = SoPickStyleElement::BOUNDING_BOX,
-    UNPICKABLE = SoPickStyleElement::UNPICKABLE,
-    SHAPE_ON_TOP = SoPickStyleElement::SHAPE_ON_TOP,
-    BOUNDING_BOX_ON_TOP = SoPickStyleElement::BOUNDING_BOX_ON_TOP,
-    SHAPE_FRONTFACES = SoPickStyleElement::SHAPE_FRONTFACES
-  };
+SO_ELEMENT_SOURCE(SoPickLayerElement);
 
-  SoSFEnum style;
-  SoSFInt32 layer;
+/*!
+  \copydetails SoElement::initClass(void)
+*/
 
-  virtual void doAction(SoAction * action);
-  virtual void callback(SoCallbackAction * action);
-  virtual void pick(SoPickAction * action);
+void
+SoPickLayerElement::initClass(void)
+{
+  SO_ELEMENT_INIT_CLASS(SoPickLayerElement, inherited);
+}
 
-protected:
-  virtual ~SoPickStyle();
-};
+/*!
+  Destructor.
+*/
 
-#endif // !COIN_SOPICKSTYLE_H
+SoPickLayerElement::~SoPickLayerElement()
+{
+}
+
+//! Sets the current pick layer.
+
+void
+SoPickLayerElement::set(SoState * const state,
+                        SoNode * const node,
+                        const int32_t layer)
+{
+  SoInt32Element::set(classStackIndex, state, node, layer);
+}
+
+/*!
+  Initializes the element to its default value. The default
+  value for the pick layer is 0.
+*/
+
+void
+SoPickLayerElement::init(SoState * state)
+{
+  inherited::init(state);
+  this->data = getDefault();
+}
+
+//! Sets the current pick layer.
+
+//$ EXPORT INLINE
+void
+SoPickLayerElement::set(SoState * const state, const int32_t layer)
+{
+  set(state, NULL, layer);
+}
+
+//! Returns the current pick layer.
+
+//$ EXPORT INLINE
+int32_t
+SoPickLayerElement::get(SoState * const state)
+{
+  return SoInt32Element::get(classStackIndex, state);
+}
+
+//! Returns the default pick layer (0).
+
+//$ EXPORT INLINE
+int32_t
+SoPickLayerElement::getDefault()
+{
+  return 0;
+}

--- a/src/nodes/SoPickStyle.cpp
+++ b/src/nodes/SoPickStyle.cpp
@@ -59,6 +59,7 @@
 #include <Inventor/actions/SoPickAction.h>
 
 #include <Inventor/elements/SoOverrideElement.h>
+#include <Inventor/elements/SoPickLayerElement.h>
 #include <Inventor/actions/SoCallbackAction.h>
 
 #include "nodes/SoSubNodeP.h"
@@ -130,6 +131,16 @@
   in the scene graph. Default value is SoPickStyle::SHAPE.
 */
 
+/*!
+  \var SoSFInt32 SoPickStyle::layer
+
+  The pick layer for subsequent shapes in the scene graph. Picked points
+  in a higher layer sort in front of those in a lower layer, regardless of
+  their depth; within a layer, the usual depth order applies. The on-top
+  pick styles ignore the layer and always sort frontmost. Default value
+  is 0.
+*/
+
 // *************************************************************************
 
 SO_NODE_SOURCE(SoPickStyle);
@@ -142,6 +153,7 @@ SoPickStyle::SoPickStyle(void)
   SO_NODE_INTERNAL_CONSTRUCTOR(SoPickStyle);
 
   SO_NODE_ADD_FIELD(style, (SoPickStyle::SHAPE));
+  SO_NODE_ADD_FIELD(layer, (0));
 
   SO_NODE_DEFINE_ENUM_VALUE(Style, SHAPE);
   SO_NODE_DEFINE_ENUM_VALUE(Style, BOUNDING_BOX);
@@ -170,6 +182,9 @@ SoPickStyle::initClass(void)
 
   SO_ENABLE(SoCallbackAction, SoPickStyleElement);
   SO_ENABLE(SoPickAction, SoPickStyleElement);
+
+  SO_ENABLE(SoCallbackAction, SoPickLayerElement);
+  SO_ENABLE(SoPickAction, SoPickLayerElement);
 }
 
 void
@@ -182,6 +197,9 @@ SoPickStyle::doAction(SoAction * action)
     if (this->isOverride()) {
       SoOverrideElement::setPickStyleOverride(action->getState(), this, TRUE);
     }
+  }
+  if (!this->layer.isIgnored()) {
+    SoPickLayerElement::set(action->getState(), this, this->layer.getValue());
   }
 }
 


### PR DESCRIPTION
Rebased reopen of #623

This will let picked points be ordered across the scene graph independent of depth. SoPickStyle gains a `layer` field (default 0), carried through traversal by the new SoPickLayerElement. SoRayPickAction sorts picked points by layer (descending) and then by distance (ascending), so a higher layer always picks in front while true depth order is preserved within a layer.

The existing *_ON_TOP styles are unchanged: they ignore the layer and still sort frontmost. This replaces the previous behaviour where on-top picks collapsed their distance to 0 as the only way to bias picking to the front.

Fixes: #546