### PR TITLE
Add missing debug warning on missing simage lib.

### DIFF
--- a/src/base/SbImage.cpp
+++ b/src/base/SbImage.cpp
@@ -483,7 +483,10 @@ SbImage::readFile(const SbString & filename,
       if (cbdata.cb(filename, this, cbdata.closure)) return TRUE;
     }
     if (!simage_wrapper()->available) {
-      return FALSE;
+        SoDebugError::postWarning("SbImage::readFile",
+                                  "The simage library is not available, "
+                                  "cannot import any images from disk.");
+        return FALSE;
     }
   }
 


### PR DESCRIPTION
When trying to load textures from .jpg, the user would only see a file loading error, not the hint to link with simage.