### PR TITLE
tidbits: use C++ cmath functions

### DIFF
--- a/src/tidbits.cpp
+++ b/src/tidbits.cpp
@@ -1625,7 +1625,8 @@ int
 coin_isinf(double value)
 {
 #ifdef HAVE_ISINF
-  return isinf(value);
+  if (std::isinf(value)) { return std::signbit(value) ? -1 : 1; }
+  return 0;
 #elif defined(HAVE_FPCLASS)
   if (fpclass(value) == FP_NINF) { return -1; }
   if (fpclass(value) == FP_PINF) { return +1; }
@@ -1653,7 +1654,7 @@ int
 coin_isnan(double value)
 {
 #ifdef HAVE_ISNAN
-  return isnan(value);
+  return std::isnan(value) ? 1 : 0;
 #elif defined(HAVE__ISNAN)
   return _isnan(value);
 #elif defined(HAVE_FPCLASS)


### PR DESCRIPTION
## Summary
- Use `std::isinf` and `std::isnan` from `<cmath>` in `tidbits.cpp`.
- Preserve `coin_isinf()`'s documented `-1` / `+1` return contract with `std::signbit`.

## Motivation
Some C++ environments do not expose the unqualified C `isinf` and `isnan` names when including `<cmath>`. Coin detects these functions through the C `math.h` header, but `tidbits.cpp` is C++ code, so using the `std::` namespace is the portable form.