### PR TITLE
Fix duplicate virtual and override keywords on function signatures.

### DIFF
--- a/include/Inventor/VRMLnodes/SoVRMLBox.h
+++ b/include/Inventor/VRMLnodes/SoVRMLBox.h
@@ -50,14 +50,14 @@ public:
 
   void GLRender(SoGLRenderAction * action) override;
   void rayPick(SoRayPickAction * action) override;
-  void getPrimitiveCount( SoGetPrimitiveCountAction * action ) override;
+  void getPrimitiveCount(SoGetPrimitiveCountAction * action) override;
 
 protected:
   virtual ~SoVRMLBox();
 
-  void generatePrimitives( SoAction * action ) override;
-  virtual void computeBBox( SoAction * action, SbBox3f & box,
-                            SbVec3f & center ) override;
+  void generatePrimitives(SoAction * action) override;
+  void computeBBox(SoAction * action, SbBox3f & box,
+                   SbVec3f & center) override;
 }; // class SoVRMLBox
 
 #endif // ! COIN_SOVRMLBOX_H

--- a/include/Inventor/VRMLnodes/SoVRMLCone.h
+++ b/include/Inventor/VRMLnodes/SoVRMLCone.h
@@ -60,8 +60,8 @@ protected:
   virtual ~SoVRMLCone();
 
   void generatePrimitives(SoAction * action) override;
-  virtual void computeBBox(SoAction * action,
-                           SbBox3f & box, SbVec3f & center) override;
+  void computeBBox(SoAction * action,
+                   SbBox3f & box, SbVec3f & center) override;
 
 }; // class SoVRMLCone
 

--- a/include/Inventor/VRMLnodes/SoVRMLCylinder.h
+++ b/include/Inventor/VRMLnodes/SoVRMLCylinder.h
@@ -61,8 +61,8 @@ protected:
   virtual ~SoVRMLCylinder();
 
   void generatePrimitives(SoAction * action) override;
-  virtual void computeBBox(SoAction * action, SbBox3f & box,
-                           SbVec3f & center) override;
+  void computeBBox(SoAction * action, SbBox3f & box,
+                   SbVec3f & center) override;
 
 }; // class SoVRMLCylinder
 

--- a/include/Inventor/VRMLnodes/SoVRMLElevationGrid.h
+++ b/include/Inventor/VRMLnodes/SoVRMLElevationGrid.h
@@ -79,8 +79,8 @@ protected:
 
   void notify(SoNotList * list) override;
   void generatePrimitives( SoAction * action ) override;
-  virtual void computeBBox(SoAction * action, SbBox3f & bbox,
-                           SbVec3f & center) override;
+  void computeBBox(SoAction * action, SbBox3f & bbox,
+                   SbVec3f & center) override;
 
 private:
   friend class SoVRMLElevationGridP;

--- a/include/Inventor/VRMLnodes/SoVRMLExtrusion.h
+++ b/include/Inventor/VRMLnodes/SoVRMLExtrusion.h
@@ -63,8 +63,8 @@ public:
 
   void GLRender(SoGLRenderAction * action) override;
   void getPrimitiveCount(SoGetPrimitiveCountAction * action) override;
-  virtual void computeBBox(SoAction * action,
-                           SbBox3f & bbox, SbVec3f & center) override;
+  void computeBBox(SoAction * action,
+                   SbBox3f & bbox, SbVec3f & center) override;
 
 protected:
   virtual ~SoVRMLExtrusion();
@@ -72,11 +72,11 @@ protected:
   void notify(SoNotList * list) override;
   void generatePrimitives( SoAction * action ) override;
 
-  virtual SoDetail * createTriangleDetail(SoRayPickAction * action,
-                                          const SoPrimitiveVertex * v1,
-                                          const SoPrimitiveVertex * v2,
-                                          const SoPrimitiveVertex * v3,
-                                          SoPickedPoint * pp) override;
+  SoDetail * createTriangleDetail(SoRayPickAction * action,
+                                  const SoPrimitiveVertex * v1,
+                                  const SoPrimitiveVertex * v2,
+                                  const SoPrimitiveVertex * v3,
+                                  SoPickedPoint * pp) override;
 private:
   void updateCache(void);
   class SoVRMLExtrusionP * pimpl;

--- a/include/Inventor/VRMLnodes/SoVRMLIndexedLine.h
+++ b/include/Inventor/VRMLnodes/SoVRMLIndexedLine.h
@@ -52,14 +52,14 @@ protected:
   SoVRMLIndexedLine(void);
   virtual ~SoVRMLIndexedLine();
 
-  virtual void computeBBox(SoAction * action,
-                           SbBox3f & box, SbVec3f & center) override;
+  void computeBBox(SoAction * action,
+                   SbBox3f & box, SbVec3f & center) override;
   
-  int getNumVerts( int startCoord );
-  void setupIndices( int numFaces );
+  int getNumVerts(int startCoord);
+  void setupIndices(int numFaces);
   const int32_t * getColorIndices(void);
 
-  void notify( SoNotList * list ) override;
+  void notify(SoNotList * list) override;
 
 }; // class SoVRMLIndexedLine
 

--- a/include/Inventor/VRMLnodes/SoVRMLSphere.h
+++ b/include/Inventor/VRMLnodes/SoVRMLSphere.h
@@ -56,8 +56,8 @@ protected:
   virtual ~SoVRMLSphere();
 
   void generatePrimitives(SoAction * action) override;
-  virtual void computeBBox(SoAction * action,
-                           SbBox3f & box, SbVec3f & center) override;
+  void computeBBox(SoAction * action,
+                   SbBox3f & box, SbVec3f & center) override;
 
 }; // class SoVRMLSphere
 

--- a/include/Inventor/VRMLnodes/SoVRMLText.h
+++ b/include/Inventor/VRMLnodes/SoVRMLText.h
@@ -71,8 +71,8 @@ public:
 protected:
   virtual ~SoVRMLText();
 
-  virtual void computeBBox(SoAction * action,
-                            SbBox3f & box, SbVec3f & center) override;
+  void computeBBox(SoAction * action,
+                   SbBox3f & box, SbVec3f & center) override;
   void generatePrimitives(SoAction * action) override;
   SoChildList * children;
 

--- a/include/Inventor/VRMLnodes/SoVRMLVertexPoint.h
+++ b/include/Inventor/VRMLnodes/SoVRMLVertexPoint.h
@@ -64,8 +64,8 @@ protected:
   virtual ~SoVRMLVertexPoint();
 
   SbBool shouldGLRender(SoGLRenderAction * action) override;
-  virtual void computeBBox(SoAction * action, SbBox3f & box,
-                           SbVec3f & center) override;
+  void computeBBox(SoAction * action, SbBox3f & box,
+                   SbVec3f & center) override;
 }; // class SoVRMLVertexPoint
 
 #endif // ! COIN_SOVRMLVERTEXPOINT_H

--- a/include/Inventor/elements/SoGLClipPlaneElement.h
+++ b/include/Inventor/elements/SoGLClipPlaneElement.h
@@ -46,13 +46,11 @@ protected:
 
 public:
   void init(SoState * state) override;
-  virtual void pop(SoState * state,
-                   const SoElement * prevTopElement) override;
+  void pop(SoState * state, const SoElement * prevTopElement) override;
   static  int getMaxGLPlanes(void);
 
 protected:
-  virtual void addToElt(const SbPlane & plane,
-                        const SbMatrix & modelMatrix) override;
+  void addToElt(const SbPlane & plane, const SbMatrix & modelMatrix) override;
 
 private:
 };

--- a/include/Inventor/elements/SoGLDepthBufferElement.h
+++ b/include/Inventor/elements/SoGLDepthBufferElement.h
@@ -49,8 +49,8 @@ public:
 protected:
   virtual ~SoGLDepthBufferElement();
 
-  virtual void setElt(SbBool test, SbBool write,
-                      DepthWriteFunction function, SbVec2f range) override;
+  void setElt(SbBool test, SbBool write,
+              DepthWriteFunction function, SbVec2f range) override;
 
 private:
   void updategl(void) const;

--- a/include/Inventor/elements/SoGLDrawStyleElement.h
+++ b/include/Inventor/elements/SoGLDrawStyleElement.h
@@ -48,8 +48,7 @@ public:
   void init(SoState * state) override;
 
   void push(SoState * state) override;
-  virtual void pop(SoState * state,
-                   const SoElement * prevTopElement) override;
+  void pop(SoState * state, const SoElement * prevTopElement) override;
 
 protected:
   void setElt(int32_t style) override;

--- a/include/Inventor/elements/SoGLEnvironmentElement.h
+++ b/include/Inventor/elements/SoGLEnvironmentElement.h
@@ -46,19 +46,18 @@ protected:
 
 public:
   void init(SoState * state) override;
-  virtual void pop(SoState * state,
-                   const SoElement * prevTopElement) override;
+  void pop(SoState * state, const SoElement * prevTopElement) override;
 
 protected:
+  void setElt(SoState * const state,
+              const float ambientIntensity,
+              const SbColor & ambientColor,
+              const SbVec3f & attenuation,
+              const int32_t fogType,
+              const SbColor & fogColor,
+              const float fogVisibility,
+              const float fogStart) override;
 
-  virtual void setElt(SoState * const state,
-                      const float ambientIntensity,
-                      const SbColor & ambientColor,
-                      const SbVec3f & attenuation,
-                      const int32_t fogType,
-                      const SbColor & fogColor,
-                      const float fogVisibility,
-                      const float fogStart) override;
 private:
   void updategl(SoState * const state);
 };

--- a/include/Inventor/elements/SoGLLazyElement.h
+++ b/include/Inventor/elements/SoGLLazyElement.h
@@ -99,14 +99,14 @@ public:
     uint32_t reserved[4];
   };
 
-  virtual void setDiffuseElt(SoNode*,  int32_t numcolors,
-                             const SbColor * colors, SoColorPacker * packer) override;
-  virtual void setPackedElt(SoNode * node, int32_t numcolors,
-                            const uint32_t * colors, const SbBool packedtransparency) override;
-  virtual void setColorIndexElt(SoNode * node, int32_t numindices,
-                                const int32_t * indices) override;
-  virtual void setTranspElt(SoNode * node, int32_t numtransp,
-                            const float * transp, SoColorPacker * packer) override;
+  void setDiffuseElt(SoNode*, int32_t numcolors,
+                     const SbColor * colors, SoColorPacker * packer) override;
+  void setPackedElt(SoNode * node, int32_t numcolors,
+                    const uint32_t * colors, const SbBool packedtransparency) override;
+  void setColorIndexElt(SoNode * node, int32_t numindices,
+                        const int32_t * indices) override;
+  void setTranspElt(SoNode * node, int32_t numtransp,
+                    const float * transp, SoColorPacker * packer) override;
 
   void setTranspTypeElt(int32_t type) override;
   void setAmbientElt(const SbColor* color) override;
@@ -117,15 +117,15 @@ public:
   void enableBlendingElt(int sfactor, int dfactor, int alpha_sfactor, int alpha_dfactor) override;
   void disableBlendingElt(void) override;
   void setLightModelElt(SoState *state, int32_t model) override;
-  virtual void setMaterialElt(SoNode * node, uint32_t bitmask,
-                              SoColorPacker * packer,
-                              const SbColor * diffuse, const int numdiffuse,
-                              const float * transp, const int numtransp,
-                              const SbColor & ambient,
-                              const SbColor & emissive,
-                              const SbColor & specular,
-                              const float shininess,
-                              const SbBool istransparent) override;
+  void setMaterialElt(SoNode * node, uint32_t bitmask,
+                      SoColorPacker * packer,
+                      const SbColor * diffuse, const int numdiffuse,
+                      const float * transp, const int numtransp,
+                      const SbColor & ambient,
+                      const SbColor & emissive,
+                      const SbColor & specular,
+                      const float shininess,
+                      const SbBool istransparent) override;
   void setVertexOrderingElt(VertexOrdering ordering) override;
   void setBackfaceCullingElt(SbBool onoff) override;
   void setTwosideLightingElt(SbBool onoff) override;

--- a/include/Inventor/elements/SoGLLightIdElement.h
+++ b/include/Inventor/elements/SoGLLightIdElement.h
@@ -48,8 +48,7 @@ public:
   void init(SoState * state) override;
 
   void push(SoState * state) override;
-  virtual void pop(SoState * state,
-                   const SoElement * prevTopElement) override;
+  void pop(SoState * state, const SoElement * prevTopElement) override;
 
   static int32_t increment(SoState * const state, SoNode * const node);
   static int32_t increment(SoState * const state);

--- a/include/Inventor/elements/SoGLLinePatternElement.h
+++ b/include/Inventor/elements/SoGLLinePatternElement.h
@@ -48,8 +48,7 @@ public:
   void init(SoState * state) override;
 
   void push(SoState * state) override;
-  virtual void pop(SoState * state,
-                   const SoElement * prevTopElement) override;
+  void pop(SoState * state, const SoElement * prevTopElement) override;
 
 protected:
   void setElt(int32_t pattern) override;

--- a/include/Inventor/elements/SoGLLineWidthElement.h
+++ b/include/Inventor/elements/SoGLLineWidthElement.h
@@ -48,8 +48,7 @@ public:
   void init(SoState * state) override;
 
   void push(SoState * state) override;
-  virtual void pop(SoState * state,
-                   const SoElement * prevTopElement) override;
+  void pop(SoState * state, const SoElement * prevTopElement) override;
 
 protected:
   void setElt(float width) override;

--- a/include/Inventor/elements/SoGLModelMatrixElement.h
+++ b/include/Inventor/elements/SoGLModelMatrixElement.h
@@ -48,8 +48,7 @@ public:
   void init(SoState * state) override;
 
   void push(SoState * state) override;
-  virtual void pop(SoState * state,
-                   const SoElement * prevTopElement) override;
+  void pop(SoState * state, const SoElement * prevTopElement) override;
 
 protected:
   void makeEltIdentity() override;

--- a/include/Inventor/elements/SoGLMultiTextureCoordinateElement.h
+++ b/include/Inventor/elements/SoGLMultiTextureCoordinateElement.h
@@ -50,15 +50,14 @@ protected:
 public:
   void init(SoState * state) override;
   void push(SoState * state) override;
-  virtual void pop(SoState * state,
-                   const SoElement * prevTopElement) override;
+  void pop(SoState * state, const SoElement * prevTopElement) override;
 
-  static  void setTexGen(SoState * const state, SoNode * const node,
-                         const int unit,
-                         SoTexCoordTexgenCB * const texgenFunc,
-                         void * const texgenData = NULL,
-                         SoTextureCoordinateFunctionCB * const func = NULL,
-                         void * const funcData = NULL);
+  static void setTexGen(SoState * const state, SoNode * const node,
+                        const int unit,
+                        SoTexCoordTexgenCB * const texgenFunc,
+                        void * const texgenData = NULL,
+                        SoTextureCoordinateFunctionCB * const func = NULL,
+                        void * const funcData = NULL);
 
   CoordType getType(const int unit = 0) const override;
 

--- a/include/Inventor/elements/SoGLMultiTextureEnabledElement.h
+++ b/include/Inventor/elements/SoGLMultiTextureEnabledElement.h
@@ -50,8 +50,7 @@ public:
   void init(SoState * state) override;
 
   void push(SoState * state) override;
-  virtual void pop(SoState * state,
-                   const SoElement * prevTopElement) override;
+  void pop(SoState * state, const SoElement * prevTopElement) override;
   void setElt(const int unit, const int mode) override;
 
 private:

--- a/include/Inventor/elements/SoGLMultiTextureImageElement.h
+++ b/include/Inventor/elements/SoGLMultiTextureImageElement.h
@@ -52,8 +52,7 @@ protected:
 public:
   void init(SoState * state) override;
   void push(SoState * state) override;
-  virtual void pop(SoState * state,
-                   const SoElement * prevTopElement) override;
+  void pop(SoState * state, const SoElement * prevTopElement) override;
 
   static void set(SoState * const state, SoNode * const node,
                   const int unit,

--- a/include/Inventor/elements/SoGLMultiTextureMatrixElement.h
+++ b/include/Inventor/elements/SoGLMultiTextureMatrixElement.h
@@ -49,8 +49,7 @@ protected:
 public:
   void init(SoState * state) override;
   void push(SoState * state) override;
-  virtual void pop(SoState * state,
-                   const SoElement * prevTopElement) override;
+  void pop(SoState * state, const SoElement * prevTopElement) override;
 
   void multElt(const int unit, const SbMatrix & matrix) override;
   void setElt(const int unit, const SbMatrix & matrix) override;

--- a/include/Inventor/elements/SoGLProjectionMatrixElement.h
+++ b/include/Inventor/elements/SoGLProjectionMatrixElement.h
@@ -45,8 +45,7 @@ protected:
   virtual ~SoGLProjectionMatrixElement();
 
 public:
-  virtual void pop(SoState * state,
-                   const SoElement * prevTopElement) override;
+  void pop(SoState * state, const SoElement * prevTopElement) override;
 
 protected:
   void setElt(const SbMatrix & matrix) override;

--- a/include/Inventor/elements/SoGLShapeHintsElement.h
+++ b/include/Inventor/elements/SoGLShapeHintsElement.h
@@ -48,8 +48,7 @@ public:
   void init(SoState * state) override;
 
   void push(SoState * state) override;
-  virtual void pop(SoState * state,
-                   const SoElement * prevTopElement) override;
+  void pop(SoState * state, const SoElement * prevTopElement) override;
 
   static void forceSend(SoState * const state, const SbBool twoside);
   static void forceSend(SoState * const state,
@@ -58,8 +57,8 @@ public:
                         const SbBool cull, const SbBool twoside);
 
 protected:
-  virtual void setElt(VertexOrdering vertexOrdering,
-                      ShapeType shapeType, FaceType faceType) override;
+  void setElt(VertexOrdering vertexOrdering,
+              ShapeType shapeType, FaceType faceType) override;
 private:
   SoState * state;
 };

--- a/include/Inventor/elements/SoGLUpdateAreaElement.h
+++ b/include/Inventor/elements/SoGLUpdateAreaElement.h
@@ -49,8 +49,7 @@ protected:
 public:
   void init(SoState * state) override;
   void push(SoState * state) override;
-  virtual void pop(SoState * state,
-                   const SoElement * prevTopElement) override;
+  void pop(SoState * state, const SoElement * prevTopElement) override;
 
   SbBool matches(const SoElement * element) const override;
   SoElement * copyMatchInfo() const override;

--- a/include/Inventor/elements/SoGLViewingMatrixElement.h
+++ b/include/Inventor/elements/SoGLViewingMatrixElement.h
@@ -46,10 +46,8 @@ protected:
 
 public:
   void init(SoState * state) override;
-
   void push(SoState * state) override;
-  virtual void pop(SoState * state,
-                   const SoElement * prevTopElement) override;
+  void pop(SoState * state, const SoElement * prevTopElement) override;
 
   static SbUniqueId getNodeId(SoState * const state);
   static SbMatrix getResetMatrix(SoState * state);

--- a/include/Inventor/elements/SoGLViewportRegionElement.h
+++ b/include/Inventor/elements/SoGLViewportRegionElement.h
@@ -47,8 +47,7 @@ protected:
 public:
   void init(SoState * state) override;
   void push(SoState * state) override;
-  virtual void pop(SoState * state,
-                   const SoElement * prevTopElement) override;
+  void pop(SoState * state, const SoElement * prevTopElement) override;
 
 protected:
   void setElt(const SbViewportRegion & viewportRegion) override;

--- a/include/Inventor/nodekits/SoBaseKit.h
+++ b/include/Inventor/nodekits/SoBaseKit.h
@@ -115,8 +115,8 @@ protected:
   static const SoNodekitCatalog ** getClassNodekitCatalogPtr(void);
 
   SoNode * addToCopyDict(void) const override;
-  virtual void copyContents(const SoFieldContainer * fromfc,
-                            SbBool copyconnections) override;
+  void copyContents(const SoFieldContainer * fromfc,
+                    SbBool copyconnections) override;
 
   SoGroup * getContainerNode(const SbName & listname,
                              SbBool makeifneeded = TRUE);

--- a/include/Inventor/nodekits/SoInteractionKit.h
+++ b/include/Inventor/nodekits/SoInteractionKit.h
@@ -86,8 +86,8 @@ public:
 
 protected:
   virtual ~SoInteractionKit();
-  virtual void copyContents(const SoFieldContainer *fromFC,
-                            SbBool copyConnections) override;
+  void copyContents(const SoFieldContainer *fromFC,
+                    SbBool copyConnections) override;
 
   SbBool setPart(const int partNum, SoNode *node) override;
   SbBool readInstance(SoInput *in, unsigned short flags) override;

--- a/include/Inventor/nodekits/SoNodeKitListPart.h
+++ b/include/Inventor/nodekits/SoNodeKitListPart.h
@@ -82,12 +82,12 @@ public:
   SoChildList * getChildren(void) const override;
 
 protected:
-  ~SoNodeKitListPart() override;
+  virtual ~SoNodeKitListPart();
 
   SoGroup * getContainerNode(void);
   SbBool readInstance(SoInput * in, unsigned short flags) override;
   void copyContents(const SoFieldContainer * fromFC,
-                            SbBool copyConnections) override;
+                    SbBool copyConnections) override;
   SoChildList * children;
 
 private:

--- a/include/Inventor/nodes/SoFile.h
+++ b/include/Inventor/nodes/SoFile.h
@@ -64,8 +64,8 @@ public:
 
   SoGroup * copyChildren(void) const;
   SoChildList * getChildren(void) const override;
-  virtual void copyContents(const SoFieldContainer * from,
-                            SbBool copyconnections) override;
+  void copyContents(const SoFieldContainer * from,
+                    SbBool copyconnections) override;
 
   const SbString & getFullName(void) const;
 

--- a/include/Inventor/nodes/SoGroup.h
+++ b/include/Inventor/nodes/SoGroup.h
@@ -79,15 +79,15 @@ protected:
   SbBool readInstance(SoInput * in, unsigned short flags) override;
   virtual SbBool readChildren(SoInput * in);
 
-  virtual void copyContents(const SoFieldContainer * from,
-			    SbBool copyconnections) override;
+  void copyContents(const SoFieldContainer * from,
+                    SbBool copyconnections) override;
 
   SoNotRec createNotRec(void) override;
 
   void setOperation(const SoNotRec::OperationType opType = SoNotRec::UNSPECIFIED,
-		    const SoNode * cc = NULL,
-		    const SoNode * pc = NULL,
-		    const int ci = -1);
+                    const SoNode * cc = NULL,
+                    const SoNode * pc = NULL,
+                    const int ci = -1);
 
   SoChildList * children;
 

--- a/include/Inventor/nodes/SoIndexedFaceSet.h
+++ b/include/Inventor/nodes/SoIndexedFaceSet.h
@@ -54,10 +54,10 @@ public:
   void GLRender(SoGLRenderAction * action) override;
   void getPrimitiveCount(SoGetPrimitiveCountAction * action) override;
 
-  virtual SbBool generateDefaultNormals(SoState * state,
-                                        SoNormalBundle * bundle) override;
-  virtual SbBool generateDefaultNormals(SoState * state,
-                                        SoNormalCache * cache) override;
+  SbBool generateDefaultNormals(SoState * state,
+                                SoNormalBundle * bundle) override;
+  SbBool generateDefaultNormals(SoState * state,
+                                SoNormalCache * cache) override;
 
 protected:
   virtual ~SoIndexedFaceSet();

--- a/include/Inventor/nodes/SoIndexedNurbsCurve.h
+++ b/include/Inventor/nodes/SoIndexedNurbsCurve.h
@@ -65,10 +65,10 @@ protected:
 
   void generatePrimitives(SoAction * action) override;
   void computeBBox(SoAction * action, SbBox3f & box, SbVec3f & center) override;
-  virtual SoDetail * createLineSegmentDetail(SoRayPickAction * action,
-                                             const SoPrimitiveVertex * v1,
-                                             const SoPrimitiveVertex * v2,
-                                             SoPickedPoint * pp) override;
+  SoDetail * createLineSegmentDetail(SoRayPickAction * action,
+                                     const SoPrimitiveVertex * v1,
+                                     const SoPrimitiveVertex * v2,
+                                     SoPickedPoint * pp) override;
 private:
   class SoIndexedNurbsCurveP * pimpl;
   friend class SoIndexedNurbsCurveP;

--- a/include/Inventor/nodes/SoIndexedPointSet.h
+++ b/include/Inventor/nodes/SoIndexedPointSet.h
@@ -60,8 +60,8 @@ protected:
   void generatePrimitives(SoAction * action) override;
 
   SbBool generateDefaultNormals(SoState *, SoNormalCache * nc) override;
-  virtual SbBool generateDefaultNormals(SoState * state,
-                                        SoNormalBundle * bundle) override;
+  SbBool generateDefaultNormals(SoState * state,
+                                SoNormalBundle * bundle) override;
   SoVertexArrayIndexer * vaindexer;
 
   enum Binding {

--- a/include/Inventor/nodes/SoLineSet.h
+++ b/include/Inventor/nodes/SoLineSet.h
@@ -61,8 +61,8 @@ protected:
 
 private:
   SbBool generateDefaultNormals(SoState *, SoNormalCache * nc) override;
-  virtual SbBool generateDefaultNormals(SoState * state,
-                                        SoNormalBundle * bundle) override;
+  SbBool generateDefaultNormals(SoState * state,
+                                SoNormalBundle * bundle) override;
 
   enum Binding {
     OVERALL = 0,

--- a/include/Inventor/nodes/SoLinearProfile.h
+++ b/include/Inventor/nodes/SoLinearProfile.h
@@ -45,11 +45,11 @@ public:
   static void initClass(void);
   SoLinearProfile(void);
 
-  virtual void getTrimCurve(SoState * state, int32_t & numpoints,
-                            float *& points, int & floatspervec,
-                            int32_t & numknots, float *& knotvector) override;
-  virtual void getVertices(SoState * state, int32_t & numvertices,
-                           SbVec2f *& vertices) override;
+  void getTrimCurve(SoState * state, int32_t & numpoints,
+                    float *& points, int & floatspervec,
+                    int32_t & numknots, float *& knotvector) override;
+  void getVertices(SoState * state, int32_t & numvertices,
+                   SbVec2f *& vertices) override;
 
 protected:
   virtual ~SoLinearProfile();

--- a/include/Inventor/nodes/SoNode.h
+++ b/include/Inventor/nodes/SoNode.h
@@ -121,10 +121,9 @@ public:
 
   void writeInstance(SoOutput * out) override;
   virtual SoNode * addToCopyDict(void) const;
-  virtual void copyContents(const SoFieldContainer * from,
-                            SbBool copyconnections) override;
+  void copyContents(const SoFieldContainer * from,
+                    SbBool copyconnections) override;
   SoFieldContainer * copyThroughConnection(void) const override;
-
 
   static SoType getClassTypeId(void);
   static SoNode * getByName(const SbName & name);

--- a/include/Inventor/nodes/SoNurbsCurve.h
+++ b/include/Inventor/nodes/SoNurbsCurve.h
@@ -63,10 +63,10 @@ protected:
 
   void generatePrimitives(SoAction * action) override;
   void computeBBox(SoAction * action, SbBox3f & box, SbVec3f & center) override;
-  virtual SoDetail * createLineSegmentDetail(SoRayPickAction * action,
-                                             const SoPrimitiveVertex * v1,
-                                             const SoPrimitiveVertex * v2,
-                                             SoPickedPoint * pp) override;
+  SoDetail * createLineSegmentDetail(SoRayPickAction * action,
+                                     const SoPrimitiveVertex * v1,
+                                     const SoPrimitiveVertex * v2,
+                                     SoPickedPoint * pp) override;
 private:
   class SoNurbsCurveP * pimpl;
   friend class SoNurbsCurveP;

--- a/include/Inventor/nodes/SoNurbsProfile.h
+++ b/include/Inventor/nodes/SoNurbsProfile.h
@@ -49,11 +49,11 @@ public:
 
   SoMFFloat knotVector;
 
-  virtual void getTrimCurve(SoState * state, int32_t & numpoints,
-                            float *& points, int & floatspervec,
-                            int32_t & numknots, float *& knotvector) override;
-  virtual void getVertices(SoState * state, int32_t & numvertices,
-                           SbVec2f *& vertices) override;
+  void getTrimCurve(SoState * state, int32_t & numpoints,
+                    float *& points, int & floatspervec,
+                    int32_t & numknots, float *& knotvector) override;
+  void getVertices(SoState * state, int32_t & numvertices,
+                   SbVec2f *& vertices) override;
 
 protected:
   virtual ~SoNurbsProfile();

--- a/include/Inventor/nodes/SoPointSet.h
+++ b/include/Inventor/nodes/SoPointSet.h
@@ -59,8 +59,8 @@ protected:
   void computeBBox(SoAction * action, SbBox3f & box, SbVec3f & center) override;
 
   SbBool generateDefaultNormals(SoState *, SoNormalCache * nc) override;
-  virtual SbBool generateDefaultNormals(SoState * state,
-                                        SoNormalBundle * bundle) override;
+  SbBool generateDefaultNormals(SoState * state,
+                                SoNormalBundle * bundle) override;
 
 private:
   enum Binding {

--- a/include/Inventor/nodes/SoVertexAttribute.h
+++ b/include/Inventor/nodes/SoVertexAttribute.h
@@ -62,8 +62,8 @@ public:
   void doAction(SoAction * action) override;
   void GLRender(SoGLRenderAction * action) override;
   void write(SoWriteAction * action) override;
-  virtual void copyContents(const SoFieldContainer * from, 
-                            SbBool copyconnections) override;
+  void copyContents(const SoFieldContainer * from, 
+                    SbBool copyconnections) override;
   void notify(SoNotList * l) override;
 
 protected:

--- a/include/Inventor/nodes/SoWWWInline.h
+++ b/include/Inventor/nodes/SoWWWInline.h
@@ -117,8 +117,8 @@ protected:
 
   virtual void addBoundingBoxChild(SbVec3f center, SbVec3f size);
   SbBool readInstance(SoInput * in, unsigned short flags) override;
-  virtual void copyContents(const SoFieldContainer * fromfC,
-                            SbBool copyconnections) override;
+  void copyContents(const SoFieldContainer * fromfC,
+                    SbBool copyconnections) override;
 
 private:
   friend class SoWWWInlineP;

--- a/include/Inventor/projectors/SbCylinderPlaneProjector.h
+++ b/include/Inventor/projectors/SbCylinderPlaneProjector.h
@@ -47,8 +47,8 @@ public:
 
   SbProjector * copy(void) const override;
   SbVec3f project(const SbVec2f & point) override;
-  virtual SbRotation getRotation(const SbVec3f & point1,
-                                 const SbVec3f & point2) override;
+  SbRotation getRotation(const SbVec3f & point1,
+                         const SbVec3f & point2) override;
 
 protected:
   SbRotation getRotation(const SbVec3f & point1, const SbBool tol1,

--- a/include/Inventor/projectors/SbCylinderSectionProjector.h
+++ b/include/Inventor/projectors/SbCylinderSectionProjector.h
@@ -49,8 +49,8 @@ public:
 
   SbProjector * copy(void) const override;
   SbVec3f project(const SbVec2f & point) override;
-  virtual SbRotation getRotation(const SbVec3f & point1,
-                                 const SbVec3f & point2) override;
+  SbRotation getRotation(const SbVec3f & point1,
+                         const SbVec3f & point2) override;
   void setTolerance(const float edgetol);
   float getTolerance(void) const;
   SbBool isWithinTolerance(const SbVec3f & point);

--- a/include/Inventor/projectors/SbSpherePlaneProjector.h
+++ b/include/Inventor/projectors/SbSpherePlaneProjector.h
@@ -47,8 +47,8 @@ public:
 
   SbProjector * copy(void) const override;
   SbVec3f project(const SbVec2f & point) override;
-  virtual SbRotation getRotation(const SbVec3f & point1,
-                                 const SbVec3f & point2) override;
+  SbRotation getRotation(const SbVec3f & point1,
+                         const SbVec3f & point2) override;
 
 protected:
   SbRotation getRotation(const SbVec3f & point1, const SbBool tol1,

--- a/include/Inventor/projectors/SbSphereSectionProjector.h
+++ b/include/Inventor/projectors/SbSphereSectionProjector.h
@@ -48,8 +48,8 @@ public:
 
   SbProjector * copy(void) const override;
   SbVec3f project(const SbVec2f & point) override;
-  virtual SbRotation getRotation(const SbVec3f & point1,
-                                 const SbVec3f & point2) override;
+  SbRotation getRotation(const SbVec3f & point1,
+                         const SbVec3f & point2) override;
   void setTolerance(const float edgetol);
   float getTolerance(void) const;
   void setRadialFactor(const float rad = 0.0f);

--- a/include/Inventor/scxml/ScXMLAbstractStateElt.h
+++ b/include/Inventor/scxml/ScXMLAbstractStateElt.h
@@ -46,7 +46,7 @@ public:
   static void cleanClass(void);
 
   ScXMLAbstractStateElt(void);
-  ~ScXMLAbstractStateElt(void) override;
+  virtual ~ScXMLAbstractStateElt(void);
 
   // XML attributes
   virtual void setIdAttribute(const char * id);

--- a/include/Inventor/scxml/ScXMLExecutableElt.h
+++ b/include/Inventor/scxml/ScXMLExecutableElt.h
@@ -48,7 +48,7 @@ public:
   static void cleanClass(void);
 
   ScXMLExecutableElt(void);
-  ~ScXMLExecutableElt(void) override;
+  virtual ~ScXMLExecutableElt(void);
 
   void copyContents(const ScXMLElt * rhs) override;
 


### PR DESCRIPTION
The PR #640 created some functions that had duplicate keywords virtual and override on function signatures and override keywords on destructors. This PR fixes that.