### PR TITLE
Fix lifetime of cached OpenGL strings

### DIFF
--- a/src/glue/gl.cpp
+++ b/src/glue/gl.cpp
@@ -634,10 +634,25 @@ returnpoint:
    actual cc_glglue instances. */
 static cc_dict * gldict = NULL;
 
+static char *
+glglue_strdup(const char * string)
+{
+  if (!string) return NULL;
+  const size_t length = strlen(string) + 1;
+  char * copy = (char *)malloc(length);
+  assert(copy && "could not copy OpenGL string");
+  if (copy) memcpy(copy, string, length);
+  return copy;
+}
+
 static void
 free_glglue_instance(uintptr_t COIN_UNUSED_ARG(key), void * value, void * COIN_UNUSED_ARG(closure))
 {
   cc_glglue * glue = (cc_glglue*) value;
+  free(glue->versionstr);
+  free(glue->vendorstr);
+  free(glue->rendererstr);
+  free(glue->extensionsstr);
   cc_dict_destruct(glue->glextdict);
   free(value);
 }
@@ -2356,9 +2371,10 @@ cc_glglue_instance(int contextid)
     /* NB: if you are getting a crash here, it's because an attempt at
      * setting up a cc_glglue instance was made when there is no
      * current OpenGL context. */
-    gi->versionstr = (const char *)glGetString(GL_VERSION);
-    assert(gi->versionstr && "could not call glGetString() -- no current GL context?");
+    const char * versionstr = (const char *)glGetString(GL_VERSION);
+    assert(versionstr && "could not call glGetString() -- no current GL context?");
     assert(glGetError() == GL_NO_ERROR && "GL error when calling glGetString() -- no current GL context?");
+    gi->versionstr = glglue_strdup(versionstr);
 
     glglue_set_glVersion(gi);
 
@@ -2377,7 +2393,7 @@ cc_glglue_instance(int contextid)
     }
 #endif
 
-    gi->vendorstr = (const char *)glGetString(GL_VENDOR);
+    gi->vendorstr = glglue_strdup((const char *)glGetString(GL_VENDOR));
     gi->vendor_is_SGI = strcmp((const char *)gi->vendorstr, "SGI") == 0;
     gi->vendor_is_nvidia = strcmp((const char*)gi->vendorstr, "NVIDIA Corporation") == 0;
     gi->vendor_is_intel =
@@ -2393,8 +2409,8 @@ cc_glglue_instance(int contextid)
       if (env) gi->nvidia_color_per_face_bug = 0;
     }
 
-    gi->rendererstr = (const char *)glGetString(GL_RENDERER);
-    gi->extensionsstr = (const char *)glGetString(GL_EXTENSIONS);
+    gi->rendererstr = glglue_strdup((const char *)glGetString(GL_RENDERER));
+    gi->extensionsstr = glglue_strdup((const char *)glGetString(GL_EXTENSIONS));
 
     /* Randall O'Reilly reports that the above call is deprecated from OpenGL 3.0
        onwards and may, particularly on some Linux systems, return NULL.

--- a/src/glue/glp.h
+++ b/src/glue/glp.h
@@ -834,16 +834,16 @@ struct cc_glglue {
   /* glGetStringi - part of replacement for obsolete glGetString(GL_EXTENSIONS) in OpenGL 3.0 */
   COIN_PFNGLGETSTRINGIPROC glGetStringi;
 
-  const char * versionstr;
-  const char * vendorstr;
+  char * versionstr;
+  char * vendorstr;
   SbBool vendor_is_SGI;
   SbBool vendor_is_nvidia;
   SbBool vendor_is_intel;
   SbBool vendor_is_ati;
   SbBool vendor_is_3dlabs;
   SbBool nvidia_color_per_face_bug;
-  const char * rendererstr;
-  const char * extensionsstr;
+  char * rendererstr;
+  char * extensionsstr;
   int maxtextureunits;
   struct cc_glxglue glx;
   float max_anisotropy;


### PR DESCRIPTION
`cc_glglue` caches the pointers returned by `glGetString()` for the OpenGL version, vendor, renderer, and extensions.

Those strings are owned by the active OpenGL context. Their pointers may become invalid after that context is destroyed, even when another context in the same share group continues using the existing Coin cache-context ID.

Dereferencing one of these stale pointers can cause a segmentation fault. The observed failure occurred in `SoGLDisplayList` while comparing the cached version string.

## Fix

Copy all four `glGetString()` values into storage owned by `cc_glglue`:

- version
- vendor
- renderer
- extensions

The copies are released during normal GL glue cleanup.

This preserves the existing cache-context behavior while ensuring the cached strings remain valid for the lifetime of the glue instance.

Fixes https://github.com/FreeCAD/FreeCAD/issues/31774