### PR TITLE
Remove duplicate declaration of cc_glglue_has_framebuffer_objects

### DIFF
--- a/include/Inventor/C/glue/gl.h
+++ b/include/Inventor/C/glue/gl.h
@@ -576,7 +576,6 @@ COIN_DLL_API void cc_glglue_glFramebufferTexture3D(const cc_glglue * glue, GLenu
 COIN_DLL_API void cc_glglue_glFramebufferRenderbuffer(const cc_glglue * glue, GLenum target, GLenum attachment, GLenum renderbuffertarget, GLuint renderbuffer);
 COIN_DLL_API void cc_glglue_glGetFramebufferAttachmentParameteriv(const cc_glglue * glue, GLenum target, GLenum attachment, GLenum pname, GLint *params);
 COIN_DLL_API void cc_glglue_glGenerateMipmap(const cc_glglue * glue, GLenum target);
-COIN_DLL_API SbBool cc_glglue_has_framebuffer_objects(const cc_glglue * glue);
 
 
 /* GL feature queries */


### PR DESCRIPTION
## Summary
`cc_glglue_has_framebuffer_objects` is declared twice in `include/Inventor/C/glue/gl.h`: once at the end of the FBO function block, and again under the "GL feature queries" section a few lines later.

Git archaeology (`3546c07388`, "Support for framebuffer objects.") shows both declarations were introduced together in the same 2007 commit — a copy-paste duplicate from day one, not something that drifted apart later. This PR keeps the declaration grouped with its `can_do_X`/`has_X` capability-query siblings (where it thematically belongs) and drops the stray earlier copy.

Found while auditing `-Wredundant-decls`: 149 raw GCC warnings reduce to 11 unique sites, 10 of which are third-party (`expat`) or bison/flex-generated evaluator code. This was the only real one in Coin's own source.

---
**Verified:** Full clean rebuild under GCC and clang (Linux) with `-Wall -Wextra -Wpedantic`, confirming the warning is gone and no new ones appear. `ctest` (1/1 pass). Debug build under AddressSanitizer/UndefinedBehaviorSanitizer, full `CoinTests` suite, no findings.

Also verified on Windows (MSVC / Visual Studio 17 2022, x64 Release, /W4): built and tested together with all sibling branches from this audit (merged into a local integration build), 0 errors, full `CoinTests` suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FHRXMxksBcEGfbN5bDVJzb

