### PR TITLE
Fix -Wdeprecated-copy warnings by defaulting missing copy special members

### DIFF
--- a/include/Inventor/SbDPMatrix.h
+++ b/include/Inventor/SbDPMatrix.h
@@ -54,6 +54,7 @@ public:
   SbDPMatrix(const SbDPMat & matrix);
   SbDPMatrix(const SbDPMat * matrix);
   SbDPMatrix(const SbMatrix & matrix);
+  SbDPMatrix(const SbDPMatrix & matrix) = default;
   ~SbDPMatrix(void);
 
   void setValue(const SbDPMat & m);

--- a/include/Inventor/SbMatrix.h
+++ b/include/Inventor/SbMatrix.h
@@ -54,6 +54,7 @@ public:
   SbMatrix(const SbMat & matrix);
   SbMatrix(const SbMat * matrix);
   explicit SbMatrix(const SbDPMatrix & matrix);
+  SbMatrix(const SbMatrix & matrix) = default;
   ~SbMatrix(void);
 
   void setValue(const SbMat & m);

--- a/include/Inventor/SbName.h
+++ b/include/Inventor/SbName.h
@@ -43,6 +43,7 @@ public:
   SbName(const char * namestring);
   SbName(const SbString & str);
   SbName(const SbName & name);
+  SbName & operator=(const SbName & name) = default;
   ~SbName();
 
   const char * getString(void) const;

--- a/include/Inventor/SbViewportRegion.h
+++ b/include/Inventor/SbViewportRegion.h
@@ -43,6 +43,7 @@ public:
   SbViewportRegion(short width, short height);
   SbViewportRegion(SbVec2s winSize);
   SbViewportRegion(const SbViewportRegion & vpReg);
+  SbViewportRegion & operator=(const SbViewportRegion & vpReg) = default;
 
   void setWindowSize(short width, short height);
   void setWindowSize(SbVec2s winSize);

--- a/include/Inventor/elements/SoGLMultiTextureCoordinateElement.h
+++ b/include/Inventor/elements/SoGLMultiTextureCoordinateElement.h
@@ -70,6 +70,7 @@ public:
   public:
     GLUnitData() : texgenCB(NULL), texgenData(NULL) {}
     GLUnitData(const GLUnitData & org) : texgenCB(org.texgenCB), texgenData(org.texgenData) {}
+    GLUnitData & operator=(const GLUnitData & org) = default;
     SoTexCoordTexgenCB * texgenCB;
     void * texgenData;
   };

--- a/include/Inventor/elements/SoGLMultiTextureImageElement.h
+++ b/include/Inventor/elements/SoGLMultiTextureImageElement.h
@@ -70,6 +70,7 @@ public:
   public:
   GLUnitData() : glimage(NULL) {}
   GLUnitData(const GLUnitData & org) : glimage(org.glimage) {}
+  GLUnitData & operator=(const GLUnitData & org) = default;
     SoGLImage * glimage;
   };
   

--- a/include/Inventor/elements/SoMultiTextureCoordinateElement.h
+++ b/include/Inventor/elements/SoMultiTextureCoordinateElement.h
@@ -107,6 +107,7 @@ public:
   public:
     UnitData();
     UnitData(const UnitData & org);
+    UnitData & operator=(const UnitData & org) = default;
 
     SbUniqueId nodeid;
     CoordType whatKind;

--- a/include/Inventor/elements/SoMultiTextureImageElement.h
+++ b/include/Inventor/elements/SoMultiTextureImageElement.h
@@ -156,6 +156,7 @@ public:
   public:
     UnitData();
     UnitData(const UnitData & org);
+    UnitData & operator=(const UnitData & org) = default;
     SbUniqueId nodeid;
     SbVec3s size;
     int numComponents;

--- a/include/Inventor/elements/SoMultiTextureMatrixElement.h
+++ b/include/Inventor/elements/SoMultiTextureMatrixElement.h
@@ -62,6 +62,7 @@ public:
   public:
     UnitData() : textureMatrix(SbMatrix::identity()) {}
     UnitData(const UnitData & org) : textureMatrix(org.textureMatrix) {}
+    UnitData & operator=(const UnitData & org) = default;
     SbMatrix textureMatrix;
   };
 

--- a/include/Inventor/elements/SoTextureCombineElement.h
+++ b/include/Inventor/elements/SoTextureCombineElement.h
@@ -126,6 +126,7 @@ public:
   public:
     UnitData();
     UnitData(const UnitData & org);
+    UnitData & operator=(const UnitData & org) = default;
 
     SbUniqueId nodeid;
     Source rgbsource[3];

--- a/include/Inventor/lists/SoFieldList.h
+++ b/include/Inventor/lists/SoFieldList.h
@@ -42,7 +42,8 @@ public:
   SoFieldList(void) : SbPList() { }
   SoFieldList(const int sizehint) : SbPList(sizehint) { }
   SoFieldList(const SoFieldList & l) : SbPList(l) { }
-  
+  SoFieldList & operator=(const SoFieldList & l) = default;
+
   void append(SoField * field) { 
     SbPList::append(static_cast<void *>(field));
   }

--- a/include/Inventor/lists/SoTypeList.h
+++ b/include/Inventor/lists/SoTypeList.h
@@ -41,6 +41,7 @@ public:
   SoTypeList(void) : SbPList() { }
   SoTypeList(const int sizehint) : SbPList(sizehint) { }
   SoTypeList(const SoTypeList & l) : SbPList(l) { }
+  SoTypeList & operator=(const SoTypeList & l) = default;
 
   void append(const SoType type);
   int find(const SoType type) const;

--- a/src/rendering/SoGLCubeMapImage.cpp
+++ b/src/rendering/SoGLCubeMapImage.cpp
@@ -115,6 +115,7 @@ public:
     dldata(const dldata & org)
       : dlist(org.dlist),
         age(org.age) { }
+    dldata & operator=(const dldata & org) = default;
     SoGLDisplayList * dlist;
     uint32_t age;
   };

--- a/src/rendering/SoGLImage.cpp
+++ b/src/rendering/SoGLImage.cpp
@@ -674,6 +674,7 @@ public:
     dldata(const dldata & org)
       : dlist(org.dlist),
         age(org.age) { }
+    dldata & operator=(const dldata & org) = default;
     SoGLDisplayList *dlist;
     uint32_t age;
   };


### PR DESCRIPTION
## Summary

Several classes declared only one of {copy constructor, copy assignment,
destructor} without the others, which makes GCC's implicitly-generated
counterpart deprecated under -Wdeprecated-copy: SbMatrix and SbDPMatrix
had a destructor and operator= but no copy constructor; SbName and
SbViewportRegion had a copy constructor but no operator=; and several
small value-type helper classes (SoGLImageP::dldata,
SoGLCubeMapImageP::dldata, the per-unit texture UnitData/GLUnitData
structs, SoFieldList, SoTypeList) were missing operator= alongside an
existing copy constructor.

In every case the missing member is added as `= default`, which
reproduces the exact memberwise-copy behavior the compiler was already
implicitly generating (verified against the existing hand-written copy
constructors, several of which use memcpy of a plain-data layout) with
no change to object layout or ABI. This removes roughly 370 of the
1126 warnings from a full -Wall -Wextra -Wpedantic build.

---
**Verified:** Full clean rebuild under GCC and clang (Linux) with the strict warning recipe (`-Wall -Wextra -Wpedantic` plus the specific flag(s) this fixes), `ctest` (1/1 pass), and a Debug build under AddressSanitizer/UndefinedBehaviorSanitizer running the full `CoinTests` suite with no new findings.

Also verified on Windows (MSVC / Visual Studio 17 2022, x64 Release, /W4): built and tested together with all sibling branches from this audit (merged into a local integration build), 0 errors, full `CoinTests` suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FHRXMxksBcEGfbN5bDVJzb
