### PR TITLE
Fix strict-alignment UB in SoInput/SoOutput convertShort/convertInt32

### DIFF
--- a/src/io/SoInput.cpp
+++ b/src/io/SoInput.cpp
@@ -2326,7 +2326,9 @@ SoInput::makeRoomInBuf(size_t /* nBytes */)
 void
 SoInput::convertShort(char * from, short * s)
 {
-  *s = (short) (coin_ntoh_uint16(*((uint16_t*)from)));
+  uint16_t tmp;
+  memcpy(&tmp, from, sizeof(tmp));
+  *s = (short) (coin_ntoh_uint16(tmp));
 }
 
 /*!
@@ -2337,7 +2339,9 @@ SoInput::convertShort(char * from, short * s)
 void
 SoInput::convertInt32(char * from, int32_t * l)
 {
-  *l = (int32_t) (coin_ntoh_uint32(*((uint32_t*)from)));
+  uint32_t tmp;
+  memcpy(&tmp, from, sizeof(tmp));
+  *l = (int32_t) (coin_ntoh_uint32(tmp));
 }
 
 /*!

--- a/src/io/SoOutput.cpp
+++ b/src/io/SoOutput.cpp
@@ -1579,7 +1579,8 @@ void
 SoOutput::convertShort(short s, char * to)
 {
   assert(sizeof(s) == sizeof(uint16_t));
-  *((uint16_t *)to) = coin_hton_uint16((uint16_t)s);
+  const uint16_t tmp = coin_hton_uint16((uint16_t)s);
+  memcpy(to, &tmp, sizeof(tmp));
 }
 
 /*!
@@ -1592,7 +1593,8 @@ void
 SoOutput::convertInt32(int32_t l, char * to)
 {
   assert(sizeof(l) == sizeof(uint32_t));
-  *((uint32_t *)to) = coin_hton_uint32(l);
+  const uint32_t tmp = coin_hton_uint32(l);
+  memcpy(to, &tmp, sizeof(tmp));
 }
 
 /*!


### PR DESCRIPTION
## Summary

SoInput::convertShort()/convertInt32() and SoOutput::convertShort()/
convertInt32() cast a char* buffer pointer directly to uint16_t*/
uint32_t* and dereferenced it, which is undefined behavior whenever
the buffer isn't naturally aligned for that type -- readily possible
for these, since they convert raw bytes read from (or about to be
written to) an arbitrary offset in a binary Inventor file. This is
harmless on x86 (which tolerates unaligned loads/stores at the ISA
level) but a real SIGBUS on strict-alignment architectures.

Their siblings convertFloat()/convertDouble() already use the correct,
established pattern for this exact problem: memcpy() the bytes into a
local variable before reinterpreting them (see
coin_ntoh_float_bytes()/coin_hton_float_bytes() in tidbits.cpp, which
convertFloat/convertDouble call into). convertShort/convertInt32 were
the only two functions using an aligned-pointer-cast shortcut instead,
apparently because coin_ntoh_uint16()/coin_ntoh_uint32() take an
already-loaded value rather than a pointer. Unchanged since the
original 1999 revision of SoOutput.cpp.

Fixed by memcpy'ing through a local uint16_t/uint32_t, matching the
convertFloat/convertDouble pattern.

Verified with a standalone smoke test calling both SoInput converters
on a deliberately 1-byte-offset (misaligned) buffer under
-fsanitize=undefined,alignment: the original code reproducibly hit
"runtime error: load of misaligned address ... requires 2/4 byte
alignment" at the exact flagged lines; the fix produces the correct
converted values with no sanitizer finding.

Found via a curated sweep of clang-specific strict warnings
(-Wcast-align, alongside several other flags whose hits turned out to
already be fixed by earlier branches in this audit: -Wuninitialized in
gl_egl.cpp, -Wsometimes-uninitialized in SoShaderParameter.cpp, and
-Wdynamic-class-memaccess in soshape_primdata.cpp).

---
**Verified:** Full clean rebuild under GCC and clang (Linux) with the strict warning recipe (`-Wall -Wextra -Wpedantic` plus the specific flag(s) this fixes), `ctest` (1/1 pass), and a Debug build under AddressSanitizer/UndefinedBehaviorSanitizer running the full `CoinTests` suite with no new findings.

Also verified on Windows (MSVC / Visual Studio 17 2022, x64 Release, /W4): built and tested together with all sibling branches from this audit (merged into a local integration build), 0 errors, full `CoinTests` suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FHRXMxksBcEGfbN5bDVJzb
