### PR TITLE
Fix -Wcast-function-type in GLU NURBS begin-callback registration

### DIFF
--- a/src/shapenodes/SoIndexedNurbsCurve.cpp
+++ b/src/shapenodes/SoIndexedNurbsCurve.cpp
@@ -345,7 +345,7 @@ SoIndexedNurbsCurveP::doNurbs(SoAction * action,
     this->nurbsrenderer = GLUWrapper()->gluNewNurbsRenderer();
 
     if (GLUWrapper()->versionMatchesAtLeast(1, 3, 0)) {
-      GLUWrapper()->gluNurbsCallback(this->nurbsrenderer, (GLenum) GLU_NURBS_BEGIN_DATA, (gluNurbsCallback_cb_t)SoNurbsP<SoIndexedNurbsCurve>::tessBegin);
+      GLUWrapper()->gluNurbsCallback(this->nurbsrenderer, (GLenum) GLU_NURBS_BEGIN_DATA, (gluNurbsCallback_cb_t)(void (*)(void))SoNurbsP<SoIndexedNurbsCurve>::tessBegin);
       GLUWrapper()->gluNurbsCallback(this->nurbsrenderer, (GLenum) GLU_NURBS_TEXTURE_COORD_DATA, (gluNurbsCallback_cb_t)SoNurbsP<SoIndexedNurbsCurve>::tessTexCoord);
       GLUWrapper()->gluNurbsCallback(this->nurbsrenderer, (GLenum) GLU_NURBS_NORMAL_DATA, (gluNurbsCallback_cb_t)SoNurbsP<SoIndexedNurbsCurve>::tessNormal);
       GLUWrapper()->gluNurbsCallback(this->nurbsrenderer, (GLenum) GLU_NURBS_VERTEX_DATA, (gluNurbsCallback_cb_t)SoNurbsP<SoIndexedNurbsCurve>::tessVertex);

--- a/src/shapenodes/SoIndexedNurbsSurface.cpp
+++ b/src/shapenodes/SoIndexedNurbsSurface.cpp
@@ -368,7 +368,7 @@ SoIndexedNurbsSurfaceP::doNurbs(SoAction * action, const SbBool glrender)
     this->nurbsrenderer = GLUWrapper()->gluNewNurbsRenderer();
 
     if (GLUWrapper()->versionMatchesAtLeast(1, 3, 0)) {
-      GLUWrapper()->gluNurbsCallback(this->nurbsrenderer, (GLenum) GLU_NURBS_BEGIN_DATA, (gluNurbsCallback_cb_t)SoNurbsP<SoIndexedNurbsSurface>::tessBegin);
+      GLUWrapper()->gluNurbsCallback(this->nurbsrenderer, (GLenum) GLU_NURBS_BEGIN_DATA, (gluNurbsCallback_cb_t)(void (*)(void))SoNurbsP<SoIndexedNurbsSurface>::tessBegin);
       GLUWrapper()->gluNurbsCallback(this->nurbsrenderer, (GLenum) GLU_NURBS_TEXTURE_COORD_DATA, (gluNurbsCallback_cb_t)SoNurbsP<SoIndexedNurbsSurface>::tessTexCoord);
       GLUWrapper()->gluNurbsCallback(this->nurbsrenderer, (GLenum) GLU_NURBS_NORMAL_DATA,  (gluNurbsCallback_cb_t)SoNurbsP<SoIndexedNurbsSurface>::tessNormal);
       GLUWrapper()->gluNurbsCallback(this->nurbsrenderer, (GLenum) GLU_NURBS_VERTEX_DATA,  (gluNurbsCallback_cb_t)SoNurbsP<SoIndexedNurbsSurface>::tessVertex);

--- a/src/shapenodes/SoNurbsCurve.cpp
+++ b/src/shapenodes/SoNurbsCurve.cpp
@@ -389,7 +389,7 @@ SoNurbsCurveP::doNurbs(SoAction * action,
     this->nurbsrenderer = GLUWrapper()->gluNewNurbsRenderer();
 
     if (GLUWrapper()->versionMatchesAtLeast(1, 3, 0)) {
-      GLUWrapper()->gluNurbsCallback(this->nurbsrenderer, (GLenum) GLU_NURBS_BEGIN_DATA, (gluNurbsCallback_cb_t)SoNurbsP<SoNurbsCurve>::tessBegin);
+      GLUWrapper()->gluNurbsCallback(this->nurbsrenderer, (GLenum) GLU_NURBS_BEGIN_DATA, (gluNurbsCallback_cb_t)(void (*)(void))SoNurbsP<SoNurbsCurve>::tessBegin);
       GLUWrapper()->gluNurbsCallback(this->nurbsrenderer, (GLenum) GLU_NURBS_TEXTURE_COORD_DATA, (gluNurbsCallback_cb_t)SoNurbsP<SoNurbsCurve>::tessTexCoord);
       GLUWrapper()->gluNurbsCallback(this->nurbsrenderer, (GLenum) GLU_NURBS_NORMAL_DATA, (gluNurbsCallback_cb_t)SoNurbsP<SoNurbsCurve>::tessNormal);
       GLUWrapper()->gluNurbsCallback(this->nurbsrenderer, (GLenum) GLU_NURBS_VERTEX_DATA, (gluNurbsCallback_cb_t)SoNurbsP<SoNurbsCurve>::tessVertex);

--- a/src/shapenodes/SoNurbsSurface.cpp
+++ b/src/shapenodes/SoNurbsSurface.cpp
@@ -406,7 +406,7 @@ SoNurbsSurfaceP::doNurbs(SoAction * action, const SbBool glrender)
     this->nurbsrenderer = GLUWrapper()->gluNewNurbsRenderer();
 
     if (GLUWrapper()->versionMatchesAtLeast(1, 3, 0)) {
-      GLUWrapper()->gluNurbsCallback(this->nurbsrenderer, (GLenum) GLU_NURBS_BEGIN_DATA, (gluNurbsCallback_cb_t)SoNurbsP<SoNurbsSurface>::tessBegin);
+      GLUWrapper()->gluNurbsCallback(this->nurbsrenderer, (GLenum) GLU_NURBS_BEGIN_DATA, (gluNurbsCallback_cb_t)(void (*)(void))SoNurbsP<SoNurbsSurface>::tessBegin);
       GLUWrapper()->gluNurbsCallback(this->nurbsrenderer, (GLenum) GLU_NURBS_TEXTURE_COORD_DATA, (gluNurbsCallback_cb_t)SoNurbsP<SoNurbsSurface>::tessTexCoord);
       GLUWrapper()->gluNurbsCallback(this->nurbsrenderer, (GLenum) GLU_NURBS_NORMAL_DATA,  (gluNurbsCallback_cb_t)SoNurbsP<SoNurbsSurface>::tessNormal);
       GLUWrapper()->gluNurbsCallback(this->nurbsrenderer, (GLenum) GLU_NURBS_VERTEX_DATA,  (gluNurbsCallback_cb_t)SoNurbsP<SoNurbsSurface>::tessVertex);


### PR DESCRIPTION
## Summary

One site per NURBS shape class (SoNurbsCurve, SoNurbsSurface,
SoIndexedNurbsCurve, SoIndexedNurbsSurface): the GLU_NURBS_BEGIN_DATA
callback is registered by casting SoNurbsP<T>::tessBegin, whose real
signature is void(int, void*), straight to gluNurbsCallback_cb_t
(void(*)(void*, ...)). This is the standard GLU idiom -- the API
groups every NURBS callback selector (begin/vertex/normal/texcoord/
end/error, each with its own real signature) under one generic
registration type, and GLU internally calls back through the correct
concrete signature for the selector actually passed to
gluNurbsCallback(). The other 4 registrations in each of these files
(tessTexCoord/tessNormal/tessVertex/tessEnd) go through the identical
generic-registration idiom but don't trigger this warning, since only
a scalar (int) in a pointer-shaped slot -- as in tessBegin -- crosses
GCC's -Wcast-function-type threshold; the float*/void* mismatches on
the others don't.

Fixed with the standard, GCC/Clang-recognized suppression idiom for
intentional callback-dispatch casts: an intermediate cast through
void(*)(void) before the final cast to gluNurbsCallback_cb_t. This is
purely a type-system reinterpretation with no codegen effect -- cast
through void(*)(void) or not, the resulting function pointer is the
exact same value (confirmed with a standalone comparison: identical
address either way) -- so this changes nothing about how GLU actually
invokes the callback.

Verified: full clean rebuild shows the exact same warning breakdown as
master except -Wcast-function-type 4->0 (859->855 total, zero errors);
full CoinTests suite passes (326 tests, 83566 checks) in both a normal
build and a Debug+ASan/UBSan build, with only the known pre-existing,
unrelated SbByteBufferP.icc UBSan finding present. As in the earlier
-Wunused-function pass over this same NURBS code, this sandbox's GLX/
EGL offscreen context creation doesn't work even for a trivial scene,
so the actual GLU tessellation callback invocation could not be
exercised at runtime here; the fix is a pure type-level reinterpret
with no behavioral effect on the call GLU makes, which is what the
above address-identity check demonstrates directly.

---
**Verified:** Full clean rebuild under GCC and clang (Linux) with the strict warning recipe (`-Wall -Wextra -Wpedantic` plus the specific flag(s) this fixes), `ctest` (1/1 pass), and a Debug build under AddressSanitizer/UndefinedBehaviorSanitizer running the full `CoinTests` suite with no new findings.

Also verified on Windows (MSVC / Visual Studio 17 2022, x64 Release, /W4): built and tested together with all sibling branches from this audit (merged into a local integration build), 0 errors, full `CoinTests` suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FHRXMxksBcEGfbN5bDVJzb
