### PR TITLE
Fix -Wcast-qual: dead casts against const-correct GL calls, fragile readRoute()

### DIFF
--- a/src/misc/SoBase.cpp
+++ b/src/misc/SoBase.cpp
@@ -1430,21 +1430,26 @@ SoBase::readRoute(SoInput * in)
   if (ok) {
     ok = FALSE;
 
-    // parse from-string
-    char * str1 = (char*) fromstring.getString();
-    char * str2 = str1 ? (char*) strchr(str1, '.') : NULL;
+    // Parse from-string. Extract the node-name substring via
+    // SbString's own substring constructor rather than writing a NUL
+    // terminator into fromstring's buffer through a const_cast: that
+    // relies on SbString/cc_string never sharing its buffer between
+    // instances, which happens to be true today but isn't part of
+    // getString()'s documented contract. The field-name half needs no
+    // truncation at all, since it runs to fromstring's own (untouched)
+    // terminating NUL.
+    const char * str1 = fromstring.getString();
+    const char * str2 = str1 ? strchr(str1, '.') : NULL;
     if (str1 && str2) {
-      *str2++ = 0;
+      fromnodename = SbString(str1, 0, static_cast<int>(str2 - str1) - 1).getString();
+      fromfieldname = str2 + 1;
 
       // now parse to-string
-      fromnodename = str1;
-      fromfieldname = str2;
-      str1 = (char*) tostring.getString();
+      str1 = tostring.getString();
       str2 = str1 ? strchr(str1, '.') : NULL;
       if (str1 && str2) {
-        *str2++ = 0;
-        tonodename = str1;
-        tofieldname = str2;
+        tonodename = SbString(str1, 0, static_cast<int>(str2 - str1) - 1).getString();
+        tofieldname = str2 + 1;
 
         ok = TRUE;
       }

--- a/src/rendering/SoVertexArrayIndexer.cpp
+++ b/src/rendering/SoVertexArrayIndexer.cpp
@@ -291,7 +291,7 @@ SoVertexArrayIndexer::render(SoState * state, const SbBool renderasvbo, const ui
     if (SoGLDriverDatabase::isSupported(glue, SO_GL_MULTIDRAW_ELEMENTS)) {
       cc_glglue_glMultiDrawElements(glue,
                                     this->target,
-                                    (GLsizei*) this->countarray.getArrayPtr(),
+                                    this->countarray.getArrayPtr(),
                                     GL_UNSIGNED_INT,
                                     (const GLvoid**) this->ciarray.getArrayPtr(),
                                     this->countarray.getLength());

--- a/src/shapenodes/soshape_bumprender.cpp
+++ b/src/shapenodes/soshape_bumprender.cpp
@@ -510,23 +510,23 @@ soshape_bumprender::renderBumpSpecular(SoState * state,
   const SbVec3f * tptr = this->tangentlist.getArrayPtr();
   
   cc_glglue_glVertexPointer(glue, 3, GL_FLOAT, 0,
-                            (GLvoid*) cache->getVertexArray());
+                            cache->getVertexArray());
   cc_glglue_glEnableClientState(glue, GL_VERTEX_ARRAY);
 
   cc_glglue_glTexCoordPointer(glue, 2, GL_FLOAT, 0,
-                              (GLvoid*) cache->getBumpCoordArray());
+                              cache->getBumpCoordArray());
   cc_glglue_glEnableClientState(glue, GL_TEXTURE_COORD_ARRAY);
 
   cc_glglue_glNormalPointer(glue, GL_FLOAT, 0,
-                           (GLvoid*) cache->getNormalArray());
+                           cache->getNormalArray());
   cc_glglue_glEnableClientState(glue, GL_NORMAL_ARRAY);
 
   cc_glglue_glClientActiveTexture(glue, GL_TEXTURE1);
-  cc_glglue_glTexCoordPointer(glue, 3, GL_FLOAT, 6*sizeof(float), (GLvoid*) tptr);
+  cc_glglue_glTexCoordPointer(glue, 3, GL_FLOAT, 6*sizeof(float), tptr);
   cc_glglue_glEnableClientState(glue, GL_TEXTURE_COORD_ARRAY);
 
   cc_glglue_glClientActiveTexture(glue, GL_TEXTURE2);
-  cc_glglue_glTexCoordPointer(glue, 3, GL_FLOAT, 6*sizeof(float), (GLvoid*) (tptr + 1));
+  cc_glglue_glTexCoordPointer(glue, 3, GL_FLOAT, 6*sizeof(float), (tptr + 1));
   cc_glglue_glEnableClientState(glue, GL_TEXTURE_COORD_ARRAY);
 
   cc_glglue_glDrawElements(glue, GL_TRIANGLES, n, GL_UNSIGNED_INT,
@@ -654,26 +654,26 @@ soshape_bumprender::renderBump(SoState * state,
   }
 
   cc_glglue_glVertexPointer(glue, 3, GL_FLOAT, 0,
-                            (GLvoid*) cache->getVertexArray());
+                            cache->getVertexArray());
   cc_glglue_glEnableClientState(glue, GL_VERTEX_ARRAY);
   cc_glglue_glTexCoordPointer(glue, 2, GL_FLOAT, 0,
-                              (GLvoid*) cache->getBumpCoordArray());
+                              cache->getBumpCoordArray());
   cc_glglue_glEnableClientState(glue, GL_TEXTURE_COORD_ARRAY);
 
   cc_glglue_glClientActiveTexture(glue, GL_TEXTURE1);
   if (use_vertex_program) {
     cc_glglue_glColorPointer(glue, 3, GL_FLOAT, 6*sizeof(float),
-                             (GLvoid*) (tsptr + 1));
+                             (tsptr + 1));
     cc_glglue_glEnableClientState(glue, GL_COLOR_ARRAY);
     cc_glglue_glTexCoordPointer(glue, 3, GL_FLOAT, 6*sizeof(float),
-                                (GLvoid*) tsptr);
+                                tsptr);
     cc_glglue_glNormalPointer(glue, GL_FLOAT, 0,
-                              (GLvoid*) cache->getNormalArray());
+                              cache->getNormalArray());
     cc_glglue_glEnableClientState(glue, GL_NORMAL_ARRAY);
   }
   else {
     cc_glglue_glTexCoordPointer(glue, 3, GL_FLOAT, 0,
-                                (GLvoid*) cmptr);
+                                cmptr);
   }
   cc_glglue_glEnableClientState(glue, GL_TEXTURE_COORD_ARRAY);
 


### PR DESCRIPTION
## Summary

Investigated all 312 unique -Wcast-qual sites (289 in Coin's own code,
23 in vendored expat left untouched). The overwhelming majority are
established, intentional idioms that don't warrant touching:
SoGLXxxElement::pop()/matches() casting a sibling const SoElement* to
the concrete mutable type (same push/pop invariant already validated
during the -Wnull-dereference work -- pop() needs to write GL-state
cache into the previous stack element); copyContents(const
SoFieldContainer * from, ...) casting `from` to the concrete type for
read-only access (same "Shape 2" pattern from that same investigation);
const_cast<T*>(this) to satisfy a non-const return type from within a
const method; and mandatory C-API idioms (dlsym, qsort comparators,
qsort's own genuinely-mutating `base` argument, deliberately-named
"getWriteable..." accessors). None of those are touched here.

Two real, narrowly-scoped fixes came out of it:

1. soshape_bumprender.cpp (11 sites) and SoVertexArrayIndexer.cpp (1
   site): dead casts to (GLvoid*)/(GLsizei*) passed to
   cc_glglue_glVertexPointer/glTexCoordPointer/glNormalPointer/
   glColorPointer/glMultiDrawElements. Checked every target function's
   declared signature in include/Inventor/C/glue/gl.h: all of them
   already take a const pointer for this parameter, so the cast was
   discarding a qualifier the callee never needed removed -- pure
   leftover, most likely from before these wrappers were made
   const-correct. SoVertexArrayIndexer.cpp's other 8 -Wcast-qual sites
   were individually checked and left alone: qsort() comparator
   callbacks and qsort()'s own `base` argument (which really does need
   non-const, since it sorts in place) and the deliberately-named,
   documented getWriteableIndices() accessor.

2. SoBase::readRoute(): parsed "from.field TO to.field" ROUTE syntax
   by const_casting SbString::getString()'s result and writing a NUL
   terminator into it in place to split the string, relying on
   SbString/cc_string never sharing its buffer between instances.
   Confirmed that's true today (cc_string is a plain struct with small-
   string-optimization, no refcounting/COW) and that fromstring/
   tostring are never read again after the mutation, so this wasn't an
   active bug -- but it depends on an implementation detail getString()
   doesn't promise to keep. Rewrote using SbString's own substring
   constructor (SbString(const char*, start, end)) for the node-name
   half; the field-name half needs no truncation at all, since it
   already runs to the original string's own (now untouched)
   terminating NUL. No more casting away const, no mutation of
   SbString's buffer.

No test coverage existed for ROUTE parsing (grepped testsuite/ for
ROUTE/readRoute, found nothing), so verified the rewrite directly with
a standalone SoInput/SoDB::readAll() smoke test: a valid two-node
ROUTE resolves with zero SoReadError callbacks (confirming both
node/field name splits are byte-exact, not off-by-one in either
direction), and a deliberately malformed ROUTE (missing the dot)
still correctly triggers "Error parsing ROUTE keyword".

Verified: full clean builds under GCC and clang
(-Wall -Wextra -Wpedantic -Wno-write-strings, tests included) show 0
compile errors and identical warning counts to the master baseline in
every category, including the 4 pre-existing -Wdeprecated-copy hits in
readRoute() itself (confirmed via a side-by-side build against
unmodified master that they already existed there, just at different
line numbers before this commit added explanatory comments).
CoinTests passes 1/1 via ctest on both compilers. Debug+ASan/UBSan run
reports [OK] 326 tests, 83566 checks, zero UBSan findings, and the
same 207 pre-existing leak allocations as the established baseline,
none traceable to any file touched here.

---
**Verified:** Full clean rebuild under GCC and clang (Linux) with the strict warning recipe (`-Wall -Wextra -Wpedantic` plus the specific flag(s) this fixes), `ctest` (1/1 pass), and a Debug build under AddressSanitizer/UndefinedBehaviorSanitizer running the full `CoinTests` suite with no new findings.

Also verified on Windows (MSVC / Visual Studio 17 2022, x64 Release, /W4): built and tested together with all sibling branches from this audit (merged into a local integration build), 0 errors, full `CoinTests` suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FHRXMxksBcEGfbN5bDVJzb
