### PR TITLE
Fix clang -Wconstant-logical-operand across 6 sites

### DIFF
--- a/src/misc/CoinResources.cpp
+++ b/src/misc/CoinResources.cpp
@@ -224,10 +224,11 @@ CoinResources::get(const char * resloc)
       }
       filename.sprintf("%s/%s/%s", coindirenv, COIN_DATADIR, resloc + 5);
 #endif // !COIN_MACOSX_FRAMEWORK
-      if (COIN_DEBUG && 0) {
+      // COIN_DEBUG-gated diagnostic, deliberately disabled -- keep for future re-enabling
+#if 0
         SoDebugError::postInfo("CoinResources::get", "trying to load '%s'.",
                                filename.getString());
-      }
+#endif // 0
       FILE * fp = fopen(filename.getString(), "rb");
       if (!fp) {
         handle->filenotfound = TRUE;
@@ -257,10 +258,11 @@ CoinResources::get(const char * resloc)
         // hook up something that clears out everything instead.
         handle->loadedbuf = buffer;
 
-        if (COIN_DEBUG && 0) {
+        // COIN_DEBUG-gated diagnostic, deliberately disabled -- keep for future re-enabling
+#if 0
           SoDebugError::postInfo("CoinResources::get", "load '%s' ok.",
                                  filename.getString());
-        }
+#endif // 0
       } else {
         handle->filenotfound = TRUE;
         break;

--- a/src/navigation/SoScXMLDollyTarget.cpp
+++ b/src/navigation/SoScXMLDollyTarget.cpp
@@ -480,11 +480,12 @@ SoScXMLDollyTarget::dolly(SoCamera * camera, float diffvalue)
   // sqrt(FLT_MAX) == ~ 1e+19, which should be both safe for further
   // calculations and ok for the end-user and app-programmer.
   if (distorigo > float(sqrt(FLT_MAX))) {
-    if (COIN_DEBUG && 0) {
+    // COIN_DEBUG-gated diagnostic, deliberately disabled -- keep for future re-enabling
+#if 0
       SoDebugError::postWarning("SoScXMLDollyTarget::dolly",
                                 "zoomed too far (distance to origo==%f (%e))",
                                 distorigo, distorigo);
-    }
+#endif // 0
   }
   else {
     camera->position = newpos;
@@ -532,11 +533,12 @@ SoScXMLDollyTarget::jump(SoCamera * camera, float focaldistance)
   // sqrt(FLT_MAX) == ~ 1e+19, which should be both safe for further
   // calculations and ok for the end-user and app-programmer.
   if (distorigo > float(sqrt(FLT_MAX))) {
-    if (COIN_DEBUG && 0) {
+    // COIN_DEBUG-gated diagnostic, deliberately disabled -- keep for future re-enabling
+#if 0
       SoDebugError::postWarning("SoScXMLDollyTarget::dolly",
                                 "zoomed too far (distance to origo==%f (%e))",
                                 distorigo, distorigo);
-    }
+#endif // 0
   }
   else {
     camera->position.setValue(newpos);

--- a/src/nodekits/SoInteractionKit.cpp
+++ b/src/nodekits/SoInteractionKit.cpp
@@ -579,7 +579,7 @@ SoInteractionKit::setAnyPartAsDefault(const SbName & partname,
   if (node) {
     return this->setAnyPartAsDefault(partname, node, anypart, onlyifdefault);
   }
-  else if (COIN_DEBUG && 1) { // debug
+  else if (COIN_DEBUG) { // debug
     SoDebugError::postInfo("SoInteractionKit::setAnyPartAsDefault",
                            "nodename %s not found", nodename.getString());
 

--- a/src/profiler/SoNodeVisualize.cpp
+++ b/src/profiler/SoNodeVisualize.cpp
@@ -473,14 +473,17 @@ SoNodeVisualize::traverse(SoProfilerStats * stats)
     green = 1.0f - (float)msec / (float)CRITICAL;
   }
 
-  if(this->node->isOfType(SoSeparator::getClassTypeId()) &&
-     0 // FIXME: larsa
-     //stats->hasGLCache((SoSeparator *)this->node)
-     ) {
+  // FIXME: larsa -- deliberately disabled, stats->hasGLCache() isn't
+  // wired up yet; keep for future re-enabling
+#if 0
+  if (this->node->isOfType(SoSeparator::getClassTypeId())
+      //&& stats->hasGLCache((SoSeparator *)this->node)
+      ) {
     // FIXME All children are cached. Make them inherit material
     color = SbVec3f(0.0f, green, 1.0f);
     transparency = 0.0f;
   }
+#endif // 0
 
   if (this->node->getTypeId().getName() == SbName("ScenarioSimulator"))
     color = SbVec3f(1.0f, green, 0.0f);


### PR DESCRIPTION
## Summary

All 6 sites are the same underlying idiom: a `&&` expression manually
toggled on/off by ANDing a runtime condition with a literal 0 or 1,
left in place as an inert switch rather than being fully removed --
Clang flags this as fragile even when it's deliberate, since a literal
operand in a logical `&&`/`||` is usually a sign that a `&`/`|`
(bitwise) was intended instead.

- src/nodekits/SoInteractionKit.cpp: `COIN_DEBUG && 1` -- the literal
  `1` is a no-op (`X && 1 == X`), and this exact file already uses
  bare `if (COIN_DEBUG)` at four other call sites, so this was
  simplified to match. Pure simplification, identical behavior.

- src/navigation/SoScXMLDollyTarget.cpp (2 sites, dolly() and jump()),
  src/misc/CoinResources.cpp (2 sites): `COIN_DEBUG && 0` -- always
  false regardless of COIN_DEBUG, i.e. a debug SoDebugError call
  deliberately silenced but kept in the source for future
  re-enabling. Simply deleting the `&& 0` would have changed behavior
  (it would re-enable the diagnostic under COIN_DEBUG builds), so
  instead converted the runtime `if (COIN_DEBUG && 0) { ... }` into a
  compile-time `#if 0 ... #endif` around the same body: identical
  "never executes" behavior, but resolved at preprocessing instead of
  at runtime, which is also strictly better (removes a permanently
  dead branch and its warning instead of just hiding the warning).

- src/profiler/SoNodeVisualize.cpp: `isOfType(...) && 0 // FIXME:
  larsa \n //stats->hasGLCache(...)` -- same pattern, but the literal
  stands in for a call to a method (`hasGLCache()`) that isn't wired
  up yet per the existing FIXME. Since the `&& 0` makes the whole
  condition unconditionally false regardless of the left operand,
  wrapped the entire if-statement (condition and body) in `#if 0`
  rather than leaving a dead isOfType() check in the compiled binary.

Verified: -Wconstant-logical-operand 6 -> 0 under clang -Wall -Wextra
-Wpedantic (390 -> 384 warnings total), 0 errors, every other category
in the breakdown unchanged. GCC build unaffected (859 warnings, 0
errors, same as master baseline). Full CoinTests suite passes under
both compilers (normal build: 1/1 ctest pass each); GCC Debug+ASan/
UBSan: 326 tests, 83566 checks, no findings.

---
**Verified:** Full clean rebuild under GCC and clang (Linux) with the strict warning recipe (`-Wall -Wextra -Wpedantic` plus the specific flag(s) this fixes), `ctest` (1/1 pass), and a Debug build under AddressSanitizer/UndefinedBehaviorSanitizer running the full `CoinTests` suite with no new findings.

Also verified on Windows (MSVC / Visual Studio 17 2022, x64 Release, /W4): built and tested together with all sibling branches from this audit (merged into a local integration build), 0 errors, full `CoinTests` suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FHRXMxksBcEGfbN5bDVJzb
