### PR TITLE
Fix clang -Wenum-compare-switch in shapenode GL-render dispatch macros

### DIFF
--- a/src/shapenodes/SoFaceSet.cpp
+++ b/src/shapenodes/SoFaceSet.cpp
@@ -424,7 +424,7 @@ SoFaceSet::initClass(void)
   }
 
 #define SOGL_FACESET_GLRENDER_RESOLVE_ARG2(normalbinding, materialbinding, texturing, args) \
-  switch (materialbinding) {                                             \
+  switch ((SoGL::FaceSet::AttributeBinding)materialbinding) {            \
   case SoGL::FaceSet::OVERALL:                                           \
     SOGL_FACESET_GLRENDER_RESOLVE_ARG3(normalbinding, OVERALL, texturing, args); \
     break;                                                               \
@@ -440,7 +440,7 @@ SoFaceSet::initClass(void)
   }
 
 #define SOGL_FACESET_GLRENDER_RESOLVE_ARG1(normalbinding, materialbinding, texturing, args) \
-  switch (normalbinding) {                                               \
+  switch ((SoGL::FaceSet::AttributeBinding)normalbinding) {              \
   case SoGL::FaceSet::OVERALL:                                           \
     SOGL_FACESET_GLRENDER_RESOLVE_ARG2(OVERALL, materialbinding, texturing, args); \
     break;                                                               \

--- a/src/shapenodes/SoLineSet.cpp
+++ b/src/shapenodes/SoLineSet.cpp
@@ -390,7 +390,7 @@ SoLineSet::initClass(void)
   }
 
 #define SOGL_LINESET_GLRENDER_RESOLVE_ARG2(normalbinding, materialbinding, texturing, args) \
-  switch (materialbinding) {                                            \
+  switch ((SoGL::LineSet::AttributeBinding)materialbinding) {           \
   case SoGL::LineSet::OVERALL:                                          \
     SOGL_LINESET_GLRENDER_RESOLVE_ARG3(normalbinding, SoGL::LineSet::OVERALL, texturing, args); \
     break;                                                              \
@@ -409,7 +409,7 @@ SoLineSet::initClass(void)
   }
 
 #define SOGL_LINESET_GLRENDER_RESOLVE_ARG1(normalbinding, materialbinding, texturing, args) \
-  switch (normalbinding) {                                              \
+  switch ((SoGL::LineSet::AttributeBinding)normalbinding) {             \
   case SoGL::LineSet::OVERALL:                                          \
     SOGL_LINESET_GLRENDER_RESOLVE_ARG2(SoGL::LineSet::OVERALL, materialbinding, texturing, args); \
     break;                                                              \

--- a/src/shapenodes/SoQuadMesh.cpp
+++ b/src/shapenodes/SoQuadMesh.cpp
@@ -808,7 +808,7 @@ SoQuadMesh::initClass(void)
   }
 
 #define SOGL_QUADMESH_GLRENDER_RESOLVE_ARG2(normalbinding, materialbinding, texturing, args) \
-  switch (materialbinding) {                                            \
+  switch ((SoGL::QuadMesh::AttributeBinding)materialbinding) {          \
   case SoGL::QuadMesh::OVERALL:                                         \
     SOGL_QUADMESH_GLRENDER_RESOLVE_ARG3(normalbinding, SoGL::QuadMesh::OVERALL, texturing, args); \
     break;                                                              \
@@ -827,7 +827,7 @@ SoQuadMesh::initClass(void)
   }
 
 #define SOGL_QUADMESH_GLRENDER_RESOLVE_ARG1(normalbinding, materialbinding, texturing, args) \
-  switch (normalbinding) {                                              \
+  switch ((SoGL::QuadMesh::AttributeBinding)normalbinding) {            \
   case SoGL::QuadMesh::OVERALL:                                         \
     SOGL_QUADMESH_GLRENDER_RESOLVE_ARG2(SoGL::QuadMesh::OVERALL, materialbinding, texturing, args); \
     break;                                                              \

--- a/src/shapenodes/SoTriangleStripSet.cpp
+++ b/src/shapenodes/SoTriangleStripSet.cpp
@@ -398,7 +398,7 @@ SoTriangleStripSet::initClass(void)
   }
 
 #define SOGL_TRISTRIPSET_GLRENDER_RESOLVE_ARG2(normalbinding, materialbinding, texturing, args) \
-  switch (materialbinding) {                                              \
+  switch ((SoGL::TriStripSet::AttributeBinding)materialbinding) {         \
   case SoGL::TriStripSet::OVERALL:                                        \
     SOGL_TRISTRIPSET_GLRENDER_RESOLVE_ARG3(normalbinding, OVERALL, texturing, args); \
     break;                                                                \
@@ -417,7 +417,7 @@ SoTriangleStripSet::initClass(void)
   }
 
 #define SOGL_TRISTRIPSET_GLRENDER_RESOLVE_ARG1(normalbinding, materialbinding, texturing, args) \
-  switch (normalbinding) {                                                \
+  switch ((SoGL::TriStripSet::AttributeBinding)normalbinding) {           \
   case SoGL::TriStripSet::OVERALL:                                        \
     SOGL_TRISTRIPSET_GLRENDER_RESOLVE_ARG2(OVERALL, materialbinding, texturing, args); \
     break;                                                                \


### PR DESCRIPTION
## Summary

SoFaceSet.cpp, SoLineSet.cpp, SoQuadMesh.cpp and SoTriangleStripSet.cpp
each define a local SOGL_<SHAPE>_GLRENDER_RESOLVE_ARG{1,2} macro pair
that switches on a real Binding-typed value (the enum declared in the
node's public header, e.g. SoFaceSet::Binding) but lists case labels
belonging to a *different*, file-local AttributeBinding enum (declared
in an anonymous namespace, used to parameterize the templated
SoGL::<Shape>::GLRender<...> instantiation selected by the macro).

The two enums are separate types that happen to enumerate the same
binding modes with matching underlying integer values by construction
(verified for all four: FaceSet OVERALL/PER_FACE/PER_VERTEX = 0/1/2 in
both types; LineSet, QuadMesh and TriangleStripSet likewise line up
0..3 in the same order in both their header Binding and local
AttributeBinding). GCC accepts this silently; Clang's
-Wenum-compare-switch flags it because matching a switch controlling
expression of one enum type against case labels of an unrelated enum
type is fragile even when the values happen to line up today.

Fixed by casting the switch's controlling expression to the local
AttributeBinding type at each of the two switches per file (the
"resolve normal binding" and "resolve material binding" dispatch
levels), matching the type of the case labels already used there.
This is a pure type annotation with identical codegen -- the
underlying integer values are unchanged, and the cast target already
has the same integer representation, so no case can newly reach
`default` or fail to match that didn't before.

Verified: -Wenum-compare-switch 72 -> 0 under clang -Wall -Wextra
-Wpedantic (390 -> 317 warnings total, 0 errors), every other category
in the breakdown unchanged. GCC build unaffected (859 warnings, 0
errors, same as master baseline -- GCC has no equivalent check). Full
CoinTests suite passes under both compilers (normal build: 1/1 ctest
pass each); GCC Debug+ASan/UBSan: 326 tests, 83566 checks, no findings
(the previously-known SbByteBufferP.icc UBSan finding was fixed
upstream in the master merge this branch is based on).

---
**Verified:** Full clean rebuild under GCC and clang (Linux) with the strict warning recipe (`-Wall -Wextra -Wpedantic` plus the specific flag(s) this fixes), `ctest` (1/1 pass), and a Debug build under AddressSanitizer/UndefinedBehaviorSanitizer running the full `CoinTests` suite with no new findings.

Also verified on Windows (MSVC / Visual Studio 17 2022, x64 Release, /W4): built and tested together with all sibling branches from this audit (merged into a local integration build), 0 errors, full `CoinTests` suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FHRXMxksBcEGfbN5bDVJzb
