### PR TITLE
Fix clang -Wformat-pedantic: %p given char* instead of void* (5 sites)

### DIFF
--- a/src/base/string.cpp
+++ b/src/base/string.cpp
@@ -115,7 +115,7 @@ cc_string_grow_buffer(cc_string * me, size_t newsize)
     printf("cc_string_grow_buffer: "
            "me->bufsize==%zu, me->pointer==%p, me->buffer==%p => "
            "newsize==%zu\n",
-           me->bufsize, me->pointer, me->buffer, newsize);
+           me->bufsize, (void *) me->pointer, (void *) me->buffer, newsize);
   }
 
 
@@ -125,11 +125,11 @@ cc_string_grow_buffer(cc_string * me, size_t newsize)
      the current memory buffer is not the default static, of course). */
   if (me->pointer != me->buffer) {
     newbuf = static_cast<char *>(realloc(me->pointer, newsize));
-    if (debug) { printf("cc_string_grow_buffer: newbuf==%p\n", newbuf); }
+    if (debug) { printf("cc_string_grow_buffer: newbuf==%p\n", (void *) newbuf); }
     assert(newbuf != NULL);
   } else {
     newbuf = static_cast<char *>(malloc(newsize));
-    if (debug) { printf("cc_string_grow_buffer: newbuf==%p\n", newbuf); }
+    if (debug) { printf("cc_string_grow_buffer: newbuf==%p\n", (void *) newbuf); }
     assert(newbuf != NULL);
 
     (void) strcpy(newbuf, me->pointer);

--- a/src/tidbits.cpp
+++ b/src/tidbits.cpp
@@ -225,7 +225,7 @@ coin_common_vsnprintf(func_vsnprintf * func,
 
   /* Can not use cc_debugerror_* interface(), as that could cause an
      infinite recursion. */
-  if (debug) { printf("dst==%p, n==%zu, fmtstr=='%s'\n", dst, n, fmtstr); }
+  if (debug) { printf("dst==%p, n==%zu, fmtstr=='%s'\n", (void *) dst, n, fmtstr); }
 
 #ifdef HAVE_VA_COPY_MACRO
   /* The C99 va_copy() is available, so use that to help us "rewind"


### PR DESCRIPTION
## Summary

Same underlying issue as fix/format-string's -Wformat= fixes (which
this branch is stacked on): %p strictly requires a void* argument per
the C standard, but Clang's stricter -Wformat-pedantic catches 5 more
instances GCC's -Wformat= didn't -- all char* debug-logging printf()
calls guarded by the COIN_DEBUG_STRING_GROW / equivalent runtime debug
toggles in cc_string_grow_buffer() (src/base/string.cpp, 4 sites) and
coin_vsnprintf() (src/tidbits.cpp, 1 site).

Fixed with the same explicit (void *) cast at each call site used
throughout this audit for the equivalent GCC warning: a pure type
annotation, zero behavior change, identical printed output on any
real ABI.

Verified: -Wformat-pedantic 5 -> 0 under clang -Wall -Wextra -Wpedantic
(380 -> 375 warnings total), 0 errors, every other category in the
breakdown unchanged. GCC: 848 warnings (859 baseline minus this
branch's parent -Wformat= fix's 11 sites), 0 errors, no regression.
Full CoinTests suite passes under both compilers (normal build: 1/1
ctest pass each); GCC Debug+ASan/UBSan: 326 tests, 83566 checks, no
findings.

---
**Verified:** Full clean rebuild under GCC and clang (Linux) with the strict warning recipe (`-Wall -Wextra -Wpedantic` plus the specific flag(s) this fixes), `ctest` (1/1 pass), and a Debug build under AddressSanitizer/UndefinedBehaviorSanitizer running the full `CoinTests` suite with no new findings.

Also verified on Windows (MSVC / Visual Studio 17 2022, x64 Release, /W4): built and tested together with all sibling branches from this audit (merged into a local integration build), 0 errors, full `CoinTests` suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FHRXMxksBcEGfbN5bDVJzb
