### PR TITLE
Fix -Wformat= warnings (11 sites across 11 files)

### DIFF
--- a/src/elements/SoElement.cpp
+++ b/src/elements/SoElement.cpp
@@ -595,7 +595,7 @@ void
 SoElement::print(FILE * file) const
 {
   (void)fprintf(file, "%s[%p]\n",
-                this->getTypeId().getName().getString(), this);
+                this->getTypeId().getName().getString(), (void *)this);
 }
 
 /*!

--- a/src/elements/SoEnvironmentElement.cpp
+++ b/src/elements/SoEnvironmentElement.cpp
@@ -261,7 +261,7 @@ SoEnvironmentElement::getFogType(SoState * const state)
 void
 SoEnvironmentElement::print(FILE * file) const
 {
-  fprintf(file, "SoEnvironmentElement[%p]\n", this);
+  fprintf(file, "SoEnvironmentElement[%p]\n", (void *)this);
 }
 
 /*!

--- a/src/elements/SoFloatElement.cpp
+++ b/src/elements/SoFloatElement.cpp
@@ -111,7 +111,7 @@ void
 SoFloatElement::print(FILE * file) const
 {
   (void)fprintf(file, "%s[%p]: data = %f\n",
-                this->getTypeId().getName().getString(), this, this->data);
+                this->getTypeId().getName().getString(), (void *)this, this->data);
 }
 
 /*!

--- a/src/elements/SoFontNameElement.cpp
+++ b/src/elements/SoFontNameElement.cpp
@@ -149,7 +149,7 @@ SoFontNameElement::copyMatchInfo(void) const
 void
 SoFontNameElement::print(FILE * file) const
 {
-  fprintf(file, "SoFontNameElement[%p]: font = %s\n", this,
+  fprintf(file, "SoFontNameElement[%p]: font = %s\n", (void *)this,
            this->fontName.getString());
 }
 

--- a/src/elements/SoInt32Element.cpp
+++ b/src/elements/SoInt32Element.cpp
@@ -115,7 +115,7 @@ void
 SoInt32Element::print(FILE * file) const
 {
   (void)fprintf(file, "%s[%p]: data = %d\n",
-                getTypeId().getName().getString(), this, this->data);
+                getTypeId().getName().getString(), (void *)this, this->data);
 }
 
 /*!

--- a/src/elements/SoLightAttenuationElement.cpp
+++ b/src/elements/SoLightAttenuationElement.cpp
@@ -146,7 +146,7 @@ SoLightAttenuationElement::copyMatchInfo() const
 void
 SoLightAttenuationElement::print(FILE * file) const
 {
-  fprintf(file, "SoLightAttenuationElement[%p]: attenuation = ", this);
+  fprintf(file, "SoLightAttenuationElement[%p]: attenuation = ", (void *)this);
   fprintf(file, "<%f, %f, %f>\n",
            this->lightAttenuation[0],
            this->lightAttenuation[1],

--- a/src/elements/SoReplacedElement.cpp
+++ b/src/elements/SoReplacedElement.cpp
@@ -120,7 +120,7 @@ void
 SoReplacedElement::print(FILE * file) const
 {
   const char * typen = this->getTypeId().getName().getString();
-  (void)fprintf(file, "%s[%p]\n", typen, this);
+  (void)fprintf(file, "%s[%p]\n", typen, (void *)this);
 }
 
 /*!

--- a/src/elements/SoViewportRegionElement.cpp
+++ b/src/elements/SoViewportRegionElement.cpp
@@ -141,5 +141,5 @@ SoViewportRegionElement::setElt(const SbViewportRegion & viewportRegionarg)
 void
 SoViewportRegionElement::print(FILE * file) const
 {
-  fprintf(file, "SoViewportRegionElement[%p]\n", this);
+  fprintf(file, "SoViewportRegionElement[%p]\n", (void *)this);
 }

--- a/src/misc/SoState.cpp
+++ b/src/misc/SoState.cpp
@@ -319,7 +319,7 @@ SoState::pop(void)
 void
 SoState::print(FILE * const file) const
 {
-  fprintf(file, "SoState[%p]: depth = %d\n", this, PRIVATE(this)->depth);
+  fprintf(file, "SoState[%p]: depth = %d\n", (void *)this, PRIVATE(this)->depth);
   fprintf(file, "  enabled elements {\n");
   for (int i = 0; i < this->numstacks; i++) {
     SoElement * element;

--- a/src/threads/mutex.cpp
+++ b/src/threads/mutex.cpp
@@ -218,7 +218,7 @@ cc_mutex_lock(cc_mutex * mutex)
          recursive call to this function, and a non-terminating lock /
          hang. */
       (void)fprintf(stdout, "DEBUG cc_mutex_lock(): mutex %p spent %f secs in lock\n",
-                    mutex, spent);
+                    (void *)mutex, spent);
     }
 
     assert(spent <= maxmutexlocktime);

--- a/src/xml/element.cpp
+++ b/src/xml/element.cpp
@@ -641,7 +641,7 @@ cc_xml_elt_get_int32(const cc_xml_elt * elt, int32_t * value)
   const char * data = cc_xml_elt_get_data(elt);
   assert(value != NULL);
   if ( data == NULL ) return FALSE;
-  if ( sscanf(data, "%u", value) == 1 ) return TRUE;
+  if ( sscanf(data, "%d", value) == 1 ) return TRUE;
   return FALSE;
 }
 


### PR DESCRIPTION
## Summary

Two shapes:

- 10 sites (SoElement, SoEnvironmentElement, SoFloatElement,
  SoFontNameElement, SoInt32Element, SoLightAttenuationElement,
  SoReplacedElement, SoViewportRegionElement, SoState print()
  methods, plus mutex.cpp's lock-timing debug message): a `%p`
  conversion is given `this` (or, for mutex.cpp, a `cc_mutex *`)
  directly, but %p's argument must be exactly `void *` per the
  C standard -- passing any other pointer type is technically
  UB even though every real ABI represents all data pointers
  identically. Fixed with the standard, portable idiom: cast the
  argument to (void *) at the call site. Pure formatting-diagnostic
  code (print() methods, a debug log line), zero behavioral
  effect -- same bit pattern in, same characters out.

- 1 site (src/xml/element.cpp's cc_xml_elt_get_int32()): a real,
  if minor, correctness bug. This function was evidently copied
  from the cc_xml_elt_get_uint32() immediately above it (identical
  structure) but the format specifier was left as "%u" instead of
  being updated to "%d" for the now-signed int32_t * argument.
  Passing a signed target to a %u conversion is again technically
  UB, and can behave differently from %d for certain scanf() corner
  cases even where the representations coincide. Fixed by changing
  the specifier to "%d" to match the parameter's actual signedness.

Verified: full clean rebuild shows the exact same warning breakdown as
master except -Wformat= 11->0 (859->848 total, zero errors); full
CoinTests suite passes (326 tests, 83566 checks) in both a normal
build and a Debug+ASan/UBSan build, with only the known pre-existing,
unrelated SbByteBufferP.icc UBSan finding present.

---
**Verified:** Full clean rebuild under GCC and clang (Linux) with the strict warning recipe (`-Wall -Wextra -Wpedantic` plus the specific flag(s) this fixes), `ctest` (1/1 pass), and a Debug build under AddressSanitizer/UndefinedBehaviorSanitizer running the full `CoinTests` suite with no new findings.

Also verified on Windows (MSVC / Visual Studio 17 2022, x64 Release, /W4): built and tested together with all sibling branches from this audit (merged into a local integration build), 0 errors, full `CoinTests` suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FHRXMxksBcEGfbN5bDVJzb
