### PR TITLE
Fix -Wignored-qualifiers: drop meaningless top-level const on cast targets

### DIFF
--- a/include/Inventor/fields/SoSubField.h
+++ b/include/Inventor/fields/SoSubField.h
@@ -376,7 +376,7 @@ _class_::setValues(const int start, const int numarg, const _valtype_ * newvals)
   else if (start+numarg > this->num) this->num = start+numarg; \
  \
   for (int i=0; i < numarg; i++) \
-    this->values[i+start] = static_cast<const _valtype_>(newvals[i]); \
+    this->values[i+start] = static_cast<_valtype_>(newvals[i]); \
   this->setChangedIndices(start, numarg); \
   this->valueChanged(); \
   this->setChangedIndices(); \

--- a/src/elements/SoOverrideElement.cpp
+++ b/src/elements/SoOverrideElement.cpp
@@ -146,7 +146,7 @@ return (element->flags & flag)
 
 #define SO_SET_OVERRIDE(flag) \
 SoOverrideElement * const element = \
-  const_cast<SoOverrideElement * const> \
+  const_cast<SoOverrideElement *> \
   ( \
    coin_safe_cast<const SoOverrideElement *>(getElement(state, classStackIndex)) \
     ); \


### PR DESCRIPTION
## Summary

Both of the 34 warnings (8 distinct SoMFxxx::setValues() instantiations
plus 26 instantiations of the SO_SET_OVERRIDE macro) came from a single
macro-expansion site each:

- SoSubField.h's SO_MFIELD_VALUE_SOURCE macro:
  `static_cast<const _valtype_>(newvals[i])` casts a scalar value
  (SbBool/double/int/float/int32_t/short/uint32_t/unsigned short,
  depending on the field type) to a const-qualified type. A top-level
  const on the result type of a cast is meaningless -- the cast
  produces a prvalue, which was never assignable to begin with, so
  "const" changes nothing about it. Dropped the const; the conversion
  itself (and the value assigned into this->values[i+start]) is
  unchanged.

- SoOverrideElement.cpp's SO_SET_OVERRIDE macro:
  `const_cast<SoOverrideElement * const>(...)` -- same issue, one
  level of indirection over: this const-qualifies the pointer *value*
  produced by the cast (not what it points to), which is immediately
  discarded into `element`, itself already declared
  `SoOverrideElement * const` two lines up (that's the const that
  actually matters, on the named variable). Dropped the redundant
  const from the cast's target type.

No behavior change in either case -- these are the exact values that
were already being produced and assigned, just spelled without a
qualifier the compiler was already ignoring.

Full clean rebuild: 0 errors, 0 -Wignored-qualifiers remaining (was 34
across these 2 macro definitions), total warnings 859->825. Full
CoinTests suite (326 tests) passes.

---
**Verified:** Full clean rebuild under GCC and clang (Linux) with the strict warning recipe (`-Wall -Wextra -Wpedantic` plus the specific flag(s) this fixes), `ctest` (1/1 pass), and a Debug build under AddressSanitizer/UndefinedBehaviorSanitizer running the full `CoinTests` suite with no new findings.

Also verified on Windows (MSVC / Visual Studio 17 2022, x64 Release, /W4): built and tested together with all sibling branches from this audit (merged into a local integration build), 0 errors, full `CoinTests` suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FHRXMxksBcEGfbN5bDVJzb
