### PR TITLE
Fix -Wimplicit-fallthrough in SoExtSelectionP::testShape

### DIFF
--- a/src/nodes/SoExtSelection.cpp
+++ b/src/nodes/SoExtSelection.cpp
@@ -1533,12 +1533,14 @@ SoExtSelectionP::testShape(SoCallbackAction * action, const SoShape * shape)
 
   SbBool full = FALSE;
   switch (PUBLIC(this)->lassoPolicy.getValue()) {
-  case SoExtSelection::FULL_BBOX: /* fall through intended */
+  case SoExtSelection::FULL_BBOX:
     full = TRUE;
+    /*FALLTHROUGH*/
   case SoExtSelection::PART_BBOX:
     return testBBox(action, projmatrix, shape, rectbbox, full);
-  case SoExtSelection::FULL: /* fall through intended */
+  case SoExtSelection::FULL:
     full = TRUE;
+    /*FALLTHROUGH*/
   case SoExtSelection::PART:
     return testPrimitives(action, projmatrix, shape, rectbbox, full);
   default:


### PR DESCRIPTION
## Summary

Both fallthroughs in this switch were already intentional and
documented -- FULL_BBOX falls into PART_BBOX (and FULL into PART)
after setting full=TRUE, so the BBOX/primitive cases share one
implementation parameterized by that flag -- but the existing
"/* fall through intended */" comments sat on the case label *above*
the fallthrough, not between the falling-through statement and the
next case, which is not a position GCC's -Wimplicit-fallthrough
heuristic associates with that fallthrough.

Moved each comment to right after `full = TRUE;` (immediately before
the case it falls into) and reformatted it as "/*FALLTHROUGH*/", the
exact convention already used and already working elsewhere in this
codebase (src/engines/so_eval.ic, src/foreignfiles/steel.cpp,
src/scxml/eval-minimum.cpp, src/soscxml/eval-coin.cpp all use this
same comment, in this same position, with no warning) -- rather than
introduce a second convention such as C++17's [[fallthrough]], which
the project's CMakeLists.txt (CMAKE_CXX_STANDARD 11) doesn't support
without an extra feature-test guard for no real benefit here.

No behavior change: only comments moved/reformatted, the executed
statements (full = TRUE; then falling into the next case) are
unchanged. Full clean rebuild: 0 errors, 0 -Wimplicit-fallthrough
remaining (was 2), total warnings 859->857. Full CoinTests suite
(326 tests) passes unchanged.

---
**Verified:** Full clean rebuild under GCC and clang (Linux) with the strict warning recipe (`-Wall -Wextra -Wpedantic` plus the specific flag(s) this fixes), `ctest` (1/1 pass), and a Debug build under AddressSanitizer/UndefinedBehaviorSanitizer running the full `CoinTests` suite with no new findings.

Also verified on Windows (MSVC / Visual Studio 17 2022, x64 Release, /W4): built and tested together with all sibling branches from this audit (merged into a local integration build), 0 errors, full `CoinTests` suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FHRXMxksBcEGfbN5bDVJzb
