### PR TITLE
Fix SFRotation memory leak, remove redundant work found via -Wshadow

### DIFF
--- a/src/io/SoInput.cpp
+++ b/src/io/SoInput.cpp
@@ -1213,9 +1213,12 @@ SoInput::read(SbName & n, SbBool validIdent)
 // to warn if the data doesn't fit in the storage type?
 // std::numeric_limits<type>::max() ought to be all the information
 // needed.  20070520 larsa
+//
+// Assumes a SoInput_FileInfo * named "fi" is already in scope: every
+// call site is the non-binary branch of a SoInput::read()/readByte()
+// overload that has already fetched it via getTopOfStack() to check
+// isBinary().
 #define READ_NUM(reader, readType, num, type) \
-  SoInput_FileInfo * fi = this->getTopOfStack(); \
-  assert(fi); \
   if (!fi->skipWhiteSpace()) return FALSE; \
   readType _tmp; \
   if (!fi->reader(_tmp)) return FALSE; \

--- a/src/shapenodes/SoText3.cpp
+++ b/src/shapenodes/SoText3.cpp
@@ -878,9 +878,6 @@ SoText3P::render(SoState * state, const cc_font_specification * fontspec,
             if (normalb.length() > 0)
               normalb.normalize();
 
-            SoProfile * pn = (SoProfile *) profilenodes[firstprofile];
-            pn->getVertices(state, profnum, profcoords);
-
             SbVec3f vc,vd;
             SbVec2f starta(va[0], va[1]);
             SbVec2f startb(vb[0], vb[1]);
@@ -1329,9 +1326,6 @@ SoText3P::generate(SoAction * action, const cc_font_specification * fontspec,
             normalb = normalb.cross(SbVec3f(0.0f, 0.0f,  -1.0f));
             if (normalb.length() > 0)
               normalb.normalize();
-
-            SoProfile *pn = (SoProfile *)profilenodes[firstprofile];
-            pn->getVertices(state, profnum, profcoords);
 
             SbVec3f vc,vd;
             SbVec2f starta(va[0], va[1]);

--- a/src/vrml97/JS_VRMLClasses.cpp
+++ b/src/vrml97/JS_VRMLClasses.cpp
@@ -562,10 +562,6 @@ static JSBool SFRotationConstructor(JSContext * cx, JSObject * obj,
       }
       // new SFRotation(SFVec3f axis, numeric angle)
       else {
-        SbVec4f * data = new SbVec4f();
-        spidermonkey()->JS_SetPrivate(cx, obj, data);
-        *rval = OBJECT_TO_JSVAL(obj);
-
         double number = 0.0;
         spidermonkey()->JS_ValueToNumber(cx, argv[1], &number);
 


### PR DESCRIPTION
## Summary

Three findings from a -Wshadow investigation (a "local shadows a
previous local" audit across 51 sites, done to see whether Coin's own
this->-qualified-member convention was masking real bugs behind
otherwise-safe-looking shadowed variables). Two are harmless-but-wasted
work; one is a genuine bug.

1. JS_VRMLClasses.cpp: SFRotationConstructor's "new SFRotation(axis,
   angle)" JS constructor overload leaked one SbVec4f (16 bytes) per
   call. The function allocates `data`, registers it with the JS
   object via JS_SetPrivate(), and sets *rval -- all unconditionally,
   before branching on the second argument's type. The
   "axis + numeric angle" branch then allocated a *second* SbVec4f
   into a same-named, shadowing `data`, and re-registered *that* with
   JS_SetPrivate(), orphaning the first allocation with no remaining
   reference to free it.

   Confirmed via git archaeology this is a real regression, not
   original design: the pre-refactor code (parent of 283c8fbd4b, 2005,
   "a lot of cleanup in Javascript classes") allocated a single
   JS_SFPrivate wrapper once up front and had both branches only ever
   assign into its ->obj member -- never re-allocate or re-register.
   The 2005 rewrite to work directly with SbVec4f* dropped that
   allocate-once invariant while restructuring, and one branch ended up
   redoing the full setup sequence instead of just reusing what the
   caller had already set up. Fix: the second branch now reuses the
   outer `data`, restoring the original one-allocation contract.

2. SoText3.cpp: two near-identical extrusion functions (render() and
   generate()) each primed `profcoords` via SoProfile::getVertices()
   for profilenodes[firstprofile] immediately before a loop whose first
   iteration (j=firstprofile) does the exact same call again. Traced
   to 473929d857 (2000, "coordinate fetching wasn't done correctly"),
   where the priming call was genuinely load-bearing -- code right
   after it used to read profcoords[0] before the loop started. A 2003
   "cleaned up extrusion code" pass (69b7a8938b) moved/removed that
   intervening code, leaving the priming call with nothing left to feed
   -- getVertices() is a pure recompute-from-scratch call (confirmed by
   reading SoLinearProfile/SoNurbsProfile's implementations), so the
   call was harmless, just wasted, duplicated in both copies of the
   function. Removed both.

3. SoInput.cpp: the READ_NUM(reader, readType, num, type) macro backing
   all 8 SoInput::read()/readByte() numeric overloads redeclared
   `SoInput_FileInfo * fi = this->getTopOfStack()` and re-asserted it,
   even though every one of its 8 call sites already fetches the exact
   same `fi` a few lines earlier (needed there for the isBinary()
   check the macro's branch is the "else" of). Verified all 8 call
   sites share this identical shape before changing the macro to
   assume `fi` is already in scope, documented with a comment on the
   macro since that's now a load-bearing, non-obvious precondition.

None of these were reachable via any other warning category already
fixed on other branches in this audit -- they only surfaced by manually
tracing each -Wshadow "shadows a previous local" site to rule out an
actual wrong-variable-read bug.

Verified: full clean builds under GCC and clang
(-Wall -Wextra -Wpedantic -Wno-write-strings, tests included) show 0
compile errors and identical warning counts to the master baseline in
every category (no new warnings, none at the touched lines).
JS_VRMLClasses.cpp confirmed to still compile correctly under this
environment's default SPIDERMONKEY_RUNTIME_LINKING=ON configuration
(no jsapi.h needed). CoinTests passes 1/1 via ctest on both compilers.
Debug+ASan/UBSan run reports [OK] 326 tests, 83566 checks, zero UBSan
findings, and the same 207 pre-existing leak allocations as the
established baseline, none traceable to any file touched here (this
sandbox has no SpiderMonkey runtime available to directly exercise the
fixed JS constructor path, so the leak fix itself relies on the git
archaeology and code-reading argument above rather than a new
regression test).

---
**Verified:** Full clean rebuild under GCC and clang (Linux) with the strict warning recipe (`-Wall -Wextra -Wpedantic` plus the specific flag(s) this fixes), `ctest` (1/1 pass), and a Debug build under AddressSanitizer/UndefinedBehaviorSanitizer running the full `CoinTests` suite with no new findings.

Also verified on Windows (MSVC / Visual Studio 17 2022, x64 Release, /W4): built and tested together with all sibling branches from this audit (merged into a local integration build), 0 errors, full `CoinTests` suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FHRXMxksBcEGfbN5bDVJzb
