### PR TITLE
Fix clang -Wliteral-range: always-true float/double comparison in SoVRMLBackground's sky sphere angle closing

### DIFF
--- a/src/vrml97/Background.cpp
+++ b/src/vrml97/Background.cpp
@@ -655,7 +655,7 @@ SoVRMLBackgroundP::buildGeometry(void)
         } 
         angles.append(angle);
       }
-      if (angle != M_PI)
+      if (angle != (float) M_PI)
         angles.append((float)M_PI);
 
     }


### PR DESCRIPTION
## Summary

buildGeometry()'s skyAngle loop clamps out-of-range angles to
`angle = (float) M_PI;` (line 651), then checks `if (angle != M_PI)`
to decide whether to append a closing angle at PI so the sky sphere's
triangle strip ends exactly at the pole. Since `angle` is a float and
M_PI is a double literal that isn't exactly representable in float,
the comparison implicitly widens `angle` back to double for the
comparison -- but the widened value is the double representation of
the *rounded* float, not the full-precision M_PI, so it can never
equal the double M_PI literal. The comparison was therefore always
true regardless of what the loop computed, including right after
explicitly setting angle to (float) M_PI two lines above: a genuine,
if minor, bug -- a redundant, zero-length closing angle was always
appended to the sky sphere's angle list, even when the last supplied
skyAngle value was already (at float precision) PI.

Fixed by casting the right-hand side to float: `angle != (float) M_PI`
compares two floats of identical precision, so it now correctly
evaluates false in exactly the case where angle already equals the
float-rounded M_PI (both the explicit-PI-clamp path and any skyAngle
input close enough to round to the same float), matching the
apparent original intent. Checked the sibling groundAngle loop in the
same function for the same pattern -- it uses a different closing
condition (`angles.getLength() < 3`) with no float/double equality
comparison, so it doesn't have this bug.

Verified: -Wliteral-range 1 -> 0 under clang -Wall -Wextra -Wpedantic
(390 -> 389 warnings total), 0 errors, every other category in the
breakdown unchanged. GCC build unaffected (859 warnings, 0 errors,
same as master baseline). Full CoinTests suite passes under both
compilers (normal build: 1/1 ctest pass each); GCC Debug+ASan/UBSan:
326 tests, 83566 checks, no findings.

---
**Verified:** Full clean rebuild under GCC and clang (Linux) with the strict warning recipe (`-Wall -Wextra -Wpedantic` plus the specific flag(s) this fixes), `ctest` (1/1 pass), and a Debug build under AddressSanitizer/UndefinedBehaviorSanitizer running the full `CoinTests` suite with no new findings.

Also verified on Windows (MSVC / Visual Studio 17 2022, x64 Release, /W4): built and tested together with all sibling branches from this audit (merged into a local integration build), 0 errors, full `CoinTests` suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FHRXMxksBcEGfbN5bDVJzb
