### PR TITLE
Fix -Wpedantic: void*/function-pointer comparisons in dl.cpp

### DIFF
--- a/src/glue/dl.cpp
+++ b/src/glue/dl.cpp
@@ -1003,7 +1003,7 @@ cc_dl_coin_handle(void)
        the public API) */
 
     if (func) {
-      if (func == cc_dl_open) { return hnd; }
+      if (func == (void *)cc_dl_open) { return hnd; }
 
       if (cc_dl_debugging()) {
         cc_debugerror_post("cc_dl_coin_handle",
@@ -1047,7 +1047,7 @@ cc_dl_opengl_handle(void)
     void * func = cc_dl_sym(hnd, "glGetString");
 
     if (func) {
-      if (func == glGetString) { return hnd; }
+      if (func == (void *)glGetString) { return hnd; }
 
       if (cc_dl_debugging()) {
         cc_debugerror_post("cc_dl_opengl_handle",


### PR DESCRIPTION
## Summary

cc_dl_coin_handle() and cc_dl_opengl_handle() each dlopen() a system
image and dlsym() a known symbol out of it, then compare the result
(void *) directly against the address of the equivalent statically-
linked function (cc_dl_open, glGetString) to confirm the dynamically
found image is the same one already loaded in the current process
(not a stray duplicate on disk). Comparing void* against a function
pointer directly is technically ill-formed in strict ISO C++ --
object and function pointers aren't guaranteed interconvertible,
even though POSIX's dlsym() contract (returning void* for any kind of
symbol, function or data) is exactly what makes this idiom universal
in practice on every platform Coin runs on.

Fixed with the standard portable idiom for this exact situation: an
explicit (void *) cast on the function pointer before comparing,
turning the implicit, questionable conversion into an explicit one.
Confirmed with a standalone comparison that the explicit-cast form
produces identical codegen/semantics to the implicit one (same
underlying bit pattern either way) -- this is a pure type-level
annotation with no behavioral effect.

Verified: full clean rebuild shows the exact same warning breakdown as
master except -Wpedantic 2->0 (859->857 total, zero errors); full
CoinTests suite passes (326 tests, 83566 checks) in both a normal
build and a Debug+ASan/UBSan build, with only the known pre-existing,
unrelated SbByteBufferP.icc UBSan finding present. This was the last
warning category remaining in master's baseline breakdown -- every
-W flag GCC reported under -Wall -Wextra -Wpedantic is now fixed by
one of the fix/* branches from this audit.

---
**Verified:** Full clean rebuild under GCC and clang (Linux) with the strict warning recipe (`-Wall -Wextra -Wpedantic` plus the specific flag(s) this fixes), `ctest` (1/1 pass), and a Debug build under AddressSanitizer/UndefinedBehaviorSanitizer running the full `CoinTests` suite with no new findings.

Also verified on Windows (MSVC / Visual Studio 17 2022, x64 Release, /W4): built and tested together with all sibling branches from this audit (merged into a local integration build), 0 errors, full `CoinTests` suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FHRXMxksBcEGfbN5bDVJzb
