### PR TITLE
Fix two index/variable-mismatch bugs found while auditing -Wdouble-promotion

### DIFF
--- a/src/base/SbDPViewVolume.cpp
+++ b/src/base/SbDPViewVolume.cpp
@@ -971,7 +971,7 @@ SbDPViewVolume::zNarrow(double nearval, double farval) const
   SbDPViewVolume narrowed = *this;
 
   narrowed.nearDist = this->nearDist + (1.0f - nearval) * this->nearToFar;
-  narrowed.nearToFar = this->nearDist + this->nearToFar * (1.0f - farval);
+  narrowed.nearToFar = this->nearToFar * (nearval - farval);
 
   SbVec3d dummy;
   this->getPlaneRectangle(narrowed.nearDist - this->nearDist,

--- a/src/base/SbViewVolume.cpp
+++ b/src/base/SbViewVolume.cpp
@@ -1038,6 +1038,19 @@ BOOST_AUTO_TEST_CASE(intersect_vv_inside_bbox)
   COIN_TESTCASE_CHECK_FLOAT(isect.getMax()[2], 0.0f);
 }
 
+BOOST_AUTO_TEST_CASE(znarrow)
+{
+  SbViewVolume vv;
+  vv.ortho(-0.5, 0.5, -0.5, 0.5, 2, 10);
+
+  // nearval==1.0 keeps the near plane fixed; farval==0.5 moves the far
+  // plane halfway back from the original far plane towards the near
+  // plane, so the new depth should be half of the original (8 -> 4).
+  SbViewVolume narrowed = vv.zNarrow(1.0f, 0.5f);
+  COIN_TESTCASE_CHECK_FLOAT(narrowed.getNearDist(), 2.0f);
+  COIN_TESTCASE_CHECK_FLOAT(narrowed.getDepth(), 4.0f);
+}
+
 BOOST_AUTO_TEST_CASE(intersect_perspective)
 {
   // FIXME: set up a better perspective vv which also tests left/right/top/bottom

--- a/src/hardcopy/VectorizePSAction.cpp
+++ b/src/hardcopy/VectorizePSAction.cpp
@@ -313,7 +313,7 @@ SoVectorizePSAction::printHeader(void) const
     fputs("% rotate to LANDSCAPE orientation\n", file);
     fprintf(file, "%g %g translate\n", porg[0] + psize[0], porg[1] + psize[1]);
     fprintf(file, "90 rotate\n");
-    fprintf(file, "%g %g translate\n\n", -(psize[1]+porg[1]), -(psize[0]+porg[1]));
+    fprintf(file, "%g %g translate\n\n", -(psize[1]+porg[1]), -(psize[0]+porg[0]));
   }
 
   // used for gouraud shading workaround


### PR DESCRIPTION
## Summary

Neither bug relates to double-promotion itself; both were found by
reading the full context around flagged lines while triaging that
warning category.

src/hardcopy/VectorizePSAction.cpp: SoVectorizePSAction::printHeader()
emits two PostScript "translate" commands to rotate the page for
LANDSCAPE orientation. The first pairs porg[i] with psize[i] for each
axis (porg[0]+psize[0], porg[1]+psize[1]). After the 90-degree
rotate, the second translate swaps which psize index goes in which
argument (as expected, since the axes have swapped) but should still
pair each psize[i] with the matching porg[i] -- instead both terms
used porg[1]. Unchanged since the file's original 2003 commit
(5f12bc7acf1); likely never noticed because it only produces visible
misplacement when a print page's horizontal and vertical start
offsets differ.

src/base/SbDPViewVolume.cpp: SbDPViewVolume::zNarrow() computes a new
near distance (correct, an absolute distance-from-eye value) and a
new nearToFar (which should be a span, matching every other writer
of this field in the file -- see the ortho()/perspective() methods
and frustum(), all of which set nearToFar = farval - nearval). The
old code instead computed another absolute distance and assigned it
to nearToFar, double-counting nearDist. Fixed by computing the span
directly: nearToFar * (nearval - farval).

SbViewVolume::zNarrow() (the float API) delegates to this same
double-precision implementation, so both call paths were affected.
The only production caller is SoShadowGroup's maxShadowDistance
handling (SoShadowGroup.cpp), immediately followed by
intersectionBox(), which uses nearToFar to place the far clipping
plane -- so this bug made maxShadowDistance clip much farther out
than configured whenever nearDist wasn't ~0. Unchanged since the
file's original 2002 commit (9167aae8ea).

Added a regression test (znarrow, in SbViewVolume.cpp's existing
COIN_TEST_SUITE block) exercising zNarrow() directly via
getNearDist()/getDepth(); verified it fails with the old formula
(expected 4, got 6) and passes with the fix.

---
**Verified:** Full clean rebuild under GCC and clang (Linux) with the strict warning recipe (`-Wall -Wextra -Wpedantic` plus the specific flag(s) this fixes), `ctest` (1/1 pass), and a Debug build under AddressSanitizer/UndefinedBehaviorSanitizer running the full `CoinTests` suite with no new findings.

Also verified on Windows (MSVC / Visual Studio 17 2022, x64 Release, /W4): built and tested together with all sibling branches from this audit (merged into a local integration build), 0 errors, full `CoinTests` suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FHRXMxksBcEGfbN5bDVJzb
