### PR TITLE
Fix -Warray-bounds false positive in SbList<Type>::grow()

### DIFF
--- a/include/Inventor/lists/SbList.h
+++ b/include/Inventor/lists/SbList.h
@@ -238,8 +238,17 @@ protected:
 
 private:
   void grow(const int size = -1) {
-    // Default behavior is to double array size.
-    if (size == -1) this->itembuffersize <<= 1;
+    // Default behavior is to double array size. itembuffersize is
+    // always >= DEFAULTSIZE for the lifetime of the object (set in
+    // the constructor, and every other assignment below either
+    // doubles it or clamps it to at least DEFAULTSIZE), so the ">
+    // 0" branch is the only one ever taken in practice -- but the
+    // explicit floor lets the compiler prove that locally too,
+    // instead of just at this call's actual call sites, which is
+    // what silences a GCC -Warray-bounds false positive seen when
+    // append() is inlined right after code that resets numitems to
+    // 0 (e.g. truncate(0)) without narrowing itembuffersize.
+    if (size == -1) this->itembuffersize = (this->itembuffersize > 0) ? (this->itembuffersize << 1) : DEFAULTSIZE;
     else if (size <= this->itembuffersize) return;
     else { this->itembuffersize = size; }
 

--- a/src/lists/SbList.cpp
+++ b/src/lists/SbList.cpp
@@ -30,6 +30,8 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 \**************************************************************************/
 
+#include <Inventor/lists/SbList.h>
+
 /*!
   \class SbList SbList.h Inventor/lists/SbList.h
   \brief The SbList class is a template container class for lists.
@@ -274,3 +276,42 @@
   
   \since Coin 2.5
 */
+
+#ifdef COIN_TEST_SUITE
+
+// Regression test for the real-world usage pattern found in e.g.
+// SoLightPath::setHead(), SoBaseKit::createFieldList() and
+// SbHeap::emptyHeap(): truncate(0) immediately followed by append(),
+// then growing well past the point where a re-grow of the internal
+// buffer is required. This is also the exact pattern that used to
+// trigger a GCC -Warray-bounds false positive in grow() (GCC's
+// constant propagation of numitems==0 from truncate(0) into the
+// inlined append()/grow() met its inability to prove itembuffersize
+// can never be 0, and it flagged a "new Type[0]" allocation that is
+// not actually reachable) -- this test exercises the real memory
+// behavior so any future change to grow()'s bookkeeping that broke
+// the underlying invariant (itembuffersize is always >= DEFAULTSIZE)
+// would show up here, not just as a compiler warning.
+BOOST_AUTO_TEST_CASE(truncate_zero_then_grow_past_default_size)
+{
+  SbList<int> list;
+  for (int i = 0; i < 4; i++) { list.append(i); }
+  BOOST_CHECK_EQUAL(list.getLength(), 4);
+
+  list.truncate(0);
+  BOOST_CHECK_EQUAL(list.getLength(), 0);
+
+  // Append well past the built-in inline buffer size (4), forcing
+  // grow() to run its "double the buffer" path multiple times right
+  // after numitems was reset to 0 by truncate(0).
+  const int n = 100;
+  for (int i = 0; i < n; i++) { list.append(i * 3); }
+
+  BOOST_REQUIRE_EQUAL(list.getLength(), n);
+  for (int i = 0; i < n; i++) {
+    BOOST_CHECK_MESSAGE(list[i] == i * 3,
+                        "SbList value corrupted after truncate(0) + growth");
+  }
+}
+
+#endif // COIN_TEST_SUITE


### PR DESCRIPTION
## Summary

GCC flagged 8 call sites across the codebase (SoOutput::reset,
SoReorganizeActionP::initShape, SoNodekitCatalog::reallyAddEntry,
SoBaseKit::createFieldList, SbHeap::emptyHeap, SoLightPath::setHead,
Background.cpp's buildGeometry) with "array subscript 0 is outside
array bounds of 'Type* [0]'" / "note: object of size 0 allocated by
operator new []", pointing at SbList.h:248, the element-copy loop in
grow().

Audited every mutator of itembuffersize (constructor sets it to
DEFAULTSIZE; grow() only ever doubles it or raises it to an explicit
size > the current one; fit() clamps it to max(items, DEFAULTSIZE))
and confirmed by full-suite runs under AddressSanitizer/UBSan (before
and after) that itembuffersize can never actually be 0 when grow()
runs new Type[itembuffersize] -- there is no real out-of-bounds write.

Bisected the false positive to a minimal, Coin-independent repro: it
requires code that sets numitems to 0 (e.g. truncate(0), or a
getLength()==0 guard) immediately before an append(), fully inlined
together. All 8 real call sites match this exact shape (6 via
truncate(0)+append(), one via an empty-the-list loop + append(), one
via if(getLength()==0){append();}). GCC constant-propagates
numitems==0 into the inlined grow(), and -- unable to prove
itembuffersize can't also be 0 across the constructor/inlining
boundary -- reports the (actually unreachable) "new Type[0]" branch.

Fix: give grow() a floor that is provable from purely local
information, instead of relying on cross-function knowledge GCC
doesn't have here: `itembuffersize > 0 ? itembuffersize << 1 :
DEFAULTSIZE` instead of a bare `itembuffersize <<= 1`. Confirmed this
eliminates the warning (0 remaining after a full clean rebuild, was 8)
with the exact same object code behavior for the only state that ever
actually occurs (itembuffersize >= DEFAULTSIZE); no pragma or
suppression involved.

Added a regression test (src/lists/SbList.cpp, under COIN_TEST_SUITE)
that exercises the real truncate(0)-then-grow-past-DEFAULTSIZE pattern
end to end and checks the resulting values, so a future change that
actually breaks the itembuffersize invariant would fail a real memory
check, not just silence a compiler warning. Full CoinTests suite
(327 tests after this addition) passes clean under ASan+UBSan both
before and after the fix.

---
**Verified:** Full clean rebuild under GCC and clang (Linux) with the strict warning recipe (`-Wall -Wextra -Wpedantic` plus the specific flag(s) this fixes), `ctest` (1/1 pass), and a Debug build under AddressSanitizer/UndefinedBehaviorSanitizer running the full `CoinTests` suite with no new findings.

Also verified on Windows (MSVC / Visual Studio 17 2022, x64 Release, /W4): built and tested together with all sibling branches from this audit (merged into a local integration build), 0 errors, full `CoinTests` suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FHRXMxksBcEGfbN5bDVJzb
