### PR TITLE
Fix -Wshift-negative-value in SpiderMonkey glue's INT_TO_JSVAL

### DIFF
--- a/include/Inventor/C/glue/spidermonkey.h
+++ b/include/Inventor/C/glue/spidermonkey.h
@@ -215,7 +215,7 @@ struct JSErrorReport {
 #define JSVAL_INT_MAX           (JSVAL_INT_POW2(30) - 1)
 #define INT_FITS_IN_JSVAL(i)    ((uint32_t)((i)+JSVAL_INT_MAX) <= 2*JSVAL_INT_MAX)
 #define JSVAL_TO_INT(v)         ((int32_t)(v) >> 1)
-#define INT_TO_JSVAL(i)         (((jsval)(i) << 1) | JSVAL_INT)
+#define INT_TO_JSVAL(i)         (((jsval)((uintptr_t)(i) << 1)) | JSVAL_INT)
 
 #define JSVAL_TO_GCTHING(v)     ((void *)JSVAL_CLRTAG(v))
 #define JSVAL_TO_OBJECT(v)      ((JSObject *)JSVAL_TO_GCTHING(v))


### PR DESCRIPTION
## Summary

All 37 warnings are the same macro, INT_TO_JSVAL(i), expanded at every
call site (JSVAL_VOID's own definition, plus every val = JSVAL_VOID;
in JS_VRMLClasses.cpp/Script.cpp). jsval is intptr_t (signed), and
JSVAL_VOID's argument (0 - JSVAL_INT_POW2(30)) is negative, so
`(jsval)(i) << 1` left-shifts a negative signed integer -- undefined
behavior pre-C++20, and still warned about by GCC regardless of
-std level.

This header hand-reimplements SpiderMonkey's own jsapi.h bit-packing
scheme for Coin's dlopen-based glue, so the computed value has to stay
byte-for-byte identical to what the real library expects; this is a
warning-only fix, not a value change. Fixed by doing the shift in
uintptr_t (well-defined for any bit pattern, including the sign bit)
and casting the result back to jsval, which reproduces the exact same
bit pattern as the original left-shift on any two's-complement target
(i.e. every platform Coin actually runs on) -- confirmed with a
standalone comparison of both macro forms across JSVAL_VOID's actual
argument plus a spread of boundary values (0, +-1, +-2^30, INT32_MIN/
MAX): identical output in every case.

Verified: full clean rebuild shows the exact same warning breakdown as
master except -Wshift-negative-value 37->0 (859->822 total, zero
errors); full CoinTests suite passes (326 tests, 83566 checks) in both
a normal build and a Debug+ASan/UBSan build, with only the known
pre-existing, unrelated SbByteBufferP.icc UBSan finding present.

---
**Verified:** Full clean rebuild under GCC and clang (Linux) with the strict warning recipe (`-Wall -Wextra -Wpedantic` plus the specific flag(s) this fixes), `ctest` (1/1 pass), and a Debug build under AddressSanitizer/UndefinedBehaviorSanitizer running the full `CoinTests` suite with no new findings.

Also verified on Windows (MSVC / Visual Studio 17 2022, x64 Release, /W4): built and tested together with all sibling branches from this audit (merged into a local integration build), 0 errors, full `CoinTests` suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FHRXMxksBcEGfbN5bDVJzb
