### PR TITLE
Fix signed integer overflow in STL binary-format detection heuristic

### DIFF
--- a/src/foreignfiles/steel.cpp
+++ b/src/foreignfiles/steel.cpp
@@ -2732,8 +2732,15 @@ stl_reader_create(const char * filename)
     readok &= !fseek(reader->file, 80, SEEK_SET);
     readok &= fread(bytes, 4, 1, reader->file);
     reader->facets_total =
-      (bytes[3] << 24) | (bytes[2] << 16) | (bytes[1] << 8) | bytes[0];
-    if ( (84 + (reader->facets_total * 50)) != length ) {
+      static_cast<int>((static_cast<uint32_t>(bytes[3]) << 24) |
+                        (static_cast<uint32_t>(bytes[2]) << 16) |
+                        (static_cast<uint32_t>(bytes[1]) << 8) |
+                        bytes[0]);
+    /* bytes[80..83] are attacker/file-controlled and not yet known to
+       be a real facet count at this point (that's what this check is
+       trying to determine) -- do the arithmetic in a wide enough type
+       to avoid signed overflow on a bogus (e.g. ASCII STL) input. */
+    if ( (84 + (static_cast<int64_t>(reader->facets_total) * 50)) != length ) {
       break; /* not a binary stl file */
     }
     reader->flags |= STL_BINARY;

--- a/src/foreignfiles/steel.l
+++ b/src/foreignfiles/steel.l
@@ -859,8 +859,15 @@ stl_reader_create(const char * filename)
     readok &= !fseek(reader->file, 80, SEEK_SET);
     readok &= fread(bytes, 4, 1, reader->file);
     reader->facets_total =
-      (bytes[3] << 24) | (bytes[2] << 16) | (bytes[1] << 8) | bytes[0];
-    if ( (84 + (reader->facets_total * 50)) != length ) {
+      static_cast<int>((static_cast<uint32_t>(bytes[3]) << 24) |
+                        (static_cast<uint32_t>(bytes[2]) << 16) |
+                        (static_cast<uint32_t>(bytes[1]) << 8) |
+                        bytes[0]);
+    /* bytes[80..83] are attacker/file-controlled and not yet known to
+       be a real facet count at this point (that's what this check is
+       trying to determine) -- do the arithmetic in a wide enough type
+       to avoid signed overflow on a bogus (e.g. ASCII STL) input. */
+    if ( (84 + (static_cast<int64_t>(reader->facets_total) * 50)) != length ) {
       break; /* not a binary stl file */
     }
     reader->flags |= STL_BINARY;


### PR DESCRIPTION
## Summary

stl_reader_create() (src/foreignfiles/steel.l, generating the
checked-in src/foreignfiles/steel.cpp) probes whether a file is
binary STL by reading 4 file-controlled bytes at offset 80 as a
facet count, then checking whether 84 + facets_total*50 equals the
file length. Since facets_total is not yet known to be a real facet
count at this point -- that's what the check is trying to determine
-- it can be any 32-bit bit pattern from arbitrary file content,
including an ASCII STL file or any other unrelated file being probed
by this same heuristic before falling back to ASCII parsing.

Two latent problems, both unchanged since the STL importer's original
2005 commit (9f2006a609):
  - shifting a byte with its high bit set into bit 31 of a signed int
    (bytes[3] << 24) is undefined behavior if the result doesn't fit
    in 'int';
  - facets_total * 50 overflows a 32-bit signed int for any
    facets_total beyond ~43 million, also undefined behavior.

Confirmed via -fsanitize=undefined: the CoinTests suite already hits
"signed integer overflow: 538976266 * 50 cannot be represented in
type 'int'" at this exact line. Reproduced standalone with a crafted
104-byte file and SoSTLFileKit::readFile() under ASan/UBSan: the
original code reliably reports the same overflow; the fix reports
nothing and correctly rejects the file (it is not valid STL of
either kind) with no undefined behavior along the way.

Fixed by assembling the byte pattern via unsigned intermediates
(avoiding the shift UB) and comparing in a 64-bit signed range
(avoiding the multiply overflow), without changing the comparison's
logic or the (unvalidated, deliberately permissive) semantics of the
heuristic itself.

steel.cpp is generated from steel.l by flex but checked into the
repository rather than regenerated at build time (no FLEX_TARGET for
it in CMakeLists.txt), so both files needed the identical edit;
confirmed byte-identical in this region both before and after.

Found while re-running a strict clang warning/sanitizer sweep against
lab/all-fixes-integration (all of this audit's fix branches merged
together) to look for anything only visible once the rest of the
cleanup had landed.

---
**Verified:** Full clean rebuild under GCC and clang (Linux) with the strict warning recipe (`-Wall -Wextra -Wpedantic` plus the specific flag(s) this fixes), `ctest` (1/1 pass), and a Debug build under AddressSanitizer/UndefinedBehaviorSanitizer running the full `CoinTests` suite with no new findings.

Also verified on Windows (MSVC / Visual Studio 17 2022, x64 Release, /W4): built and tested together with all sibling branches from this audit (merged into a local integration build), 0 errors, full `CoinTests` suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FHRXMxksBcEGfbN5bDVJzb
