### PR TITLE
Fix SoCube texture coordinates for SoTexture3 (3D/volume textures)

### DIFF
--- a/src/shapenodes/SoCube.cpp
+++ b/src/shapenodes/SoCube.cpp
@@ -149,15 +149,7 @@ SoCube::GLRender(SoGLRenderAction * action)
      binding == SoMaterialBindingElement::PER_FACE ||
      binding == SoMaterialBindingElement::PER_FACE_INDEXED);
 
-  SbBool doTextures = FALSE;
-  SbBool do3DTextures = FALSE;
-  if (SoGLMultiTextureEnabledElement::get(state, 0)) {
-    doTextures = TRUE;
-    if (SoGLMultiTextureEnabledElement::getMode(state,0) ==
-        SoMultiTextureEnabledElement::TEXTURE3D) {
-      do3DTextures = TRUE;
-    }
-  }
+  SbBool doTextures = SoGLMultiTextureEnabledElement::get(state, 0);
 
   SoMaterialBundle mb(action);
   mb.sendFirst();
@@ -173,11 +165,11 @@ SoCube::GLRender(SoGLRenderAction * action)
       flags |= SOGL_NEED_TEXCOORDS;
       break;
     case SoMultiTextureEnabledElement::CUBEMAP:
+    case SoMultiTextureEnabledElement::TEXTURE3D:
       flags |= SOGL_NEED_3DTEXCOORDS;
       break;
     }
   }
-  else if (do3DTextures) flags |= SOGL_NEED_3DTEXCOORDS;
   if (sendNormals) flags |= SOGL_NEED_NORMALS;
 
   sogl_render_cube(width.getValue(),


### PR DESCRIPTION
## Summary

SoCube::GLRender() decided between 2D and 3D texture-coordinate
generation with a switch on SoMultiTextureEnabledElement::Mode that
special-cased only CUBEMAP, sending every other mode -- including
TEXTURE3D -- down the 2D texcoord path. sogl_render_cube() then
emits glTexCoord2fv() from a 2D per-face UV table instead of
glTexCoord3fv() from the [0,1]^3 per-vertex table volume textures
need, so a cube textured with SoTexture3 got wrong-dimensionality,
wrong-value texture coordinates.

Traced via git archaeology to commit 665411f3e1 (2009), which merged
two previously separate, mutually-exclusive texture-enabled elements
(2D vs 3D) into one SoMultiTextureEnabledElement/Mode pair but kept
the old "switch on 2D-ish modes, else-if on do3DTextures" structure.
Since do3DTextures could now only be true when doTextures was also
true, the else-if became permanently unreachable, and the switch was
never updated to add a TEXTURE3D case alongside CUBEMAP -- a silent
regression dormant for 16 years (no visible crash, just wrong texture
sampling, and 3D-textured cubes are a rare combination with no visual
regression test coverage).

Simplify doTextures to a single get() call (do3DTextures no longer
needed) and add TEXTURE3D as a second case falling into the same
SOGL_NEED_3DTEXCOORDS branch as CUBEMAP.

Found via a -Wswitch-enum audit (154 raw warnings / 53 unique switch
sites, 15 in third-party expat code); this was the only genuine gap
among the 38 sites in Coin's own code.

---
**Verified:** Full clean rebuild under GCC and clang (Linux) with the strict warning recipe (`-Wall -Wextra -Wpedantic` plus the specific flag(s) this fixes), `ctest` (1/1 pass), and a Debug build under AddressSanitizer/UndefinedBehaviorSanitizer running the full `CoinTests` suite with no new findings.

Also verified on Windows (MSVC / Visual Studio 17 2022, x64 Release, /W4): built and tested together with all sibling branches from this audit (merged into a local integration build), 0 errors, full `CoinTests` suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FHRXMxksBcEGfbN5bDVJzb
