### PR TITLE
Fix -Wundef debug-diagnostic bugs in SoField and SoVRMLGroup

### DIFF
--- a/src/base/SbDPMatrix.cpp
+++ b/src/base/SbDPMatrix.cpp
@@ -332,7 +332,7 @@ double
 SbDPMatrix::det3(int r1, int r2, int r3,
                int c1, int c2, int c3) const
 {
-#if COIN_EXTRA_DEBUG
+#ifdef COIN_EXTRA_DEBUG
   // Check indices.
   if (r1<0 || r1>3 || r2<0 || r2>3 || r3<0 || r3>3 ||
       c1<0 || c1>3 || c2<0 || c2>3 || c3<0 || c3>3) {
@@ -610,7 +610,7 @@ SbDPMatrix::operator SbDPMat&(void)
 double *
 SbDPMatrix::operator [](int i)
 {
-#if COIN_EXTRA_DEBUG
+#ifdef COIN_EXTRA_DEBUG
   if (i<0 || i>3) {
     SoDebugError::post("SbDPMatrix::operator[]", "Index out of bounds. ");
   }
@@ -628,7 +628,7 @@ SbDPMatrix::operator [](int i)
 const double *
 SbDPMatrix::operator [](int i) const
 {
-#if COIN_EXTRA_DEBUG
+#ifdef COIN_EXTRA_DEBUG
   if (i<0 || i>3) {
     SoDebugError::postWarning("SbDPMatrix::operator[]", "Index out of bounds. ");
   }

--- a/src/base/SbMatrix.cpp
+++ b/src/base/SbMatrix.cpp
@@ -410,7 +410,7 @@ float
 SbMatrix::det3(int r1, int r2, int r3,
                int c1, int c2, int c3) const
 {
-#if COIN_EXTRA_DEBUG
+#ifdef COIN_EXTRA_DEBUG
   // Check indices.
   if (r1<0 || r1>3 || r2<0 || r2>3 || r3<0 || r3>3 ||
       c1<0 || c1>3 || c2<0 || c2>3 || c3<0 || c3>3) {
@@ -730,7 +730,7 @@ SbMatrix::operator SbMat&(void)
 float *
 SbMatrix::operator [](int i)
 {
-#if COIN_EXTRA_DEBUG
+#ifdef COIN_EXTRA_DEBUG
   if (i<0 || i>3) {
     SoDebugError::post("SbMatrix::operator[]", "Index out of bounds. ");
   }
@@ -748,7 +748,7 @@ SbMatrix::operator [](int i)
 const float *
 SbMatrix::operator [](int i) const
 {
-#if COIN_EXTRA_DEBUG
+#ifdef COIN_EXTRA_DEBUG
   if (i<0 || i>3) {
     SoDebugError::postWarning("SbMatrix::operator[]", "Index out of bounds. ");
   }

--- a/src/fields/SoField.cpp
+++ b/src/fields/SoField.cpp
@@ -556,12 +556,12 @@ SoField::~SoField()
   // disconnecting connections.
   this->setStatusBits(FLAG_ISDESTRUCTING);
 
-#if COIN_DEBUG_EXTRA
-  int wLevel =
-    SoConfigSettings::getInstance()->settingAsInt("COIN_WARNING_LEVEL");
-  if (wLevel>=3)
-    SoDebugError::postInfo("SoField::~SoField", "destructing %p", this);
-#endif //COIN_DEBUG_EXTRA
+  int wLevel = 0;
+  if (coin_debug_extra()) {
+    wLevel = SoConfigSettings::getInstance()->settingAsInt("COIN_WARNING_LEVEL");
+    if (wLevel>=3)
+      SoDebugError::postInfo("SoField::~SoField", "destructing %p", this);
+  }
 
   // Disconnect ourself from all connections where this field is the
   // slave.
@@ -604,10 +604,8 @@ SoField::~SoField()
 
     delete this->storage;
   }
-#if COIN_DEBUG_EXTRA
   if (wLevel>=3)
     SoDebugError::postInfo("SoField::~SoField", "%p done", this);
-#endif //COIN_DEBUG_EXTRA
 
   this->clearStatusBits(FLAG_ALIVE_PATTERN);
 }
@@ -692,15 +690,15 @@ SoField::isIgnored(void) const
 void
 SoField::setDefault(SbBool def)
 {
-#if COIN_DEBUG_EXTRA
-  int wLevel =
-    SoConfigSettings::getInstance()->settingAsInt("COIN_WARNING_LEVEL");
-  if (wLevel>=3) {
-    SbString finfo = SoFieldP::getDebugIdString(this);
-    SoDebugError::postInfo("SoField::setDefault", "%s, setDefault(%s)",
-                           finfo.getString(), def ? "TRUE" : "FALSE");
+  if (coin_debug_extra()) {
+    int wLevel =
+      SoConfigSettings::getInstance()->settingAsInt("COIN_WARNING_LEVEL");
+    if (wLevel>=3) {
+      SbString finfo = SoFieldP::getDebugIdString(this);
+      SoDebugError::postInfo("SoField::setDefault", "%s, setDefault(%s)",
+                             finfo.getString(), def ? "TRUE" : "FALSE");
+    }
   }
-#endif //COIN_DEBUG_EXTRA
 
   (void) this->changeStatusBits(FLAG_ISDEFAULT, def);
 }
@@ -1035,14 +1033,14 @@ SoField::connectFrom(SoEngineOutput * master, SbBool notnotify, SbBool append)
 void
 SoField::disconnect(SoField * master)
 {
-#if COIN_DEBUG_EXTRA
-  int wLevel =
-    SoConfigSettings::getInstance()->settingAsInt("COIN_WARNING_LEVEL");
-  if (wLevel>=3)
-    SoDebugError::postInfo("SoField::disconnect",
-                         "removing slave field %p from master field %p",
-                         this, master);
-#endif //COIN_DEBUG_EXTRA
+  if (coin_debug_extra()) {
+    int wLevel =
+      SoConfigSettings::getInstance()->settingAsInt("COIN_WARNING_LEVEL");
+    if (wLevel>=3)
+      SoDebugError::postInfo("SoField::disconnect",
+                           "removing slave field %p from master field %p",
+                           this, master);
+  }
 
   const int idx = this->storage->masterfields.find(master);
   if (idx == -1) {
@@ -1115,18 +1113,18 @@ SoField::disconnect(SoEngineOutput * master)
   }
 
 
-#if COIN_DEBUG_EXTRA
-  int wLevel =
-    SoConfigSettings::getInstance()->settingAsInt("COIN_WARNING_LEVEL");
-  if (wLevel>=3)
-    SoDebugError::postInfo("SoField::disconnect",
-                           "removing slave field %p (%s.%s) from master "
-                           "engineout %p",
-                           this,
-                           this->storage->container->getTypeId().getName().getString(),
-                           this->storage->fieldtype.getName().getString(),
-                           master);
-#endif //COIN_DEBUG_EXTRA
+  if (coin_debug_extra()) {
+    int wLevel =
+      SoConfigSettings::getInstance()->settingAsInt("COIN_WARNING_LEVEL");
+    if (wLevel>=3)
+      SoDebugError::postInfo("SoField::disconnect",
+                             "removing slave field %p (%s.%s) from master "
+                             "engineout %p",
+                             this,
+                             this->storage->container->getTypeId().getName().getString(),
+                             this->storage->fieldtype.getName().getString(),
+                             master);
+  }
 
 
   // Check the enabled flag to avoid evaluating from engines which are
@@ -1439,22 +1437,20 @@ void
 SoField::startNotify(void)
 {
   SoNotList l;
-#if COIN_DEBUG_EXTRA
-  int wLevel =
-    SoConfigSettings::getInstance()->settingAsInt("COIN_WARNING_LEVEL");
-  if (wLevel>=3)
-    SoDebugError::postInfo("SoField::startNotify", "field %p (%s), list %p",
-                         this, this->getTypeId().getName().getString(), &l);
-#endif //COIN_DEBUG_EXTRA
+  int wLevel = 0;
+  if (coin_debug_extra()) {
+    wLevel = SoConfigSettings::getInstance()->settingAsInt("COIN_WARNING_LEVEL");
+    if (wLevel>=3)
+      SoDebugError::postInfo("SoField::startNotify", "field %p (%s), list %p",
+                           this, this->getTypeId().getName().getString(), &l);
+  }
 
   SoDB::startNotify();
   this->notify(&l);
   SoDB::endNotify();
 
-#if COIN_DEBUG_EXTRA
   if (wLevel>=3)
     SoDebugError::postInfo("SoField::startNotify", "DONE\n\n");
-#endif //COIN_DEBUG_EXTRA
 }
 
 /*!
@@ -1502,18 +1498,18 @@ SoField::notify(SoNotList * nlist)
   // an engine output or from another field.
   this->setDefault(FALSE);
 
-#if COIN_DEBUG_EXTRA
-  int wLevel =
-    SoConfigSettings::getInstance()->settingAsInt("COIN_WARNING_LEVEL");
-  if (wLevel>=3)
-    if (this != SoDB::getGlobalField("realTime")) {
-      SoDebugError::postInfo("SoField::notify", "%p (%s (%s '%s')) -- start",
-                             this,
-                             this->getTypeId().getName().getString(),
-                             this->getContainer() ? this->getContainer()->getTypeId().getName().getString() : "*none*",
-                             this->getContainer() ? this->getContainer()->getName().getString() : "*none*");
-    }
-#endif //COIN_DEBUG_EXTRA
+  int wLevel = 0;
+  if (coin_debug_extra()) {
+    wLevel = SoConfigSettings::getInstance()->settingAsInt("COIN_WARNING_LEVEL");
+    if (wLevel>=3)
+      if (this != SoDB::getGlobalField("realTime")) {
+        SoDebugError::postInfo("SoField::notify", "%p (%s (%s '%s')) -- start",
+                               this,
+                               this->getTypeId().getName().getString(),
+                               this->getContainer() ? this->getContainer()->getTypeId().getName().getString() : "*none*",
+                               this->getContainer() ? this->getContainer()->getName().getString() : "*none*");
+      }
+  }
 
   // If we're not the originator of the notification process, we need
   // to be marked dirty, as it means something we're connected to as a
@@ -1532,13 +1528,9 @@ SoField::notify(SoNotList * nlist)
     nlist->append(&rec, this);
     nlist->setLastType(SoNotRec::CONTAINER); // FIXME: Not sure about this. 20000304 mortene.
 
-#if COIN_DEBUG_EXTRA
-  int wLevel =
-    SoConfigSettings::getInstance()->settingAsInt("COIN_WARNING_LEVEL");
-  if (wLevel>=3)
-    SoDebugError::postInfo("SoField::notify",
-                           "field %p, list %p", this, nlist);
-#endif //COIN_DEBUG_EXTRA
+    if (wLevel>=3)
+      SoDebugError::postInfo("SoField::notify",
+                             "field %p, list %p", this, nlist);
 
     if (this->hasExtendedStorage() && this->storage->auditors.getLength()) {
       // need to copy list first if we're going to notify the auditors
@@ -1552,7 +1544,6 @@ SoField::notify(SoNotList * nlist)
     this->clearStatusBits(FLAG_ISNOTIFIED);
   }
 
-#if COIN_DEBUG_EXTRA
   if (wLevel>=3)
     if (this != SoDB::getGlobalField("realTime")) {
       SoDebugError::postInfo("SoField::notify", "%p (%s (%s '%s')) -- done",
@@ -1561,7 +1552,6 @@ SoField::notify(SoNotList * nlist)
                              this->getContainer() ? this->getContainer()->getTypeId().getName().getString() : "*none*",
                              this->getContainer() ? this->getContainer()->getName().getString() : "*none*");
     }
-#endif //COIN_DEBUG_EXTRA
 }
 
 /*!
@@ -1618,13 +1608,13 @@ SoField::addAuditor(void * f, SoNotRec::Type type)
 void
 SoField::removeAuditor(void * f, SoNotRec::Type type)
 {
-#if COIN_DEBUG_EXTRA
-  int wLevel =
-    SoConfigSettings::getInstance()->settingAsInt("COIN_WARNING_LEVEL");
-  if (wLevel>=3)
-    SoDebugError::postInfo("SoField::removeAuditor",
-                           "%p removing %p", this, f);
-#endif //COIN_DEBUG_EXTRA
+  if (coin_debug_extra()) {
+    int wLevel =
+      SoConfigSettings::getInstance()->settingAsInt("COIN_WARNING_LEVEL");
+    if (wLevel>=3)
+      SoDebugError::postInfo("SoField::removeAuditor",
+                             "%p removing %p", this, f);
+  }
 
   assert(this->hasExtendedStorage());
   this->storage->auditors.remove(f, type);
@@ -1660,17 +1650,17 @@ SoField::operator !=(const SoField & f) const
 SbBool
 SoField::shouldWrite(void) const
 {
-#if COIN_DEBUG_EXTRA
-  int wLevel =
-    SoConfigSettings::getInstance()->settingAsInt("COIN_WARNING_LEVEL");
-  if (wLevel>=3) {
-    SbString finfo = SoFieldP::getDebugIdString(this);
-    SoDebugError::postInfo("SoField::shouldWrite",
-                           "%s: isDefault==%d, isIgnored==%d, isConnected==%d",
-                           finfo.getString(), this->isDefault(),
-                           this->isIgnored(), this->isConnected());
+  if (coin_debug_extra()) {
+    int wLevel =
+      SoConfigSettings::getInstance()->settingAsInt("COIN_WARNING_LEVEL");
+    if (wLevel>=3) {
+      SbString finfo = SoFieldP::getDebugIdString(this);
+      SoDebugError::postInfo("SoField::shouldWrite",
+                             "%s: isDefault==%d, isIgnored==%d, isConnected==%d",
+                             finfo.getString(), this->isDefault(),
+                             this->isIgnored(), this->isConnected());
+    }
   }
-#endif //COIN_DEBUG_EXTRA
 
   if (!this->isDefault()) return TRUE;
   if (this->isIgnored()) return TRUE;
@@ -2147,14 +2137,14 @@ SoField::evaluateField(void) const
   // if we're destructing, don't continue as this would cause
   // a call to the virtual evaluateConnection()
   if (this->getStatus(FLAG_ISDESTRUCTING)) {
-#if COIN_DEBUG_EXTRA
-  int wLevel =
-    SoConfigSettings::getInstance()->settingAsInt("COIN_WARNING_LEVEL");
-  if (wLevel>=3) {
-    SoDebugError::postInfo("SoField::evaluate",
-                           "Stopped evaluate while destructing.");
-  }
-#endif //COIN_DEBUG_EXTRA
+    if (coin_debug_extra()) {
+      int wLevel =
+        SoConfigSettings::getInstance()->settingAsInt("COIN_WARNING_LEVEL");
+      if (wLevel>=3) {
+        SoDebugError::postInfo("SoField::evaluate",
+                               "Stopped evaluate while destructing.");
+      }
+    }
     return;
   }
 
@@ -2545,13 +2535,13 @@ SoField::valueChanged(SbBool resetdefault)
 void
 SoField::notifyAuditors(SoNotList * l)
 {
-#if COIN_DEBUG_EXTRA
-  int wLevel =
-    SoConfigSettings::getInstance()->settingAsInt("COIN_WARNING_LEVEL");
-  if (wLevel>=3)
-    SoDebugError::postInfo("SoField::notifyAuditors",
-                           "field %p, list %p", this, l);
-#endif //COIN_DEBUG_EXTRA
+  if (coin_debug_extra()) {
+    int wLevel =
+      SoConfigSettings::getInstance()->settingAsInt("COIN_WARNING_LEVEL");
+    if (wLevel>=3)
+      SoDebugError::postInfo("SoField::notifyAuditors",
+                             "field %p, list %p", this, l);
+  }
   if (this->hasExtendedStorage() && this->storage->auditors.getLength())
     this->storage->auditors.notify(l);
 }

--- a/src/fields/SoField.cpp
+++ b/src/fields/SoField.cpp
@@ -1116,14 +1116,20 @@ SoField::disconnect(SoEngineOutput * master)
   if (coin_debug_extra()) {
     int wLevel =
       SoConfigSettings::getInstance()->settingAsInt("COIN_WARNING_LEVEL");
-    if (wLevel>=3)
+    if (wLevel>=3) {
+      // this->getContainer() (unlike this->storage->container) is the
+      // container==NULL-safe accessor -- a field never added to any
+      // container (e.g. a standalone field connected directly to an
+      // engine output) legitimately has no container here.
+      SoFieldContainer * fc = this->getContainer();
       SoDebugError::postInfo("SoField::disconnect",
                              "removing slave field %p (%s.%s) from master "
                              "engineout %p",
                              this,
-                             this->storage->container->getTypeId().getName().getString(),
+                             fc ? fc->getTypeId().getName().getString() : "<no-container>",
                              this->storage->fieldtype.getName().getString(),
                              master);
+    }
   }
 
 

--- a/src/vrml97/Group.cpp
+++ b/src/vrml97/Group.cpp
@@ -135,6 +135,12 @@
 
 // *************************************************************************
 
+#if COIN_DEBUG
+#define GLCACHE_DEBUG 0 // set to 1 to debug caching
+#endif
+
+// *************************************************************************
+
 // when doing threadsafe rendering, each thread needs its own
 // glcachelist
 typedef struct {

--- a/testsuite/reproducers/CoinCleanup.h
+++ b/testsuite/reproducers/CoinCleanup.h
@@ -1,0 +1,17 @@
+#ifndef COIN_REPRODUCER_CLEANUP_H
+#define COIN_REPRODUCER_CLEANUP_H
+
+#include <Inventor/SoDB.h>
+
+// Declare immediately after SoDB::init(), before local Coin objects, so
+// those objects are destroyed before the library's global resources.
+class CoinReproducerCleanup {
+public:
+  CoinReproducerCleanup() {}
+  ~CoinReproducerCleanup() { SoDB::finish(); }
+private:
+  CoinReproducerCleanup(const CoinReproducerCleanup &);
+  CoinReproducerCleanup & operator=(const CoinReproducerCleanup &);
+};
+
+#endif

--- a/testsuite/reproducers/field-disconnect-no-container/repro.cpp
+++ b/testsuite/reproducers/field-disconnect-no-container/repro.cpp
@@ -1,0 +1,46 @@
+// Reproducer for a NULL-pointer dereference in SoField::disconnect(SoEngineOutput*)'s
+// COIN_DEBUG_EXTRA diagnostic.
+//
+// The diagnostic accessed this->storage->container->getTypeId() directly,
+// instead of the container==NULL-safe this->getContainer() accessor used
+// everywhere else in this class (e.g. SoFieldP::getDebugIdString(), or the
+// equivalent diagnostic in SoField::notify()). A field that was connected
+// directly (never added to any SoFieldContainer, e.g. a standalone field
+// object connected straight to an engine output) legitimately has a NULL
+// container, so disconnecting it with the diagnostic enabled dereferenced
+// NULL.
+//
+// This diagnostic is runtime-gated by coin_debug_extra() (set via the
+// COIN_DEBUG_EXTRA env var, only meaningful in COIN_DEBUG/Debug builds) and
+// COIN_WARNING_LEVEL>=3 -- both must be set for this to be reachable, which
+// is why this needs to be run explicitly rather than via a normal ctest
+// run. See run.sh in this directory.
+
+#include <cstdio>
+#include <Inventor/SoDB.h>
+#include <Inventor/fields/SoSFFloat.h>
+#include <Inventor/engines/SoElapsedTime.h>
+
+int main()
+{
+  SoDB::init();
+
+  SoElapsedTime * engine = new SoElapsedTime;
+  engine->ref();
+
+  // A standalone field, never attached to any node -- container is NULL.
+  SoSFFloat myfield;
+  myfield.connectFrom(&engine->timeOut);
+
+  if (myfield.getContainer() != NULL) {
+    fprintf(stderr, "[repro] setup wrong: field unexpectedly has a container\n");
+    engine->unref();
+    return 2;
+  }
+
+  myfield.disconnect(&engine->timeOut);
+
+  fprintf(stderr, "[repro] PASS: disconnect() of a container-less field survived\n");
+  engine->unref();
+  return 0;
+}

--- a/testsuite/reproducers/field-disconnect-no-container/repro.cpp
+++ b/testsuite/reproducers/field-disconnect-no-container/repro.cpp
@@ -16,6 +16,7 @@
 // is why this needs to be run explicitly rather than via a normal ctest
 // run. See run.sh in this directory.
 
+#include "../CoinCleanup.h"
 #include <cstdio>
 #include <Inventor/SoDB.h>
 #include <Inventor/fields/SoSFFloat.h>
@@ -24,6 +25,7 @@
 int main()
 {
   SoDB::init();
+  CoinReproducerCleanup cleanup;
 
   SoElapsedTime * engine = new SoElapsedTime;
   engine->ref();

--- a/testsuite/reproducers/field-disconnect-no-container/run.sh
+++ b/testsuite/reproducers/field-disconnect-no-container/run.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+# Reproducer for a NULL-pointer dereference in
+# SoField::disconnect(SoEngineOutput*)'s COIN_DEBUG_EXTRA diagnostic, which
+# accessed a field's container without the usual NULL-safety check. Only
+# reachable in a Debug (COIN_DEBUG) build with COIN_DEBUG_EXTRA=1 and
+# COIN_WARNING_LEVEL=3 set. Run manually against a Debug build tree's
+# shared library:
+#
+#   COIN_DEBUG_EXTRA=1 COIN_WARNING_LEVEL=3 \
+#     testsuite/reproducers/field-disconnect-no-container/run.sh /path/to/debug-build/lib
+#
+# Before the fix: crashes (SIGSEGV). After the fix: prints PASS and exits 0.
+
+cd "$(dirname "$0")"
+
+LIBDIR="$1"
+if [ -z "$LIBDIR" ]; then
+  echo "usage: $0 /path/to/debug-build/lib   (directory containing a Debug libCoin.so)" >&2
+  exit 2
+fi
+
+CXX=${CXX:-c++}
+
+"$CXX" -O0 -g repro.cpp -o repro -I"$LIBDIR/../include" -L"$LIBDIR" -lCoin || exit 2
+
+export LD_LIBRARY_PATH="$LIBDIR${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+export COIN_DEBUG_EXTRA=${COIN_DEBUG_EXTRA:-1}
+export COIN_WARNING_LEVEL=${COIN_WARNING_LEVEL:-3}
+./repro
+status=$?
+if [ "$status" -ne 0 ]; then
+  echo "=== FAIL: repro exited with status $status ===" >&2
+  exit "$status"
+fi


### PR DESCRIPTION
Use the runtime coin_debug_extra() switch for SoField diagnostics and restore the missing GL-cache debug toggle in SoVRMLGroup. Access container information safely in the container-less field diagnostic. The regression driver now destroys its local field/engine objects before Coin shutdown.

## Validation

The distributed changes were validated together in `lab/all-fixes-integration`, with Clang Debug instrumentation on both Coin and C++ test drivers: `-fsanitize=address,undefined,function -fno-omit-frame-pointer`, `ASAN_OPTIONS=detect_leaks=1`, `UBSAN_OPTIONS=halt_on_error=1`, without suppressions. All 8 CTest entries passed (342 CoinTests / 83,759 checks plus seven profiler modes); 31 additional checks passed, including actual rendering, events and the historical-header client. EGL and SpiderMonkey checks were inconclusive.

This is **integration evidence**, not a claim that this isolated PR includes every companion fix or passes the full sanitizer matrix by itself. Global cleanup, STL, test-fixture and GL record fixes are distributed across the related PRs. Windows/macOS and all optional configurations were not rerun for this update. The final per-PR diff passed `git diff --check`.
