### PR TITLE
Fix -Wunused-but-set-variable warnings (54 sites across 27 files)

### DIFF
--- a/src/base/rbptree.cpp
+++ b/src/base/rbptree.cpp
@@ -266,14 +266,12 @@ static void
 rbptree_delete_fixup(cc_rbptree * t, cc_rbptree_node * x)
 {
   /* page 274 */
-  cc_rbptree_node * w, * nil;
-
-  nil = &rbptree_sentinel;
+  cc_rbptree_node * w;
 
   while (x != t->root && x->color == RBPTREE_BLACK) {
     if (x == x->parent->left) { /* x is left child */
       w = x->parent->right;
-      assert(w != nil);
+      assert(w != &rbptree_sentinel);
       if (w->color == RBPTREE_RED) {
         w->color = RBPTREE_BLACK;
         x->parent->color = RBPTREE_RED;
@@ -300,7 +298,7 @@ rbptree_delete_fixup(cc_rbptree * t, cc_rbptree_node * x)
     }
     else { /* x is right child */
       w = x->parent->left;
-      assert(w != nil);
+      assert(w != &rbptree_sentinel);
       if (w->color == RBPTREE_RED) {
         w->color = RBPTREE_BLACK;
         x->parent->color = RBPTREE_RED;

--- a/src/fields/SoFieldContainer.cpp
+++ b/src/fields/SoFieldContainer.cpp
@@ -876,10 +876,8 @@ SoFieldContainer::addCopy(const SoFieldContainer * orig,
   assert(copiedinstances);
   assert(contentscopied);
 
-  SbBool s = copiedinstances->put(orig, copy);
-  assert(s);
-  s = contentscopied->put(orig, FALSE);
-  assert(s);
+  if (!copiedinstances->put(orig, copy)) assert(!"put(orig, copy) failed");
+  if (!contentscopied->put(orig, FALSE)) assert(!"put(orig, FALSE) failed");
 }
 
 
@@ -985,8 +983,7 @@ SoFieldContainer::findCopy(const SoFieldContainer * orig,
   // this is handled by the Proto node.
   if (!protoinst) {
     SbBool copied = FALSE;
-    SbBool chk = contentscopied->get(orig, copied);
-    assert(chk);
+    if (!contentscopied->get(orig, copied)) assert(!"get(orig, copied) failed");
 
     if (!copied) {
       // we have to update the dictionary _before_ calling
@@ -998,8 +995,7 @@ SoFieldContainer::findCopy(const SoFieldContainer * orig,
       // }
       //
       // pederb, 2002-09-04
-      chk = contentscopied->put(orig, TRUE);
-      assert(!chk && "the key already exists");
+      if (contentscopied->put(orig, TRUE)) assert(!"the key already exists");
       cp->copyContents(orig, copyconnections);
     }
   }
@@ -1096,7 +1092,6 @@ SoFieldContainer::getFieldsMemorySize(size_t & managed, size_t & unmanaged) cons
       // well as the multi-fields
 
       const SoSField * sfield = static_cast<const SoSField *>(field);
-      SoType sftype = sfield->getTypeId();
 
       if (sfield->getTypeId().isDerivedFrom(SoSFImage::getClassTypeId())) {
         const SoSFImage * imgfield = static_cast<const SoSFImage *>(sfield);

--- a/src/fonts/freetype.cpp
+++ b/src/fonts/freetype.cpp
@@ -396,7 +396,7 @@ cc_flwft_initialize(void)
     unsigned int i = 0;
     while (i < sizeof(fontfilenames) / sizeof(fontfilenames[0])) {
       void * val;
-      SbBool found, unused;
+      SbBool found;
       cc_dynarray * array;
       const uintptr_t key = (uintptr_t)cc_namemap_get_address(fontfilenames[i]);
 
@@ -406,8 +406,7 @@ cc_flwft_initialize(void)
       }
       else {
         array = cc_dynarray_new();
-        unused = cc_dict_put(cc_flwft_globals.fontname2filename, key, array);
-        assert(unused);
+        if (!cc_dict_put(cc_flwft_globals.fontname2filename, key, array)) assert(!"cc_dict_put failed");
       }
 
       while (fontfilenames[++i] != NULL) {
@@ -818,14 +817,14 @@ cc_flwft_get_glyph(void * font, unsigned int charidx)
 void
 cc_flwft_get_vector_advance(void * font, int glyph, float *x, float *y)
 {
-  FT_Error error;
   FT_Face face;
   float tmp;
 
   assert(font);
   face = (FT_Face)font;
-  error = cc_ftglue_FT_Load_Glyph(face, glyph, FT_LOAD_DEFAULT);
-  assert(error == 0 && "FT_Load_Glyph() unexpected failure, investigate");
+  if (cc_ftglue_FT_Load_Glyph(face, glyph, FT_LOAD_DEFAULT) != 0) {
+    assert(!"FT_Load_Glyph() unexpected failure, investigate");
+  }
 
   tmp = face->glyph->advance.x * flwft_tessellator.vertex_scale;
   x[0] = (tmp / 64.0f) / flwft_3dfontsize;

--- a/src/fonts/glyph.cpp
+++ b/src/fonts/glyph.cpp
@@ -56,7 +56,6 @@ void
 cc_glyph_unref(cc_dict * dict, cc_glyph * glyph, cc_glyph_finalize * f)
 {
   cc_list * glyphlist;
-  int ret;
   void * tmp;
   int i;
 
@@ -70,8 +69,7 @@ cc_glyph_unref(cc_dict * dict, cc_glyph * glyph, cc_glyph_finalize * f)
 
   /* handling of common data: */
 
-  ret = cc_dict_get(dict, (uintptr_t)glyph->character, &tmp);
-  assert(ret);
+  if (!cc_dict_get(dict, (uintptr_t)glyph->character, &tmp)) assert(!"cc_dict_get failed");
   glyphlist = (cc_list *)tmp;
     
   for (i = 0; i < cc_list_get_length(glyphlist); i++) {

--- a/src/geo/SbPolarStereographic.cpp
+++ b/src/geo/SbPolarStereographic.cpp
@@ -120,7 +120,6 @@ SbPolarStereographic::unproject(const double easting,
   double a = this->ellipsoid.getA();
   double e = this->ellipsoid.getE();
 
-  SbGeoAngle phiF = this->ellipsoid.getLatStdParallel();
   SbGeoAngle lambda0 = this->ellipsoid.getLongOrigin();
 
   double e2 = e * e;

--- a/src/glue/freetype.cpp
+++ b/src/glue/freetype.cpp
@@ -449,10 +449,10 @@ cc_ftglue_FT_Library_Version(void * library, int * major, int * minor, int * pat
 void 
 cc_ftglue_FT_Done_FreeType(void * library)
 {
-  FT_Error err;
   assert(freetype_instance && freetype_instance->available);
-  err = freetype_instance->FT_Done_FreeType(library);
-  assert(err == 0 && "something bad happened at FreeType exit");
+  if (freetype_instance->FT_Done_FreeType(library) != 0) {
+    assert(!"something bad happened at FreeType exit");
+  }
 }
 
 FT_Error 

--- a/src/hardcopy/VectorizeActionP.cpp
+++ b/src/hardcopy/VectorizeActionP.cpp
@@ -552,9 +552,6 @@ SoVectorizeActionP::pre_text2_cb(void * userdata,
   if (nilpoint[2] < 0.0f || nilpoint[2] > 1.0f) 
     return SoCallbackAction::CONTINUE;;
 
-  const SbViewportRegion & vp = SoViewportRegionElement::get(state);
-  SbVec2s vpsize = vp.getViewportSizePixels();
-
   SbName fontname = SoFontNameElement::get(state);
   float fontsize = SoFontSizeElement::get(state); // in pixels
 
@@ -937,7 +934,8 @@ SoVectorizeActionP::shade_vertex(SoState * state,
 
   return SbColor4f(SbClamp(R, 0.0f, 1.0f),
                    SbClamp(G, 0.0f, 1.0f),
-                   SbClamp(B, 0.0f, 1.0f));
+                   SbClamp(B, 0.0f, 1.0f),
+                   A);
 }
 
 //

--- a/src/io/SoInput_FileInfo.cpp
+++ b/src/io/SoInput_FileInfo.cpp
@@ -582,9 +582,7 @@ SoInput_FileInfo::readInteger(int32_t & l)
   assert(!this->isBinary());
   readString.clear();
   char c;
-  SbBool minus = FALSE;
   if (this->readChar(&c, '-')) {
-    minus = TRUE;
     readString += c;
   }
   else if (this->readChar(&c, '+')) {

--- a/src/misc/SoDB.cpp
+++ b/src/misc/SoDB.cpp
@@ -1620,11 +1620,13 @@ SoDB::createRoute(SoNode * fromnode, const char * eventout,
       }
     }
 
-    SbBool ok;
-    if (from) ok = to->connectFrom(from, notnotify, append);
-    else ok = to->connectFrom(output, notnotify, append);
     // Both known possible failure points are caught above.
-    assert(ok && "unexpected connection error");
+    if (from) {
+      if (!to->connectFrom(from, notnotify, append)) assert(!"unexpected connection error");
+    }
+    else {
+      if (!to->connectFrom(output, notnotify, append)) assert(!"unexpected connection error");
+    }
   }
 #if COIN_DEBUG
   else {

--- a/src/misc/SoDBP.cpp
+++ b/src/misc/SoDBP.cpp
@@ -60,15 +60,17 @@ forward_sprintf(char * dst, unsigned int realdstlen, const char * fmtstr, ...)
 
   // This first call is just to get one invocation of va_arg() done
   // from the system's vsnprintf().
-  int len = coin_vsnprintf(dst, (unsigned int)(strlen(fmtstr) - 1), fmtstr, args);
-  assert(len == -1);
+  if (coin_vsnprintf(dst, (unsigned int)(strlen(fmtstr) - 1), fmtstr, args) != -1) {
+    assert(!"unexpected coin_vsnprintf() return value");
+  }
 
   // The next call is made to see whether or not additional
   // invocations of vsnprintf() on the system without an intervening
   // va_start()/va_end() pair will cause va_arg() to start picking up
   // arguments after the end of the actual argument list.
-  len = coin_vsnprintf(dst, realdstlen, fmtstr, args);
-  assert(len != -1);
+  if (coin_vsnprintf(dst, realdstlen, fmtstr, args) == -1) {
+    assert(!"unexpected coin_vsnprintf() return value");
+  }
 
   va_end(args);
 }

--- a/src/misc/SoGlyph.cpp
+++ b/src/misc/SoGlyph.cpp
@@ -314,8 +314,7 @@ SoGlyph::getBoundingBox(void) const
     // default. (20030926 handegar)    
     float advancex, advancey;
     cc_flw_get_vector_advance(PRIVATE(this)->fontidx, PRIVATE(this)->glyphidx, &advancex, &advancey);
-    SbVec2f max = PRIVATE(this)->bbox.getMax();
-    
+
     PRIVATE(this)->bbox.extendBy(SbVec2f(advancex, advancey));
    
     PRIVATE(thisp)->flags.didcalcbbox = 1;

--- a/src/misc/SoJavaScriptEngine.cpp
+++ b/src/misc/SoJavaScriptEngine.cpp
@@ -143,13 +143,11 @@ static void printJSException(JSContext *cx)
     return;
   }
 
-  SbBool ok;
   /* Todo: we loose unicode information here */
   cstr = spidermonkey()->JS_GetStringBytes(s);
   if (!cstr) {
     SoDebugError::postWarning("printJSException", "could not get string bytes");
-    ok = spidermonkey()->JS_RemoveRoot(cx, &s);
-    assert(ok && "JS_RemoveRoot failed");
+    if (!spidermonkey()->JS_RemoveRoot(cx, &s)) assert(!"JS_RemoveRoot failed");
     return;
   }
   len = spidermonkey()->JS_GetStringLength(s);
@@ -163,8 +161,7 @@ static void printJSException(JSContext *cx)
   const size_t wrote = fwrite(cstr, 1, len, stderr);
   assert(wrote == len);
   (void)fprintf(stderr, "\n");
-  ok = spidermonkey()->JS_RemoveRoot(cx, &s);
-  assert(ok && "JS_RemoveRoot failed");
+  if (!spidermonkey()->JS_RemoveRoot(cx, &s)) assert(!"JS_RemoveRoot failed");
 }
 
 /*!

--- a/src/misc/SoProto.cpp
+++ b/src/misc/SoProto.cpp
@@ -898,11 +898,13 @@ SoProto::createInstanceRoot(SoProtoInstance * inst) const
           }
         }
 
-        SbBool ok;
-        if (from) ok = to->connectFrom(from, notnotify, append);
-        else ok = to->connectFrom(output, notnotify, append);
         // Both known possible failure points are caught above.
-        assert(ok && "unexpected connection error");
+        if (from) {
+          if (!to->connectFrom(from, notnotify, append)) assert(!"unexpected connection error");
+        }
+        else {
+          if (!to->connectFrom(output, notnotify, append)) assert(!"unexpected connection error");
+        }
 
       }
     }

--- a/src/nodes/SoCamera.cpp
+++ b/src/nodes/SoCamera.cpp
@@ -465,7 +465,6 @@ SoCamera::getViewVolume(const SbViewportRegion & vp,
   if (adjustvp) {
     float cameraratio = this->aspectRatio.getValue();
     if (aspectratio != cameraratio) {
-      SbViewportRegion oldvp = resultvp;
       if (aspectratio < cameraratio) {
         resultvp.scaleHeight(aspectratio/cameraratio);
       }

--- a/src/nodes/SoExtSelection.cpp
+++ b/src/nodes/SoExtSelection.cpp
@@ -1233,9 +1233,6 @@ SoExtSelection::GLRenderBelowPath(SoGLRenderAction * action)
 
   if (action->isRenderingDelayedPaths()) {
 
-    SbViewportRegion vp = SoViewportRegionElement::get(state);
-    SbVec2s vpo = vp.getViewportOriginPixels();
-    SbVec2s vps = vp.getViewportSizePixels();
     this->draw(action);
   }
   // render this path after all other (delayed)

--- a/src/nodes/SoVertexAttribute.cpp
+++ b/src/nodes/SoVertexAttribute.cpp
@@ -285,13 +285,11 @@ SoVertexAttribute::GLRender(SoGLRenderAction * action)
   SoVertexAttribute::doAction((SoAction *) action);
 
   // check if vbo rendering should be used and create vbo if yes
-  SbBool setvbo = FALSE;
   // get data length but make sure that field has been created before (after typeName was set)
   int num = PRIVATE(this)->attributedata->data ? PRIVATE(this)->attributedata->data->getNum() : 0;
   SoBase::staticDataLock();
   if (SoGLVBOElement::shouldCreateVBO(state, num)) {
     SbBool dirty = FALSE;
-    setvbo = TRUE;
     if (PRIVATE(this)->attributedata->vbo == NULL) {
       PRIVATE(this)->attributedata->vbo = new SoVBO;
       dirty = TRUE;

--- a/src/profiler/SoNodeVisualize.cpp
+++ b/src/profiler/SoNodeVisualize.cpp
@@ -660,7 +660,6 @@ SoNodeVisualize::handleEvent(SoHandleEventAction * action)
   //REVIEW: BFG - Not sure what I'm doing here, the getDetail is
   //from an example source
   if (path->containsNode(shapenode) && pp->getDetail(shapenode) == NULL) {
-    SbVec3f point = pp->getPoint();
     this->clicked();
   }
 }

--- a/src/rendering/SoGLDriverDatabase.cpp
+++ b/src/rendering/SoGLDriverDatabase.cpp
@@ -516,38 +516,9 @@ SoGLDriverDatabaseP::findDriver(const cc_xml_elt * vendor, const cc_glglue * COI
       if (maxversionelement)
         maxversion = cc_xml_elt_get_cdata(maxversionelement);
 
-      unsigned int minversion_major = 0;
-      unsigned int minversion_minor = 0;
-      unsigned int minversion_micro = 0;
-      unsigned int minversion_nano = 0;
-      unsigned int maxversion_major = 0;
-      unsigned int maxversion_minor = 0;
-      unsigned int maxversion_micro = 0;
-      unsigned int maxversion_nano = 0;
-
       SbIntList indices;
-
       minversion.findAll(".", indices);
-
-      if (indices.getLength() >= 0)
-        minversion_major = atoi(minversion.getString());
-      if (indices.getLength() > 0)
-        minversion_minor = atoi(minversion.getSubString(indices[0] + 1).getString());
-      if (indices.getLength() > 1)
-        minversion_micro = atoi(minversion.getSubString(indices[1] + 1).getString());
-      if (indices.getLength() > 2)
-        minversion_nano = atoi(minversion.getSubString(indices[2] + 1).getString());
-
       maxversion.findAll(".", indices);
-
-      if (indices.getLength() >= 0)
-        maxversion_major = atoi(maxversion.getString());
-      if (indices.getLength() > 0)
-        maxversion_minor = atoi(maxversion.getSubString(indices[0] + 1).getString());
-      if (indices.getLength() > 1)
-        maxversion_micro = atoi(maxversion.getSubString(indices[1] + 1).getString());
-      if (indices.getLength() > 2)
-        maxversion_nano = atoi(maxversion.getSubString(indices[2] + 1).getString());
 
       //FIXME: Match Driver and add features.
       //Must probably use platform specific functions to be of any use.

--- a/src/rendering/SoGLNurbs.cpp
+++ b/src/rendering/SoGLNurbs.cpp
@@ -822,22 +822,16 @@ namespace {
     assert(fabs(v - vknotvec[numvknots-1]) < 1.e-12);
 
     // testing the findspan routine
-    int i = 0;
     // rechter rand
-    i = FindSpan(uknotvec[0], udegree, numuctrlpts, uknotvec);
-    assert( i == udegree );
+    assert( FindSpan(uknotvec[0], udegree, numuctrlpts, uknotvec) == udegree );
     // rechts ausserhalb
-    i = FindSpan(-1.0f, udegree, numuctrlpts, uknotvec);
-    assert( i == udegree );
+    assert( FindSpan(-1.0f, udegree, numuctrlpts, uknotvec) == udegree );
     // linker rand
-    i = FindSpan(uknotvec[numuknots-1], udegree, numuctrlpts, uknotvec);
-    assert( i == numuctrlpts-1 );
+    assert( FindSpan(uknotvec[numuknots-1], udegree, numuctrlpts, uknotvec) == numuctrlpts-1 );
     // links ausserhalb
-    i = FindSpan(uknotvec[numuknots-1]+1.0f, udegree, numuctrlpts, uknotvec);
-    assert( i == numuctrlpts-1 );
+    assert( FindSpan(uknotvec[numuknots-1]+1.0f, udegree, numuctrlpts, uknotvec) == numuctrlpts-1 );
     // erster Abschnitt
-    i = FindSpan((uknotvec[udegree+1]+uknotvec[udegree])/2.0f, udegree, numuctrlpts, uknotvec);
-    assert( i == udegree );
+    assert( FindSpan((uknotvec[udegree+1]+uknotvec[udegree])/2.0f, udegree, numuctrlpts, uknotvec) == udegree );
     //// zweiter Abschnitt
     //i = FindSpan((uknotvec[udegree+2]+uknotvec[udegree+1])/2.0f, udegree, numuctrlpts, uknotvec);
     //assert( i == udegree+2 );

--- a/src/rendering/SoRenderManager.cpp
+++ b/src/rendering/SoRenderManager.cpp
@@ -1086,7 +1086,6 @@ SoRenderManager::initStencilBufferForInterleavedStereo(void)
   const SbVec2s neworigin = currentvp.getViewportOriginPixels();
   const SbVec2s newsize = currentvp.getViewportSizePixels();
 
-  const SbVec2s oldorigin = PRIVATE(this)->stereostencilmaskvp.getViewportOriginPixels();
   const SbVec2s oldsize = PRIVATE(this)->stereostencilmaskvp.getViewportSizePixels();
 
   allocnewmask = allocnewmask ||

--- a/src/shadows/SoShadowGroup.cpp
+++ b/src/shadows/SoShadowGroup.cpp
@@ -949,8 +949,6 @@ SoShadowGroupP::updateShadowLights(SoGLRenderAction * action)
 
   if (!this->shadowlightsvalid) {
     int lightidoffset = SoLightElement::getLights(state).getLength();
-    float smoothing = PUBLIC(this)->smoothBorder.getValue();
-    smoothing = 0.0f; // FIXME: temporary until we have time to fix this feature
 
     int gaussmatrixsize = 0;
     float gaussstandarddeviation = 0.6f;

--- a/src/shapenodes/SoAsciiText.cpp
+++ b/src/shapenodes/SoAsciiText.cpp
@@ -536,7 +536,6 @@ void SoAsciiTextP::calculateStringStretch(const int i, const cc_font_specificati
   stretchfactor = master->width[i] / this->stringwidths[i];
 
   cc_glyph3d * prevglyph = NULL;
-  float originalmaxx = 0.0f;
   float originalmaxxpos = 0.0f;
   float originalxpos = 0.0f;
   float maxglyphwidth = 0.0f;
@@ -569,7 +568,6 @@ void SoAsciiTextP::calculateStringStretch(const int i, const cc_font_specificati
     float endx = originalxpos * stretchfactor + glyphwidth;
     if (endx > maxx) {
       originalmaxxpos = originalxpos;
-      originalmaxx = originalxpos + glyphwidth;
 
       maxx = endx;
       maxglyphwidth = glyphwidth;

--- a/src/threads/condvar.cpp
+++ b/src/threads/condvar.cpp
@@ -76,9 +76,9 @@
 void
 cc_condvar_struct_init(cc_condvar * condvar_struct)
 {
-  int ok;
-  ok = internal_condvar_struct_init(condvar_struct);
-  assert(ok == CC_OK);
+  if (internal_condvar_struct_init(condvar_struct) != CC_OK) {
+    assert(!"condvar struct init failed");
+  }
 }
 
 /*
@@ -87,10 +87,10 @@ cc_condvar_struct_init(cc_condvar * condvar_struct)
 void
 cc_condvar_struct_clean(cc_condvar * condvar_struct)
 {
-  int ok;
   assert(condvar_struct != NULL);
-  ok = internal_condvar_struct_clean(condvar_struct);
-  assert(ok == CC_OK);
+  if (internal_condvar_struct_clean(condvar_struct) != CC_OK) {
+    assert(!"condvar struct clean failed");
+  }
 }
 
 /* ********************************************************************** */
@@ -150,10 +150,10 @@ cc_condvar_timed_wait(cc_condvar * condvar,
 void
 cc_condvar_wake_one(cc_condvar * condvar)
 {
-  int ok;
   assert(condvar != NULL);
-  ok = internal_condvar_wake_one(condvar);
-  assert(ok == CC_OK);
+  if (internal_condvar_wake_one(condvar) != CC_OK) {
+    assert(!"condvar wake_one failed");
+  }
 }
 
 /*! Wake all threads waiting for the \a condvar conditional variable. */
@@ -161,10 +161,10 @@ cc_condvar_wake_one(cc_condvar * condvar)
 void
 cc_condvar_wake_all(cc_condvar * condvar)
 {
-  int ok;
   assert(condvar != NULL);
 
-  ok = internal_condvar_wake_all(condvar);
-  assert(ok == CC_OK);
+  if (internal_condvar_wake_all(condvar) != CC_OK) {
+    assert(!"condvar wake_all failed");
+  }
 }
 

--- a/src/threads/mutex.cpp
+++ b/src/threads/mutex.cpp
@@ -102,7 +102,7 @@ cc_mutex_struct_init(cc_mutex * mutex_struct)
 #else /* USE_W32THREAD */
   ok = internal_mutex_struct_init(mutex_struct);
 #endif /* ! USE_W32THREAD */
-  assert(ok);
+  if (!ok) assert(!"mutex struct init failed");
 }
 
 /*
@@ -122,7 +122,7 @@ cc_mutex_struct_clean(cc_mutex * mutex_struct)
 #else /* USE_W32THREAD */  
   ok = internal_mutex_struct_clean(mutex_struct);
 #endif /* ! USE_W32THREAD */
-  assert(ok == CC_OK);
+  if (ok != CC_OK) assert(!"mutex struct clean failed");
 }
 
 /**************************************************************************/
@@ -205,7 +205,7 @@ cc_mutex_lock(cc_mutex * mutex)
   ok = internal_mutex_lock(mutex);
 #endif /* USE_W32THREAD */
 
-  assert(ok == CC_OK);
+  if (ok != CC_OK) assert(!"mutex lock failed");
 
   /* This is here as an optional debugging aid, when having problems
      related to locks that are held too long. (Typically resulting in
@@ -260,7 +260,7 @@ cc_mutex_unlock(cc_mutex * mutex)
   ok = internal_mutex_unlock(mutex);
 #endif /* USE_W32THREAD */
 
-  assert(ok == CC_OK);
+  if (ok != CC_OK) assert(!"mutex unlock failed");
 }
 
 static cc_mutex * cc_global_mutex = NULL;

--- a/src/threads/thread.cpp
+++ b/src/threads/thread.cpp
@@ -129,10 +129,10 @@ cc_thread_construct(cc_thread_f * func, void * closure)
 void
 cc_thread_destruct(cc_thread * thread)
 {
-  int ok;
   assert(thread != NULL);
-  ok = internal_clean(thread);
-  assert(ok == CC_OK);
+  if (internal_clean(thread) != CC_OK) {
+    assert(!"thread cleanup failed");
+  }
   free(thread);
 }
 

--- a/src/tidbits.cpp
+++ b/src/tidbits.cpp
@@ -1386,8 +1386,6 @@ coin_get_stderr(void)
 SbBool
 coin_locale_set_portable(cc_string * storeold)
 {
-  const char * loc;
-
   const char * deflocale = setlocale(LC_NUMERIC, NULL);
   if (strcmp(deflocale, "C") == 0) { return FALSE; }
 
@@ -1396,8 +1394,9 @@ coin_locale_set_portable(cc_string * storeold)
   cc_string_construct(storeold);
   cc_string_set_text(storeold, deflocale);
 
-  loc = setlocale(LC_NUMERIC, "C");
-  assert(loc != NULL && "could not set locale to supposed portable C locale");
+  if (setlocale(LC_NUMERIC, "C") == NULL) {
+    assert(!"could not set locale to supposed portable C locale");
+  }
   return TRUE;
 }
 

--- a/src/vrml97/JS_VRMLClasses.cpp
+++ b/src/vrml97/JS_VRMLClasses.cpp
@@ -490,16 +490,20 @@ struct CoinVrmlJsMFHandler {
       jsval element;
       uint32_t i;
       uint32_t num;
-      JSBool ok = spidermonkey()->JS_GetArrayLength(cx, JSVAL_TO_OBJECT(*array), &num);
+      if (!spidermonkey()->JS_GetArrayLength(cx, JSVAL_TO_OBJECT(*array), &num)) {
+        assert(!"JS_GetArrayLength failed");
+      }
 
       SFFieldClass * field = (SFFieldClass *)SFFieldClass::createInstance();
 
       for (i=0; i<num; ++i) {
-        ok = spidermonkey()->JS_GetElement(cx, obj, i, &element);
-        assert(ok);
+        if (!spidermonkey()->JS_GetElement(cx, obj, i, &element)) {
+          assert(!"JS_GetElement failed");
+        }
 
-        ok = SoJavaScriptEngine::getEngine(cx)->jsval2field(element, field);
-        assert(ok && "jsval2field failed");
+        if (!SoJavaScriptEngine::getEngine(cx)->jsval2field(element, field)) {
+          assert(!"jsval2field failed");
+        }
         ((MFFieldClass *)f)->set1Value(i, field->getValue());
       }
       delete field;


### PR DESCRIPTION
## Summary

Three shapes, by far the dominant one being the same assert-is-a-noop-
in-release hazard already fixed for -Wunused-variable elsewhere in
this codebase (see 74204c497b): a side-effecting call's result is
assigned to a local and only ever checked via assert(), which
compiles out under NDEBUG, leaving the local genuinely unread in a
release build:

  - src/threads/{mutex,condvar,thread}.cpp (13 sites): every
    lock/unlock/init/clean/wake/wait wrapper around the platform
    thread primitives. Fixed by turning the trailing assert(ok [==
    CC_OK]) into an if/assert (mutex.cpp keeps `ok`, since it's
    assigned from different platform-#ifdef branches; condvar.cpp/
    thread.cpp collapse to `if (call() != CC_OK) assert(!"...")`
    since each has a single assignment site).
  - src/vrml97/JS_VRMLClasses.cpp (1 template site, 10 warnings from
    10 instantiations), src/misc/{SoDB,SoProto,SoJavaScriptEngine,
    SoDBP}.cpp, src/fields/SoFieldContainer.cpp (3 sites),
    src/fonts/{freetype,glyph}.cpp, src/glue/freetype.cpp,
    src/tidbits.cpp: same pattern, one call site each. tidbits.cpp
    and SoDBP.cpp needed care since their calls (setlocale(),
    coin_vsnprintf()) have real side effects that must still execute
    in release builds -- fixed by keeping the call as a plain
    statement and only wrapping the diagnostic comparison in the
    if/assert, never the call itself.
  - src/base/rbptree.cpp and src/rendering/SoGLNurbs.cpp: same
    consumption pattern but the right-hand side is a pure, side-
    effect-free expression (`&rbptree_sentinel`, `FindSpan(...)`), so
    here the call/expression was inlined directly into the assert
    instead, which is safe specifically because nothing depends on it
    running in release builds.

Second shape: purely dead output of an otherwise-relevant computation,
with no assert consuming it either -- SoFieldContainer.cpp's
`sftype`, SoGlyph.cpp's `max`, SoRenderManager.cpp's `oldorigin`,
SoAsciiText.cpp's `originalmaxx`, SoCamera.cpp's `oldvp`,
SoShadowGroup.cpp's `smoothing` (explicitly dead per its own "FIXME:
temporary until we have time to fix this feature" comment),
SoExtSelection.cpp's `vpo`/`vps` (and the `vp` they were the only
consumers of), VectorizeActionP.cpp's `vpsize` (and its sole producer
`vp`), SoNodeVisualize.cpp's `point`, SbPolarStereographic.cpp's
`phiF` (present and used in the sibling project() method, genuinely
unused in unproject()), SoVertexAttribute.cpp's `setvbo`, and 8
version-number locals in SoGLDriverDatabase.cpp::findDriver() feeding
a driver-matching feature its own comment says isn't implemented yet.
All of these are pure getters/literals with no side effect, so deleted
outright.

Third shape, a real bug found while investigating rather than a
hygiene issue: VectorizeActionP.cpp's shade_vertex() computes an
alpha value `A = SbClamp(vcolor[3], 0.0f, 1.0f)` for every vertex but
its return statement only ever passed 3 arguments to SbColor4f(r,g,b,
a=1.0f), silently defaulting alpha to fully opaque and discarding the
input vertex's actual transparency. Fixed by passing A through to the
constructor's 4th argument -- this is the one behavioral change in
this branch; every other file here is a pure warning fix with no
change to release-build behavior.

Verified: full clean rebuild shows the exact same warning breakdown as
master except -Wunused-but-set-variable 54->0 (859->805 total, zero
errors); full CoinTests suite passes (326 tests, 83566 checks) in both
a normal build and a Debug+ASan/UBSan build, with only the known
pre-existing, unrelated SbByteBufferP.icc UBSan finding present.

---
**Verified:** Full clean rebuild under GCC and clang (Linux) with the strict warning recipe (`-Wall -Wextra -Wpedantic` plus the specific flag(s) this fixes), `ctest` (1/1 pass), and a Debug build under AddressSanitizer/UndefinedBehaviorSanitizer running the full `CoinTests` suite with no new findings.

Also verified on Windows (MSVC / Visual Studio 17 2022, x64 Release, /W4): built and tested together with all sibling branches from this audit (merged into a local integration build), 0 errors, full `CoinTests` suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FHRXMxksBcEGfbN5bDVJzb
