### PR TITLE
Fix clang unused-but-set warnings and STL buffer cleanup

### DIFF
--- a/src/elements/GL/SoGLLazyElement.cpp
+++ b/src/elements/GL/SoGLLazyElement.cpp
@@ -159,14 +159,12 @@ static void
 create_matrix_bitmap(int intensity, unsigned char * bitmap,
                      uint32_t * matrix, int size)
 {
-  int cnt = 0;
   int i,j;
   for (i = 0; i < 32*4; i++) bitmap[i] = 0;
   for (i = 0; i < size; i++) {
     for (j = 0; j < size; j++) {
       if (matrix[i*size+j] > (uint32_t) intensity) {
         set_bit(i*32+j, bitmap);
-        cnt++;
       }
     }
   }

--- a/src/foreignfiles/SoSTLFileKit.cpp
+++ b/src/foreignfiles/SoSTLFileKit.cpp
@@ -777,4 +777,82 @@ SoSTLFileKit::put_facet_cb(void * closure,
 }
 
 #undef PRIVATE
+
+#ifdef COIN_TEST_SUITE
+
+#include <cstdio>
+#include <Inventor/actions/SoGetPrimitiveCountAction.h>
+#include <Inventor/nodes/SoCube.h>
+#include <Inventor/nodes/SoSeparator.h>
+
+// Regression tests for the binary STL reader/writer in steel.l/steel.cpp
+// (stl_reader_binary_facet(), stl_writer_put_binary_facet(),
+// stl_writer_destroy(), and the binary/ascii probing in
+// stl_reader_create()): round-trip a simple scene through
+// SoSTLFileKit::writeFile()/readFile() and check the triangle count
+// survives exactly. This exercises every readok/writeok accumulation
+// site fixed in fix/unused-but-set-variable-clang along its success
+// path -- the only path testable here without crashing the test
+// binary, since those sites intentionally assert() (a no-op under
+// NDEBUG) rather than change behavior on I/O failure. The actual
+// I/O-failure path is covered separately by
+// testsuite/reproducers/stl-writer-devfull/, which needs a Debug build
+// and a POSIX-only /dev/full trick to force a real write failure.
+
+static int32_t
+STLRoundtripTriangleCount(SoNode * scene)
+{
+  SoGetPrimitiveCountAction pca;
+  pca.apply(scene);
+  return pca.getTriangleCount();
+}
+
+static void
+STLRoundtripTest(SbBool binary)
+{
+  SoSeparator * scene = new SoSeparator;
+  scene->ref();
+  scene->addChild(new SoCube);
+  const int32_t expected = STLRoundtripTriangleCount(scene);
+  BOOST_REQUIRE_MESSAGE(expected > 0, "test setup: SoCube produced no triangles");
+
+  const char * path = binary ?
+    "coin_test_stl_binary_roundtrip_tmp.stl" :
+    "coin_test_stl_ascii_roundtrip_tmp.stl";
+
+  SoSTLFileKit * writer = new SoSTLFileKit;
+  writer->ref();
+  writer->binary = binary;
+  BOOST_REQUIRE_MESSAGE(writer->readScene(scene), "readScene() failed");
+  BOOST_REQUIRE_MESSAGE(writer->writeFile(path), "writeFile() failed");
+  writer->unref();
+  scene->unref();
+
+  SoSTLFileKit * reader = new SoSTLFileKit;
+  reader->ref();
+  SbBool readok = reader->readFile(path);
+  remove(path);
+  BOOST_REQUIRE_MESSAGE(readok, "readFile() failed to read back the file it just wrote");
+
+  SoSeparator * result = reader->convert();
+  BOOST_REQUIRE_MESSAGE(result != NULL, "convert() returned NULL");
+  result->ref();
+  BOOST_CHECK_MESSAGE(STLRoundtripTriangleCount(result) == expected,
+                      "triangle count did not survive the round trip");
+  result->unref();
+  reader->unref();
+}
+
+BOOST_AUTO_TEST_CASE(binary_roundtrip)
+{
+  STLRoundtripTest(TRUE);
+}
+
+BOOST_AUTO_TEST_CASE(ascii_roundtrip)
+{
+  STLRoundtripTest(FALSE);
+}
+
+#endif // COIN_TEST_SUITE
+
 #endif // HAVE_NODEKITS

--- a/src/foreignfiles/steel.cpp
+++ b/src/foreignfiles/steel.cpp
@@ -1079,6 +1079,9 @@ YY_RULE_SETUP
 #line 150 "steel.l"
 {
 	  char * ptr = stl_yytext;
+	  /* The ASCII format probe scans this header before rewinding. */
+	  free(reader->info);
+	  reader->info = NULL;
 	  while ( *ptr == ' ' || *ptr == '\t' ) ptr++;
 	  while ( *ptr != ' ' && *ptr != '\t' ) ptr++;
 	  while ( *ptr && (*ptr == ' ' || *ptr == '\t') ) ptr++;
@@ -2773,6 +2776,8 @@ stl_reader_create(const char * filename)
   } while ( FALSE );
 
   /* the file is not an stl file */
+  free(reader->info);
+  reader->info = NULL;
   (void)fclose(reader->file);
   free(reader->filename);
   reader->filename = NULL;
@@ -2991,6 +2996,7 @@ stl_writer_destroy(stl_writer * writer)
     stl_facet_destroy(writer->facet);
     writer->facet = NULL;
   }
+  free(writer->filename);
   free(writer);
   return STL_OK;
 } /* stl_writer_destroy() */

--- a/src/foreignfiles/steel.cpp
+++ b/src/foreignfiles/steel.cpp
@@ -2290,6 +2290,9 @@ stl_reader_binary_facet(stl_reader * reader)
   /* byteswap? */
   reader->facet->color = data.bytes[0] | (data.bytes[1] << 8);
   /* fprintf(stderr, "  color : 0x%04x\n", reader->facet->color); */
+  if (!readok) {
+    assert(!"failed to read binary STL facet data");
+  }
   reader->facets++;
 }
 
@@ -2349,7 +2352,7 @@ stl_writer_put_binary_facet(stl_writer * writer, stl_facet * facet)
   writeok &= fwrite(&data.bytes, 2, 1, writer->file);
   /* fprintf(stderr, "  color : 0x%04x\n", reader->facet->color); */
 
-  return TRUE;
+  return writeok;
 }
 
 /* ********************************************************************** */
@@ -2743,6 +2746,9 @@ stl_reader_create(const char * filename)
     readok &= fread(reader->info, 80, 1, reader->file);
     reader->info[80] = '\0';
     readok &= !fseek(reader->file, 84, SEEK_SET); /* position of first facet */
+    if (!readok) {
+      assert(!"failed to read binary STL header");
+    }
     reader->pending = STL_INIT_INFO;
     return reader;
   } while ( FALSE );
@@ -2758,6 +2764,9 @@ stl_reader_create(const char * filename)
       break; /* not an ascii stl file */
     }
     readok &= !fseek(reader->file, 0, SEEK_SET);
+    if (!readok) {
+      assert(!"failed to seek to start of ascii STL file");
+    }
     stl_yyrestart(reader->file);
     reader->pending = STL_NO_PENDING;
     return reader;
@@ -2965,6 +2974,9 @@ stl_writer_destroy(stl_writer * writer)
     writeok &= !fflush(writer->file);
     writeok &= !fseek(writer->file, 80, SEEK_SET);
     writeok &= fwrite(bytes, 4, 1, writer->file);
+    if (!writeok) {
+      assert(!"failed to write binary STL facet count to header");
+    }
   } else {
     fprintf(writer->file, "endsolid\n");
     writer->linenum++;

--- a/src/foreignfiles/steel.l
+++ b/src/foreignfiles/steel.l
@@ -417,6 +417,9 @@ stl_reader_binary_facet(stl_reader * reader)
   /* byteswap? */
   reader->facet->color = data.bytes[0] | (data.bytes[1] << 8);
   /* fprintf(stderr, "  color : 0x%04x\n", reader->facet->color); */
+  if (!readok) {
+    assert(!"failed to read binary STL facet data");
+  }
   reader->facets++;
 }
 
@@ -476,7 +479,7 @@ stl_writer_put_binary_facet(stl_writer * writer, stl_facet * facet)
   writeok &= fwrite(&data.bytes, 2, 1, writer->file);
   /* fprintf(stderr, "  color : 0x%04x\n", reader->facet->color); */
 
-  return TRUE;
+  return writeok;
 }
 
 /* ********************************************************************** */
@@ -870,6 +873,9 @@ stl_reader_create(const char * filename)
     readok &= fread(reader->info, 80, 1, reader->file);
     reader->info[80] = '\0';
     readok &= !fseek(reader->file, 84, SEEK_SET); /* position of first facet */
+    if (!readok) {
+      assert(!"failed to read binary STL header");
+    }
     reader->pending = STL_INIT_INFO;
     return reader;
   } while ( FALSE );
@@ -885,6 +891,9 @@ stl_reader_create(const char * filename)
       break; /* not an ascii stl file */
     }
     readok &= !fseek(reader->file, 0, SEEK_SET);
+    if (!readok) {
+      assert(!"failed to seek to start of ascii STL file");
+    }
     stl_yyrestart(reader->file);
     reader->pending = STL_NO_PENDING;
     return reader;
@@ -1092,6 +1101,9 @@ stl_writer_destroy(stl_writer * writer)
     writeok &= !fflush(writer->file);
     writeok &= !fseek(writer->file, 80, SEEK_SET);
     writeok &= fwrite(bytes, 4, 1, writer->file);
+    if (!writeok) {
+      assert(!"failed to write binary STL facet count to header");
+    }
   } else {
     fprintf(writer->file, "endsolid\n");
     writer->linenum++;

--- a/src/foreignfiles/steel.l
+++ b/src/foreignfiles/steel.l
@@ -149,6 +149,9 @@ LINE    [^\n]*
 
 {WHITE}solid{WHITE}{LINE}$	{
 	  char * ptr = stl_yytext;
+	  /* The ASCII format probe scans this header before rewinding. */
+	  free(reader->info);
+	  reader->info = NULL;
 	  while ( *ptr == ' ' || *ptr == '\t' ) ptr++;
 	  while ( *ptr != ' ' && *ptr != '\t' ) ptr++;
 	  while ( *ptr && (*ptr == ' ' || *ptr == '\t') ) ptr++;
@@ -900,6 +903,8 @@ stl_reader_create(const char * filename)
   } while ( FALSE );
 
   /* the file is not an stl file */
+  free(reader->info);
+  reader->info = NULL;
   (void)fclose(reader->file);
   free(reader->filename);
   reader->filename = NULL;
@@ -1118,6 +1123,7 @@ stl_writer_destroy(stl_writer * writer)
     stl_facet_destroy(writer->facet);
     writer->facet = NULL;
   }
+  free(writer->filename);
   free(writer);
   return STL_OK;
 } /* stl_writer_destroy() */

--- a/testsuite/reproducers/CoinCleanup.h
+++ b/testsuite/reproducers/CoinCleanup.h
@@ -1,0 +1,17 @@
+#ifndef COIN_REPRODUCER_CLEANUP_H
+#define COIN_REPRODUCER_CLEANUP_H
+
+#include <Inventor/SoDB.h>
+
+// Declare immediately after SoDB::init(), before local Coin objects, so
+// those objects are destroyed before the library's global resources.
+class CoinReproducerCleanup {
+public:
+  CoinReproducerCleanup() {}
+  ~CoinReproducerCleanup() { SoDB::finish(); }
+private:
+  CoinReproducerCleanup(const CoinReproducerCleanup &);
+  CoinReproducerCleanup & operator=(const CoinReproducerCleanup &);
+};
+
+#endif

--- a/testsuite/reproducers/stl-writer-devfull/repro.cpp
+++ b/testsuite/reproducers/stl-writer-devfull/repro.cpp
@@ -1,0 +1,114 @@
+// Reproducer for the discarded I/O-failure status in stl_writer_destroy()
+// (src/foreignfiles/steel.l), part of the binary STL writer: after all
+// facets have been written, this function seeks back to the file's
+// facet-count field and patches it in with the real count, tracking the
+// fflush()/fseek()/fwrite() results in a `writeok` accumulator that was
+// set but never checked.
+//
+// The fix (branch fix/unused-but-set-variable-clang, which this branch
+// is stacked on) adds `if (!writeok) { assert(!"failed to write binary
+// STL facet count to header"); }` right after that sequence. assert()
+// compiles to nothing under NDEBUG (Release/RelWithDebInfo), matching
+// this project's established behavior-preserving fix for every other
+// -Wunused-but-set-variable site in that branch -- so this reproducer
+// is only observable against a Debug (non-NDEBUG) build of libCoin.
+//
+// /dev/full is used to force a real, deterministic write failure: it
+// accepts writes into the C library's stdio buffer without complaint,
+// but every actual write() syscall against it fails with ENOSPC once
+// the buffer is flushed -- which is exactly what
+// SoSTLFileKit::writeFile()'s binary path does once per facet (small,
+// buffered fwrite() calls) and then, in stl_writer_destroy(), an
+// explicit fflush() to push all of that through before seeking back to
+// patch the header. Linux/POSIX-only, which is why this lives here as
+// a standalone reproducer instead of in the cross-platform CoinTests
+// suite.
+//
+// The failing write happens deep inside library code invoked from
+// SoSTLFileKit::writeFile(), so this runs it in a forked child process
+// and checks whether that child was killed by SIGABRT, rather than
+// letting an abort take down this reproducer itself.
+//
+// Before the fix, or in a Release/RelWithDebInfo build: writeFile()
+// returns TRUE regardless (both before and after the fix -- every
+// caller up the chain already discards stl_writer_put_binary_facet()'s
+// and stl_writer_destroy()'s return values, so this specific fix has
+// no effect on writeFile()'s own return value; see the commit message
+// for fix/unused-but-set-variable-clang for the full picture) and the
+// child exits normally despite every byte having failed to write.
+// After the fix, in a Debug build: the header-patching step aborts via
+// assert() instead of silently reporting the (bogus) success it always
+// has.
+//
+// See run.sh in this directory for how to build and run this against a
+// given Debug libCoin build.
+
+#include <cstdio>
+#include <cstdlib>
+#include <sys/stat.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <Inventor/SoDB.h>
+#include <Inventor/SoInteraction.h>
+#include <Inventor/annex/ForeignFiles/SoSTLFileKit.h>
+#include <Inventor/nodes/SoCube.h>
+#include <Inventor/nodes/SoSeparator.h>
+
+int
+main()
+{
+  struct stat st;
+  if (stat("/dev/full", &st) != 0) {
+    fprintf(stderr, "[repro] SKIP: /dev/full is not available on this system "
+            "(this reproducer is Linux/POSIX-only)\n");
+    return 0;
+  }
+
+  SoDB::init();
+  SoInteraction::init();
+
+  SoSeparator * scene = new SoSeparator;
+  scene->ref();
+  scene->addChild(new SoCube);
+
+  pid_t pid = fork();
+  if (pid == 0) {
+    SoSTLFileKit * kit = new SoSTLFileKit;
+    kit->ref();
+    kit->binary = TRUE;
+    SbBool readok = kit->readScene(scene);
+    if (!readok) {
+      fprintf(stderr, "[repro-child] readScene() unexpectedly failed\n");
+      kit->unref();
+      _exit(2);
+    }
+    SbBool writeok = kit->writeFile("/dev/full");
+    fprintf(stderr, "[repro-child] writeFile(\"/dev/full\") returned %s "
+            "without aborting, despite every byte having failed to write "
+            "-- writeFile()'s own return value is unaffected by this fix "
+            "(see repro.cpp), this is expected in a Release/RelWithDebInfo "
+            "build\n", writeok ? "TRUE" : "FALSE");
+    kit->unref();
+    _exit(0);
+  }
+
+  int status = 0;
+  waitpid(pid, &status, 0);
+  scene->unref();
+
+  if (WIFSIGNALED(status) && WTERMSIG(status) == SIGABRT) {
+    fprintf(stderr, "[repro] PASS: child aborted via assert() while "
+            "patching the binary STL header after every write to "
+            "/dev/full failed, as expected from the fix in a Debug "
+            "build\n");
+    return 0;
+  }
+
+  fprintf(stderr, "[repro] FAIL: child did not abort (wait status 0x%x). "
+          "This reproducer requires a Debug (non-NDEBUG) build of "
+          "libCoin, since the fix's writeok check compiles to nothing "
+          "under NDEBUG -- rebuild with -DCMAKE_BUILD_TYPE=Debug and "
+          "point run.sh at that build's lib directory.\n", status);
+  return 1;
+}

--- a/testsuite/reproducers/stl-writer-devfull/repro.cpp
+++ b/testsuite/reproducers/stl-writer-devfull/repro.cpp
@@ -43,6 +43,7 @@
 // See run.sh in this directory for how to build and run this against a
 // given Debug libCoin build.
 
+#include "../CoinCleanup.h"
 #include <cstdio>
 #include <cstdlib>
 #include <sys/stat.h>
@@ -66,6 +67,7 @@ main()
   }
 
   SoDB::init();
+  CoinReproducerCleanup cleanup;
   SoInteraction::init();
 
   SoSeparator * scene = new SoSeparator;

--- a/testsuite/reproducers/stl-writer-devfull/run.sh
+++ b/testsuite/reproducers/stl-writer-devfull/run.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+# Reproducer for the discarded I/O-failure status in stl_writer_destroy()
+# (src/foreignfiles/steel.l) when writing a binary STL to a device that
+# rejects every write (/dev/full). Requires a Debug (non-NDEBUG) build
+# of libCoin, since the fix's writeok check compiles to nothing under
+# NDEBUG (Release/RelWithDebInfo) -- see repro.cpp for the full
+# explanation. Linux/POSIX-only and not part of the default `ctest`
+# suite for that reason. Run manually against a Debug build tree's
+# shared library:
+#
+#   testsuite/reproducers/stl-writer-devfull/run.sh /path/to/debug-build/lib
+#
+# Before the fix, or against a non-Debug build: exits 1, reporting that
+# the write to /dev/full was reported as successful instead of
+# aborting. After the fix, against a Debug build: exits 0, reporting
+# that patching the binary STL header aborted via assert() as expected.
+
+cd "$(dirname "$0")"
+
+LIBDIR="$1"
+if [ -z "$LIBDIR" ]; then
+  echo "usage: $0 /path/to/debug-build/lib   (directory containing a Debug libCoin.so)" >&2
+  exit 2
+fi
+
+CXX=${CXX:-c++}
+INCDIR="$(cd "$LIBDIR/../include" && pwd)" || exit 2
+SRCINCDIR="$(cd "$(pwd)/../../../include" && pwd)" || exit 2
+
+"$CXX" -O0 -g -I"$SRCINCDIR" -I"$INCDIR" repro.cpp -o repro -L"$LIBDIR" -lCoin || exit 2
+
+export LD_LIBRARY_PATH="$LIBDIR${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+./repro
+status=$?
+if [ "$status" -ne 0 ]; then
+  echo "=== FAIL: repro exited with status $status ===" >&2
+  exit "$status"
+fi
+echo "=== PASS ==="


### PR DESCRIPTION
Preserve and check the accumulated STL read/write status in Debug builds, return the binary facet writer's status, remove unused bookkeeping, and add binary/ASCII round-trip coverage. This remains stacked on the GCC unused-but-set-variable cleanup.

Release the previous ASCII header buffer before rescanning after the format probe, clean it on rejection, and free writer->filename on destruction. Keep steel.l and the checked-in generated steel.cpp synchronized. The /dev/full reproducer now cleans up the parent process; the child's intentional abort/_exit is not a leak-clean shutdown check.

## Validation

The distributed changes were validated together in `lab/all-fixes-integration`, with Clang Debug instrumentation on both Coin and C++ test drivers: `-fsanitize=address,undefined,function -fno-omit-frame-pointer`, `ASAN_OPTIONS=detect_leaks=1`, `UBSAN_OPTIONS=halt_on_error=1`, without suppressions. All 8 CTest entries passed (342 CoinTests / 83,759 checks plus seven profiler modes); 31 additional checks passed, including actual rendering, events and the historical-header client. EGL and SpiderMonkey checks were inconclusive.

This is **integration evidence**, not a claim that this isolated PR includes every companion fix or passes the full sanitizer matrix by itself. Global cleanup, STL, test-fixture and GL record fixes are distributed across the related PRs. Windows/macOS and all optional configurations were not rerun for this update. The final per-PR diff passed `git diff --check`.
