### PR TITLE
Fix clang -Wunused-const-variable in SoConfigSettings.cpp

### DIFF
--- a/src/misc/SoConfigSettings.cpp
+++ b/src/misc/SoConfigSettings.cpp
@@ -18,7 +18,6 @@ namespace {
   {
     return sizeof(VALID_OPTIONS)/sizeof(VALID_OPTIONS[0]);
   }
-  const char COIN [] = "COIN";
 
   SbBool isValidOption(const SbString & option)
   {
@@ -79,6 +78,7 @@ SoConfigSettings::reinitialize()
   //disabling this for now. Write a configure test for this in the
   //future. BFG 20091013
 #if COIN_DEBUG && 0
+  const char COIN [] = "COIN";
   for (char ** test = environ; *test != NULL; ++test) {
     char * first = strchr(*test,'=');
     if (first) {


### PR DESCRIPTION
## Summary

The `COIN` byte-string constant in the anonymous namespace was only
ever referenced from inside SoConfigSettings::reinitialize()'s
environ-scanning loop, which is entirely wrapped in
`#if COIN_DEBUG && 0` -- permanently preprocessed out (per the
existing FIXME: "environ is not available on non-unix platforms, so
disabling this for now"), so the declaration had no live reference in
any actually-compiled translation unit.

Moved the declaration inside the same #if COIN_DEBUG && 0 block, right
before its only uses, instead of deleting it -- deleting it would
break the disabled code if COIN_DEBUG_ENVIRON scanning is ever
resurrected once the cross-platform environ availability is sorted
out, same reasoning as this audit's -Wconstant-logical-operand fixes
for the other deliberately-disabled-but-kept debug blocks in this
codebase. Zero behavior change: the block was never compiled before
this fix and still isn't.

Verified: -Wunused-const-variable 1 -> 0 under clang -Wall -Wextra
-Wpedantic (390 -> 389 warnings total), 0 errors, every other category
in the breakdown unchanged. GCC build unaffected (859 warnings, 0
errors, same as master baseline). Full CoinTests suite passes under
both compilers (normal build: 1/1 ctest pass each); GCC Debug+ASan/
UBSan: 326 tests, 83566 checks, no findings.

---
**Verified:** Full clean rebuild under GCC and clang (Linux) with the strict warning recipe (`-Wall -Wextra -Wpedantic` plus the specific flag(s) this fixes), `ctest` (1/1 pass), and a Debug build under AddressSanitizer/UndefinedBehaviorSanitizer running the full `CoinTests` suite with no new findings.

Also verified on Windows (MSVC / Visual Studio 17 2022, x64 Release, /W4): built and tested together with all sibling branches from this audit (merged into a local integration build), 0 errors, full `CoinTests` suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FHRXMxksBcEGfbN5bDVJzb
