### PR TITLE
Fix -Wunused-parameter warnings (67 sites across 52 files)

### DIFF
--- a/src/3ds/3dsLoader.cpp
+++ b/src/3ds/3dsLoader.cpp
@@ -1799,7 +1799,7 @@ SoTextureCoordinate2* FaceGroup::createSoTextureCoordinate2_n(tagContext *con)
 
 
 
-SoTriangleStripSet* FaceGroup::createSoTriStripSet_n(tagContext *con)
+SoTriangleStripSet* FaceGroup::createSoTriStripSet_n(tagContext * COIN_UNUSED_ARG(con))
 {
   assert(!con->useIndexedTriSet && "Improper use.");
 

--- a/src/base/SbBox3d.cpp
+++ b/src/base/SbBox3d.cpp
@@ -56,6 +56,8 @@
 #include <Inventor/SbDPMatrix.h>
 #include <Inventor/errors/SoDebugError.h>
 
+#include "coindefs.h"
+
 // *************************************************************************
 
 /*!
@@ -457,7 +459,7 @@ SbBox3d::transform(const SbDPMatrix & matrix)
   debug version of library, method does nothing in an optimized build.
  */
 void
-SbBox3d::print(FILE * fp) const
+SbBox3d::print(FILE * COIN_UNUSED_ARG(fp)) const
 {
 #if COIN_DEBUG
   SbVec3d minv, maxv;

--- a/src/base/SbBox3f.cpp
+++ b/src/base/SbBox3f.cpp
@@ -56,6 +56,8 @@
 #include <Inventor/errors/SoDebugError.h>
 #endif // COIN_DEBUG
 
+#include "coindefs.h"
+
 /*!
   \fn SbBox3f::SbBox3f(void)
   The default constructor makes an empty box.
@@ -457,7 +459,7 @@ SbBox3f::transform(const SbMatrix & matrix)
   debug version of library, method does nothing in an optimized build.
  */
 void
-SbBox3f::print(FILE * fp) const
+SbBox3f::print(FILE * COIN_UNUSED_ARG(fp)) const
 {
 #if COIN_DEBUG
   SbVec3f minv, maxv;

--- a/src/base/SbCylinder.cpp
+++ b/src/base/SbCylinder.cpp
@@ -49,6 +49,8 @@
 #include <Inventor/errors/SoDebugError.h>
 #endif // COIN_DEBUG
 
+#include "coindefs.h"
+
 /*!
   The default constructor will make a cylinder of radius 1, center axis
   going through origo in the parallel direction of the positive y-axis.
@@ -262,7 +264,7 @@ SbCylinder::intersect(const SbLine& l, SbVec3f& enter, SbVec3f& exit) const
   debug version of library, method does nothing in an optimized build.
  */
 void
-SbCylinder::print(FILE * fp) const
+SbCylinder::print(FILE * COIN_UNUSED_ARG(fp)) const
 {
 #if COIN_DEBUG
   fprintf( fp, "axis: " );

--- a/src/base/SbDPLine.cpp
+++ b/src/base/SbDPLine.cpp
@@ -53,6 +53,8 @@
 #include <Inventor/errors/SoDebugError.h>
 #endif // COIN_DEBUG
 
+#include "coindefs.h"
+
 /*!
   The empty constructor does nothing. The line will be uninitialized until
   the first assignment or setValue() call.
@@ -356,7 +358,7 @@ SbDPLine::getDirection(void) const
   debug version of library, method does nothing in an optimized build.
  */
 void
-SbDPLine::print(FILE * fp) const
+SbDPLine::print(FILE * COIN_UNUSED_ARG(fp)) const
 {
 #if COIN_DEBUG
   fprintf( fp, "p: " );

--- a/src/base/SbDPPlane.cpp
+++ b/src/base/SbDPPlane.cpp
@@ -56,6 +56,8 @@
 #include <Inventor/errors/SoDebugError.h>
 #endif // COIN_DEBUG
 
+#include "coindefs.h"
+
 
 /*!
   An SbDPPlane instantiated with the default constructor will be
@@ -370,7 +372,7 @@ operator !=(const SbDPPlane & p1, const SbDPPlane & p2)
   debug version of library, method does nothing in an optimized build.
 */
 void
-SbDPPlane::print(FILE * fp) const
+SbDPPlane::print(FILE * COIN_UNUSED_ARG(fp)) const
 {
 #if COIN_DEBUG
   this->getNormal().print(fp);

--- a/src/base/SbDPRotation.cpp
+++ b/src/base/SbDPRotation.cpp
@@ -57,6 +57,8 @@
 #include <Inventor/errors/SoDebugError.h>
 #endif // COIN_DEBUG
 
+#include "coindefs.h"
+
 /*!
   The default constructor just initializes a valid rotation. The
   actual value is unspecified, and you should not depend on it.
@@ -633,7 +635,7 @@ SbDPRotation::identity(void)
   debug version of library, method does nothing in an optimized build.
  */
 void
-SbDPRotation::print(FILE * fp) const
+SbDPRotation::print(FILE * COIN_UNUSED_ARG(fp)) const
 {
 #if COIN_DEBUG
   this->quat.print(fp);

--- a/src/base/SbDPViewVolume.cpp
+++ b/src/base/SbDPViewVolume.cpp
@@ -1159,7 +1159,7 @@ SbDPViewVolume::getDepth(void) const
   debug version of library, method does nothing in an optimized build.
  */
 void
-SbDPViewVolume::print(FILE * fp) const
+SbDPViewVolume::print(FILE * COIN_UNUSED_ARG(fp)) const
 {
 #if COIN_DEBUG
   fprintf( fp, "  projtype: %d\n", static_cast<int>(this->getProjectionType()) );

--- a/src/base/SbLine.cpp
+++ b/src/base/SbLine.cpp
@@ -55,6 +55,8 @@
 #include <Inventor/SbLine.h>
 #include <Inventor/errors/SoDebugError.h>
 
+#include "coindefs.h"
+
 
 /*!
   The default constructor does nothing. The line will be uninitialized
@@ -409,7 +411,7 @@ SbLine::getDirection(void) const
   debug version of library, method does nothing in an optimized build.
  */
 void
-SbLine::print(FILE * fp) const
+SbLine::print(FILE * COIN_UNUSED_ARG(fp)) const
 {
 #if COIN_DEBUG
   fprintf( fp, "p: " );

--- a/src/base/SbPlane.cpp
+++ b/src/base/SbPlane.cpp
@@ -53,6 +53,8 @@
 #include <Inventor/errors/SoDebugError.h>
 #endif // COIN_DEBUG
 
+#include "coindefs.h"
+
 
 /*!
   An SbPlane instantiated with the default constructor will be
@@ -375,7 +377,7 @@ operator !=(const SbPlane& p1, const SbPlane& p2)
   debug version of library, method does nothing in an optimized build.
 */
 void
-SbPlane::print(FILE * fp) const
+SbPlane::print(FILE * COIN_UNUSED_ARG(fp)) const
 {
 #if COIN_DEBUG
   this->getNormal().print(fp);

--- a/src/base/SbRotation.cpp
+++ b/src/base/SbRotation.cpp
@@ -78,6 +78,8 @@
 #include <Inventor/SbRotation.h>
 #include <Inventor/SbVec3f.h>
 #include <Inventor/SbMatrix.h>
+
+#include "coindefs.h"
 #include <Inventor/fields/SoSFRotation.h>
 #include <cassert>
 #include <cfloat>
@@ -730,7 +732,7 @@ SbRotation::fromString(const SbString & str)
   debug version of library, method does nothing in an optimized build.
  */
 void
-SbRotation::print(FILE * fp) const
+SbRotation::print(FILE * COIN_UNUSED_ARG(fp)) const
 {
 #if COIN_DEBUG
   this->quat.print(fp);

--- a/src/base/SbSphere.cpp
+++ b/src/base/SbSphere.cpp
@@ -49,6 +49,8 @@
 #include <Inventor/errors/SoDebugError.h>
 #endif // COIN_DEBUG
 
+#include "coindefs.h"
+
 /*!
   The default constructor does nothing. The center point and the radius
   will be uninitialized.
@@ -227,7 +229,7 @@ SbSphere::pointInside(const SbVec3f &p) const
   debug version of library, method does nothing in an optimized build.
  */
 void
-SbSphere::print(FILE * fp) const
+SbSphere::print(FILE * COIN_UNUSED_ARG(fp)) const
 {
 #if COIN_DEBUG
   fprintf( fp, "center: " );

--- a/src/base/SbString.cpp
+++ b/src/base/SbString.cpp
@@ -214,7 +214,7 @@ SbString::upper() const
   debug version of library, method does nothing in an optimized build.
 */
 void
-SbString::print(std::FILE * fp) const
+SbString::print(std::FILE * COIN_UNUSED_ARG(fp)) const
 {
 #if COIN_DEBUG
   std::fputs(this->getString(),fp);

--- a/src/base/SbTime.cpp
+++ b/src/base/SbTime.cpp
@@ -1066,7 +1066,7 @@ SbTime::addToString(SbString & str, const double v) const
   debug version of library, method does nothing in an optimized build.
  */
 void
-SbTime::print(FILE * fp) const
+SbTime::print(FILE * COIN_UNUSED_ARG(fp)) const
 {
 #if COIN_DEBUG
   struct timeval tm;

--- a/src/base/SbVec2d.cpp
+++ b/src/base/SbVec2d.cpp
@@ -59,6 +59,8 @@
 
 #include "tidbitsp.h" // coin_debug_normalize()
 
+#include "coindefs.h"
+
 // *************************************************************************
 
 /*!
@@ -390,7 +392,7 @@ SbVec2d::setValue(const SbVec2i32 & v)
 */
 
 void
-SbVec2d::print(FILE * fp) const
+SbVec2d::print(FILE * COIN_UNUSED_ARG(fp)) const
 {
 #if COIN_DEBUG
   fprintf( fp, "<%f, %f>", this->vec[0], this->vec[1] );

--- a/src/base/SbVec2f.cpp
+++ b/src/base/SbVec2f.cpp
@@ -62,6 +62,8 @@
 
 #include "tidbitsp.h" // coin_debug_normalize()
 
+#include "coindefs.h"
+
 // *************************************************************************
 
 /*!
@@ -415,7 +417,7 @@ SbVec2f::fromString(const SbString & str)
   debug version of library, method does nothing in an optimized build.
 */
 void
-SbVec2f::print(FILE * fp) const
+SbVec2f::print(FILE * COIN_UNUSED_ARG(fp)) const
 {
 #if COIN_DEBUG
   fputs(this->toString().getString(),fp);

--- a/src/base/SbVec2i32.cpp
+++ b/src/base/SbVec2i32.cpp
@@ -58,6 +58,8 @@
 #include <Inventor/errors/SoDebugError.h>
 #endif // COIN_DEBUG
 
+#include "coindefs.h"
+
 /*!
   \fn SbVec2i32::SbVec2i32(void)
 
@@ -375,7 +377,7 @@ SbVec2i32::operator *= (double d)
   debug version of library, method does nothing in an optimized build.
  */
 void
-SbVec2i32::print(FILE * fp) const
+SbVec2i32::print(FILE * COIN_UNUSED_ARG(fp)) const
 {
 #if COIN_DEBUG
   fprintf( fp, "<%d, %d>", this->vec[0], this->vec[1] );

--- a/src/base/SbVec2s.cpp
+++ b/src/base/SbVec2s.cpp
@@ -61,6 +61,8 @@
 #include <Inventor/errors/SoDebugError.h>
 #endif // COIN_DEBUG
 
+#include "coindefs.h"
+
 /*!
   \fn SbVec2s::SbVec2s(void)
 
@@ -416,7 +418,7 @@ SbVec2s::fromString(const SbString & str)
   debug version of library, method does nothing in an optimized build.
 */
 void
-SbVec2s::print(FILE * fp) const
+SbVec2s::print(FILE * COIN_UNUSED_ARG(fp)) const
 {
 #if COIN_DEBUG
   fputs(this->toString().getString(),fp);

--- a/src/base/SbVec3d.cpp
+++ b/src/base/SbVec3d.cpp
@@ -48,6 +48,8 @@
 #include "tidbitsp.h" // coin_debug_normalize()
 #include "coinString.h"
 
+#include "coindefs.h"
+
 /*!
   \class SbVec3d SbVec3d.h Inventor/SbVec3d.h
   \brief The SbVec3d class is a 3 dimensional vector with double precision floating point coordinates.
@@ -553,7 +555,7 @@ SbVec3d::fromString(const SbString & str)
   debug version of library, method does nothing in an optimized build.
 */
 void
-SbVec3d::print(FILE * fp) const
+SbVec3d::print(FILE * COIN_UNUSED_ARG(fp)) const
 {
 #if COIN_DEBUG
   fputs(this->toString().getString(),fp);

--- a/src/base/SbVec3f.cpp
+++ b/src/base/SbVec3f.cpp
@@ -64,6 +64,8 @@
 #include "tidbitsp.h" // coin_debug_normalize()
 #include "coinString.h"
 
+#include "coindefs.h"
+
 /*!
   \fn SbVec3f::SbVec3f(void)
 
@@ -616,7 +618,7 @@ SbVec3f::fromString(const SbString & str)
   debug version of library, method does nothing in an optimized build.
 */
 void
-SbVec3f::print(FILE * fp) const
+SbVec3f::print(FILE * COIN_UNUSED_ARG(fp)) const
 {
 #if COIN_DEBUG
   fputs(this->toString().getString(),fp);

--- a/src/base/SbVec3s.cpp
+++ b/src/base/SbVec3s.cpp
@@ -47,6 +47,8 @@
 
 #include "coinString.h"
 
+#include "coindefs.h"
+
 /*!
   \class SbVec3s SbVec3s.h Inventor/SbVec3s.h
   \brief The SbVec3s class is a 3 dimensional vector with short integer
@@ -424,7 +426,7 @@ SbVec3s::fromString(const SbString & str)
   debug version of library, method does nothing in an optimized build.
 */
 void
-SbVec3s::print(FILE * fp) const
+SbVec3s::print(FILE * COIN_UNUSED_ARG(fp)) const
 {
 #if COIN_DEBUG
   SbString str = "<";

--- a/src/base/SbVec4d.cpp
+++ b/src/base/SbVec4d.cpp
@@ -46,6 +46,8 @@
 
 #include "tidbitsp.h" // coin_debug_normalize()
 
+#include "coindefs.h"
+
 /*!
   \class SbVec4d SbVec4d.h Inventor/SbVec4d.h
   \brief The SbVec4d class is a 4 dimensional vector with double precision
@@ -404,7 +406,7 @@ SbVec4d::setValue(const SbVec4i32 & v)
   debug version of library, method does nothing in an optimized build.
  */
 void
-SbVec4d::print(FILE * fp) const
+SbVec4d::print(FILE * COIN_UNUSED_ARG(fp)) const
 {
 #if COIN_DEBUG
   fprintf( fp, "<%f, %f, %f, %f>", this->vec[0], this->vec[1], this->vec[2],

--- a/src/base/SbVec4f.cpp
+++ b/src/base/SbVec4f.cpp
@@ -46,6 +46,8 @@
 
 #include "tidbitsp.h" // coin_debug_normalize()
 
+#include "coindefs.h"
+
 /*!
   \class SbVec4f SbVec4f.h Inventor/SbVec4f.h
   \brief The SbVec4f class is a 4 dimensional vector with floating point coordinates.
@@ -413,7 +415,7 @@ SbVec4f::setValue(const SbVec4i32 & v)
   debug version of library, method does nothing in an optimized build.
  */
 void
-SbVec4f::print(FILE * fp) const
+SbVec4f::print(FILE * COIN_UNUSED_ARG(fp)) const
 {
 #if COIN_DEBUG
   fprintf( fp, "<%f, %f, %f, %f>", this->vec[0], this->vec[1], this->vec[2],

--- a/src/base/SbViewVolume.cpp
+++ b/src/base/SbViewVolume.cpp
@@ -674,7 +674,7 @@ SbViewVolume::getDepth(void) const
   debug version of library, method does nothing in an optimized build.
  */
 void
-SbViewVolume::print(FILE * fp) const
+SbViewVolume::print(FILE * COIN_UNUSED_ARG(fp)) const
 {
 #if COIN_DEBUG
   fprintf( fp, "  projtype: %d\n", static_cast<int>(this->getProjectionType()) );

--- a/src/base/SbViewportRegion.cpp
+++ b/src/base/SbViewportRegion.cpp
@@ -134,6 +134,8 @@
 #include <Inventor/SbViewportRegion.h>
 #include <Inventor/errors/SoDebugError.h>
 
+#include "coindefs.h"
+
 /*!
   The default SbViewportRegion constructor initializes the viewport to
   fully cover a [100, 100] size window with 72 pixels per inch
@@ -591,7 +593,7 @@ operator!=(const SbViewportRegion & reg1, const SbViewportRegion & reg2)
   debug version of library, method does nothing in an optimized build.
  */
 void
-SbViewportRegion::print(FILE * fp) const
+SbViewportRegion::print(FILE * COIN_UNUSED_ARG(fp)) const
 {
 #if COIN_DEBUG
   (void)fprintf( fp, "  winsize:     " );

--- a/src/base/SbXfBox3f.cpp
+++ b/src/base/SbXfBox3f.cpp
@@ -48,6 +48,8 @@
 #include <cfloat>
 #include <Inventor/errors/SoDebugError.h>
 
+#include "coindefs.h"
+
 // this value is used to signal an invalid inverse matrix
 #define INVALID_TAG FLT_MAX
 
@@ -758,7 +760,7 @@ SbXfBox3f::getVolume(void) const
   debug version of library, method does nothing in an optimized build.
  */
 void
-SbXfBox3f::print(FILE * fp) const
+SbXfBox3f::print(FILE * COIN_UNUSED_ARG(fp)) const
 {
 #if COIN_DEBUG
   SbVec3f minv, maxv;

--- a/src/base/time.cpp
+++ b/src/base/time.cpp
@@ -139,7 +139,7 @@ cc_internal_gettimeofday(cc_time * t)
 }
 
 static SbBool
-cc_internal_ftime(cc_time * t)
+cc_internal_ftime(cc_time * COIN_UNUSED_ARG(t))
 {
 #ifdef HAVE__FTIME
   struct _timeb timebuffer;

--- a/src/bundles/SoNormalBundle.cpp
+++ b/src/bundles/SoNormalBundle.cpp
@@ -152,7 +152,7 @@ SoNormalBundle::triangle(const SbVec3f & p1,
   pushed onto the current state.
 */
 void 
-SoNormalBundle::generate(int startindex, SbBool addtostate)
+SoNormalBundle::generate(int COIN_UNUSED_ARG(startindex), SbBool addtostate)
 {
   // we don't support startindex != 0 
   // The SoNonIndexedShape::startIndex field has been obsoleted by

--- a/src/elements/GL/SoGLEnvironmentElement.cpp
+++ b/src/elements/GL/SoGLEnvironmentElement.cpp
@@ -79,7 +79,7 @@ SoGLEnvironmentElement::init(SoState * state)
 // doc in superclass
 void
 SoGLEnvironmentElement::pop(SoState * COIN_UNUSED_ARG(state),
-                           const SoElement * prevTopElement)
+                           const SoElement * COIN_UNUSED_ARG(prevTopElement))
 {
   this->capture(state);
   this->updategl(state);

--- a/src/elements/GL/SoGLProjectionMatrixElement.cpp
+++ b/src/elements/GL/SoGLProjectionMatrixElement.cpp
@@ -75,7 +75,7 @@ SoGLProjectionMatrixElement::~SoGLProjectionMatrixElement(void)
 
 void
 SoGLProjectionMatrixElement::pop(SoState * COIN_UNUSED_ARG(state),
-                                 const SoElement * prevTopElement)
+                                 const SoElement * COIN_UNUSED_ARG(prevTopElement))
 {
   this->capture(state);
   this->updategl();

--- a/src/elements/SoAmbientColorElement.cpp
+++ b/src/elements/SoAmbientColorElement.cpp
@@ -81,7 +81,7 @@ SoAmbientColorElement::~SoAmbientColorElement()
 
 void
 SoAmbientColorElement::set(SoState * const state, SoNode * const COIN_UNUSED_ARG(node),
-                           const int32_t numcolors,
+                           const int32_t COIN_UNUSED_ARG(numcolors),
                            const SbColor * const colors)
 {
   SoLazyElement::setAmbient(state, colors);
@@ -105,7 +105,7 @@ SoAmbientColorElement::getNum(void) const
 //! FIXME: write doc.
 
 const SbColor &
-SoAmbientColorElement::get(const int index) const
+SoAmbientColorElement::get(const int COIN_UNUSED_ARG(index)) const
 {
   assert(index == 0);
   return SoLazyElement::getAmbient(this->state);

--- a/src/elements/SoEmissiveColorElement.cpp
+++ b/src/elements/SoEmissiveColorElement.cpp
@@ -81,7 +81,7 @@ SoEmissiveColorElement::init(SoState * stateptr)
 
 void
 SoEmissiveColorElement::set(SoState * const state, SoNode * const COIN_UNUSED_ARG(node),
-                            const int32_t numcolors,
+                            const int32_t COIN_UNUSED_ARG(numcolors),
                             const SbColor * const colors)
 {
   SoLazyElement::setEmissive(state, colors);
@@ -106,7 +106,7 @@ SoEmissiveColorElement::getNum(void) const
 //! FIXME: write doc.
 
 const SbColor &
-SoEmissiveColorElement::get(const int index) const
+SoEmissiveColorElement::get(const int COIN_UNUSED_ARG(index)) const
 {
   assert(index == 0);
   return SoLazyElement::getEmissive(this->state);

--- a/src/elements/SoShininessElement.cpp
+++ b/src/elements/SoShininessElement.cpp
@@ -84,7 +84,7 @@ SoShininessElement::init(SoState * stateptr)
 
 void
 SoShininessElement::set(SoState * const state, SoNode * const COIN_UNUSED_ARG(node),
-                           const int32_t numvalues,
+                           const int32_t COIN_UNUSED_ARG(numvalues),
                            const float * const values)
 {
   SoLazyElement::setShininess(state, values[0]);
@@ -108,7 +108,7 @@ SoShininessElement::getNum(void) const
 //! FIXME: write doc.
 
 float
-SoShininessElement::get(const int index) const
+SoShininessElement::get(const int COIN_UNUSED_ARG(index)) const
 {
   assert(index == 0);
   return SoLazyElement::getShininess(this->state);

--- a/src/elements/SoSpecularColorElement.cpp
+++ b/src/elements/SoSpecularColorElement.cpp
@@ -84,7 +84,7 @@ SoSpecularColorElement::init(SoState * stateptr)
 
 void
 SoSpecularColorElement::set(SoState * const state, SoNode * const COIN_UNUSED_ARG(node),
-                            const int32_t numcolors,
+                            const int32_t COIN_UNUSED_ARG(numcolors),
                             const SbColor * const colors)
 {
   SoLazyElement::setSpecular(state, colors);
@@ -109,7 +109,7 @@ SoSpecularColorElement::getNum() const
 //! FIXME: write doc.
 
 const SbColor &
-SoSpecularColorElement::get(const int index) const
+SoSpecularColorElement::get(const int COIN_UNUSED_ARG(index)) const
 {
   assert(index == 0);
   return SoLazyElement::getSpecular(this->state);

--- a/src/engines/SoConvertAll.cpp
+++ b/src/engines/SoConvertAll.cpp
@@ -55,6 +55,7 @@
 #include "tidbitsp.h"
 #include "engines/SoSubEngineP.h"
 #include "misc/SbHash.h"
+#include "coindefs.h"
 
 // *************************************************************************
 
@@ -1159,7 +1160,7 @@ SoConvertAll::~SoConvertAll()
 }
 
 SoField *
-SoConvertAll::getInput(SoType type)
+SoConvertAll::getInput(SoType COIN_UNUSED_ARG(type))
 {
 #if COIN_DEBUG
   SoType inputtype = this->input->getTypeId();
@@ -1177,7 +1178,7 @@ SoConvertAll::getInput(SoType type)
 }
 
 SoEngineOutput *
-SoConvertAll::getOutput(SoType type)
+SoConvertAll::getOutput(SoType COIN_UNUSED_ARG(type))
 {
 #if COIN_DEBUG
   SoType outputtype = this->output.getConnectionType();

--- a/src/foreignfiles/steel.cpp
+++ b/src/foreignfiles/steel.cpp
@@ -58,6 +58,7 @@
 #include <Inventor/system/inttypes.h>
 
 #include "steel.h"
+#include "coindefs.h"
 
 #line 62 "steel.cpp"
 
@@ -2295,7 +2296,7 @@ stl_reader_binary_facet(stl_reader * reader)
 
 static
 int
-stl_writer_put_binary_facet(stl_writer * writer, stl_facet * facet)
+stl_writer_put_binary_facet(stl_writer * writer, stl_facet * COIN_UNUSED_ARG(facet))
 {
   int writeok = 1;
   union {
@@ -2649,7 +2650,7 @@ stl_facet_get_vertex3(stl_facet * facet, stl_real * x, stl_real * y, stl_real * 
  */
 
 void
-stl_facet_set_padding(stl_facet * facet, unsigned int padding)
+stl_facet_set_padding(stl_facet * COIN_UNUSED_ARG(facet), unsigned int COIN_UNUSED_ARG(padding))
 {
   assert(facet != NULL);
 } /* stl_facet_set_padding() */
@@ -2658,7 +2659,7 @@ stl_facet_set_padding(stl_facet * facet, unsigned int padding)
  */
 
 unsigned int
-stl_facet_get_padding(stl_facet * facet)
+stl_facet_get_padding(stl_facet * COIN_UNUSED_ARG(facet))
 {
   assert(facet != NULL);
   return 0;

--- a/src/foreignfiles/steel.l
+++ b/src/foreignfiles/steel.l
@@ -58,6 +58,7 @@
 #include <Inventor/system/inttypes.h>
 
 #include "steel.h"
+#include "coindefs.h"
 }
 
 %{
@@ -422,7 +423,7 @@ stl_reader_binary_facet(stl_reader * reader)
 
 static
 int
-stl_writer_put_binary_facet(stl_writer * writer, stl_facet * facet)
+stl_writer_put_binary_facet(stl_writer * writer, stl_facet * COIN_UNUSED_ARG(facet))
 {
   int writeok = 1;
   union {
@@ -776,7 +777,7 @@ stl_facet_get_vertex3(stl_facet * facet, stl_real * x, stl_real * y, stl_real * 
  */
 
 void
-stl_facet_set_padding(stl_facet * facet, unsigned int padding)
+stl_facet_set_padding(stl_facet * COIN_UNUSED_ARG(facet), unsigned int COIN_UNUSED_ARG(padding))
 {
   assert(facet != NULL);
 } /* stl_facet_set_padding() */
@@ -785,7 +786,7 @@ stl_facet_set_padding(stl_facet * facet, unsigned int padding)
  */
 
 unsigned int
-stl_facet_get_padding(stl_facet * facet)
+stl_facet_get_padding(stl_facet * COIN_UNUSED_ARG(facet))
 {
   assert(facet != NULL);
   return 0;

--- a/src/geo/SoGeo.cpp
+++ b/src/geo/SoGeo.cpp
@@ -81,9 +81,9 @@ static int find_utm_zone(const SbString & s)
 }
 
 SbVec3d 
-SoGeo::toGD(const SbString * originsystem,
-            const int numoriginsys,
-            const SbVec3d & origincoords)
+SoGeo::toGD(const SbString * COIN_UNUSED_ARG(originsystem),
+            const int COIN_UNUSED_ARG(numoriginsys),
+            const SbVec3d & COIN_UNUSED_ARG(origincoords))
 {
     assert(0 && "not implemented yet");
     return SbVec3d(0.0, 0.0, 0.0);
@@ -94,9 +94,9 @@ SoGeo::toGD(const SbString * originsystem,
 }
 
 SbVec3d 
-SoGeo::fromGD(const SbVec3d & gd,
-              const SbString * tosystem,
-              const int numtosys)
+SoGeo::fromGD(const SbVec3d & COIN_UNUSED_ARG(gd),
+              const SbString * COIN_UNUSED_ARG(tosystem),
+              const int COIN_UNUSED_ARG(numtosys))
 {
     // to convert from GD to GC see this article
     // http://en.wikipedia.org/wiki/Geodetic_system

--- a/src/glue/gl_egl.cpp
+++ b/src/glue/gl_egl.cpp
@@ -60,7 +60,7 @@
 
 #ifndef HAVE_EGL
 
-void * eglglue_getprocaddress(const cc_glglue * glue_in, const char * fname)
+void * eglglue_getprocaddress(const cc_glglue * COIN_UNUSED_ARG(glue_in), const char * fname)
 {
   return NULL;
 }
@@ -497,7 +497,7 @@ eglglue_context_pbuffer_max(void * ctx, unsigned int * lims)
 }
 
 void *
-eglglue_getprocaddress(const cc_glglue * glue_in, const char * fname)
+eglglue_getprocaddress(const cc_glglue * COIN_UNUSED_ARG(glue_in), const char * fname)
 {
   return (void *)eglGetProcAddress(fname);
 }

--- a/src/hardcopy/VectorizeActionP.cpp
+++ b/src/hardcopy/VectorizeActionP.cpp
@@ -1067,7 +1067,7 @@ SoVectorizeActionP::clip_cb(const SbVec3f & COIN_UNUSED_ARG(v0), void * vdata0,
 // SoCamera pre callback. Needed to set up culling.
 //
 SoCallbackAction::Response 
-SoVectorizeActionP::camera_cb(void * COIN_UNUSED_ARG(data), SoCallbackAction * action, const SoNode * node)
+SoVectorizeActionP::camera_cb(void * COIN_UNUSED_ARG(data), SoCallbackAction * action, const SoNode * COIN_UNUSED_ARG(node))
 {
   assert(node->isOfType(SoCamera::getClassTypeId()));
   SoState * state = action->getState();

--- a/src/io/gzmemio.cpp
+++ b/src/io/gzmemio.cpp
@@ -829,7 +829,7 @@ cc_gzm_ftell(cc_gzm_file * file)
 }
 
 static size_t
-cc_gzm_fread(void * ptr, size_t size, size_t nmemb, cc_gzm_file * file)
+cc_gzm_fread(void * ptr, size_t COIN_UNUSED_ARG(size), size_t nmemb, cc_gzm_file * file)
 {
   uint32_t remain;
 

--- a/src/misc/SoGlyph.cpp
+++ b/src/misc/SoGlyph.cpp
@@ -329,7 +329,7 @@ SoGlyph::getBoundingBox(void) const
   Sets the coordinates for this glyph.
 */
 void
-SoGlyph::setCoords(const SbVec2f *coords, int numcoords)
+SoGlyph::setCoords(const SbVec2f *coords, int COIN_UNUSED_ARG(numcoords))
 {
   // It used to be valid to call this function with a negative value
   // (which signified that data should not be copied). All invoking
@@ -348,7 +348,7 @@ SoGlyph::setCoords(const SbVec2f *coords, int numcoords)
   Sets the face indices for this glyph.
 */
 void
-SoGlyph::setFaceIndices(const int *indices, int numindices)
+SoGlyph::setFaceIndices(const int *indices, int COIN_UNUSED_ARG(numindices))
 {
   // It used to be valid to call this function with a negative value
   // (which signified that data should not be copied). All invoking
@@ -367,7 +367,7 @@ SoGlyph::setFaceIndices(const int *indices, int numindices)
   Sets the edge indices for this glyph.
 */
 void
-SoGlyph::setEdgeIndices(const int *indices, int numindices)
+SoGlyph::setEdgeIndices(const int *indices, int COIN_UNUSED_ARG(numindices))
 {
   // It used to be valid to call this function with a negative value
   // (which signified that data should not be copied). All invoking

--- a/src/misc/SoNotRec.cpp
+++ b/src/misc/SoNotRec.cpp
@@ -58,6 +58,8 @@
 #include <Inventor/errors/SoDebugError.h>
 #include <cassert>
 
+#include "coindefs.h"
+
 #if COIN_DEBUG  // for SoNotRec::print() method
 #include <Inventor/misc/SoBase.h>
 #include <Inventor/SbName.h>
@@ -131,7 +133,7 @@ SoNotRec::setPrevious(const SoNotRec * const prevptr)
   Prints debug information.
 */
 void
-SoNotRec::print(FILE * const file) const
+SoNotRec::print(FILE * const COIN_UNUSED_ARG(file)) const
 {
 #if COIN_DEBUG
   (void)fprintf(file, "\tSoNotRec %p: type ", this);

--- a/src/misc/SoNotification.cpp
+++ b/src/misc/SoNotification.cpp
@@ -45,6 +45,8 @@
 #include <cassert>
 #include <ctime>
 
+#include "coindefs.h"
+
 
 /*!
   Initialize list.
@@ -199,7 +201,7 @@ SoNotList::getTimeStamp(void) const
   if compiled with debug information on.
 */
 void
-SoNotList::print(FILE * const file) const
+SoNotList::print(FILE * const COIN_UNUSED_ARG(file)) const
 {
 #if COIN_DEBUG
   (void)fprintf(file, "SoNotList: %p\n", this);

--- a/src/nodes/SoGroup.cpp
+++ b/src/nodes/SoGroup.cpp
@@ -213,6 +213,7 @@
 #include "rendering/SoGL.h"
 #include "glue/glp.h"
 #include "io/SoWriterefCounter.h"
+#include "coindefs.h"
 
 #include <Inventor/annex/Profiler/SoProfiler.h>
 #include "profiler/SoNodeProfiling.h"
@@ -729,7 +730,7 @@ SoGroup::audioRender(SoAudioRenderAction * action)
 
 // Doc from superclass.
 void
-SoGroup::addWriteReference(SoOutput * out, SbBool isfromfield)
+SoGroup::addWriteReference(SoOutput * out, SbBool COIN_UNUSED_ARG(isfromfield))
 {
   // SoGroup::write() used to count write references of children by calling
   // doAction() when ref was zero in the SoOutput::COUNT_REFS stage. However, 

--- a/src/rendering/SoRenderManager.cpp
+++ b/src/rendering/SoRenderManager.cpp
@@ -446,7 +446,7 @@ SoRenderManager::detachRootSensor(void)
   \deprecated Will not be available in Coin 5
 */
 void
-SoRenderManager::attachClipSensor(SoNode * const sceneroot)
+SoRenderManager::attachClipSensor(SoNode * const COIN_UNUSED_ARG(sceneroot))
 {
   //PRIVATE(this)->clipsensor->attach(sceneroot);
   //if (PRIVATE(this)->autoclipping != SoRenderManager::NO_AUTO_CLIPPING) {

--- a/src/shapenodes/SoQuadMesh.cpp
+++ b/src/shapenodes/SoQuadMesh.cpp
@@ -192,6 +192,7 @@
 
 #include "rendering/SoGL.h"
 #include "nodes/SoSubNodeP.h"
+#include "coindefs.h"
 
 /*!
   \var SoSFInt32 SoQuadMesh::verticesPerColumn
@@ -317,7 +318,7 @@ static float precalculateWeight(int i)
   double p = sqrt(p2);
   return float(p / (1.0 + p));
 }
-static float qmeshGetWeight(float value)
+static float qmeshGetWeight(float COIN_UNUSED_ARG(value))
 {
 #if defined(HAVE_ILOGB)
   int exponent = ilogb(value) + (QUADMESH_WEIGHTS_NR / 2);

--- a/src/vrml97/AudioClip.cpp
+++ b/src/vrml97/AudioClip.cpp
@@ -899,8 +899,8 @@ SoVRMLAudioClipP::internal_read(void * COIN_UNUSED_ARG(datasource), void *buffer
 }
 
 int    
-SoVRMLAudioClipP::internal_seek(void * COIN_UNUSED_ARG(datasource), long COIN_UNUSED_ARG(offset), int whence,
-                       SoVRMLAudioClip *clip)
+SoVRMLAudioClipP::internal_seek(void * COIN_UNUSED_ARG(datasource), long COIN_UNUSED_ARG(offset), int COIN_UNUSED_ARG(whence),
+                       SoVRMLAudioClip * COIN_UNUSED_ARG(clip))
 {
   return -1;
 }

--- a/src/vrml97/Box.cpp
+++ b/src/vrml97/Box.cpp
@@ -196,7 +196,7 @@ SoVRMLBox::generatePrimitives(SoAction * action)
 
 // Doc in parent
 void
-SoVRMLBox::computeBBox(SoAction * action,
+SoVRMLBox::computeBBox(SoAction * COIN_UNUSED_ARG(action),
                        SbBox3f & COIN_UNUSED_ARG(box),
                        SbVec3f & center)
 {

--- a/src/vrml97/ImageTexture.cpp
+++ b/src/vrml97/ImageTexture.cpp
@@ -732,7 +732,7 @@ SoVRMLImageTexture::oneshot_readimage_cb(void * closure, SoSensor * sensor)
 // called (from SbImage) when image data is needed.
 //
 SbBool
-SoVRMLImageTexture::image_read_cb(const SbString & filename, SbImage * image, void * closure)
+SoVRMLImageTexture::image_read_cb(const SbString & filename, SbImage * COIN_UNUSED_ARG(image), void * closure)
 {
   SoVRMLImageTexture * thisp = (SoVRMLImageTexture*) closure;
   assert(&PRIVATE(thisp)->image == image);

--- a/src/xml/attribute.cpp
+++ b/src/xml/attribute.cpp
@@ -41,6 +41,7 @@
 #include <cstring>
 
 #include "utils.h"
+#include "coindefs.h"
 
 // TODO:
 // - optimize empty strings to use a static, nonfreeable buffer?
@@ -173,7 +174,7 @@ cc_xml_attr_calculate_size(const cc_xml_attr * attr)
 }
 
 size_t
-cc_xml_attr_write_to_buffer(const cc_xml_attr * attr, char * buffer, size_t bufsize)
+cc_xml_attr_write_to_buffer(const cc_xml_attr * attr, char * buffer, size_t COIN_UNUSED_ARG(bufsize))
 {
   // We assert on mismatches between calculated memory usage and actual memory
   // usage, since this must be calculated correctly for not getting memory corruption

--- a/src/xml/document.cpp
+++ b/src/xml/document.cpp
@@ -628,7 +628,7 @@ cc_xml_doc_set_root_x(cc_xml_doc * doc, cc_xml_elt * root)
 */
 
 cc_xml_elt *
-cc_xml_doc_get_root(const cc_xml_doc * doc)
+cc_xml_doc_get_root(const cc_xml_doc * COIN_UNUSED_ARG(doc))
 {
   assert(doc);
   return doc->root;
@@ -637,7 +637,7 @@ cc_xml_doc_get_root(const cc_xml_doc * doc)
 // *************************************************************************
 
 void
-cc_xml_doc_strip_whitespace_x(cc_xml_doc * doc)
+cc_xml_doc_strip_whitespace_x(cc_xml_doc * COIN_UNUSED_ARG(doc))
 {
   assert(doc);
   return;


### PR DESCRIPTION
## Summary

All are parameters read only inside code that a normal (NDEBUG)
release build compiles out: assert()-only consumption, #if COIN_DEBUG
blocks, platform #ifdef branches that don't apply here (e.g.
cc_internal_ftime() on Linux, qmeshGetWeight() without HAVE_ILOGB), or
stub/deprecated functions whose bodies were never implemented
(SoGeo::toGD/fromGD, SoRenderManager::attachClipSensor,
stl_facet_set/get_padding). Fixed with the existing COIN_UNUSED_ARG()
idiom (src/coindefs.h), reusing it in files that already use it and
adding the "coindefs.h" include where missing.

The largest single cluster (25 sites) is every Sb*::print(FILE * fp)
debug-dump method across src/base/ -- the whole body is guarded by
#if COIN_DEBUG, so fp is provably unused in a release build. Care was
taken not to add the include inside an existing #if COIN_DEBUG block
(would make the macro itself invisible in release builds) and not to
duplicate it where a file already pulled it in under a different
spelling (<coindefs.h> vs "coindefs.h").

steel.l/steel.cpp are Flex source and its checked-in generated output
(included verbatim via steel-wrapper.cpp, with #line directives
pointing back to steel.l, which is why the warnings report as
steel.l); both were edited in lockstep to keep them byte-identical.

Verified: full clean rebuild shows the exact same warning breakdown as
master except -Wunused-parameter 67->0 (859->792 total, zero errors);
full CoinTests suite passes (326 tests, 83566 checks) in both a normal
build and a Debug+ASan/UBSan build, with only the known pre-existing,
unrelated SbByteBufferP.icc UBSan finding present.

---
**Verified:** Full clean rebuild under GCC and clang (Linux) with the strict warning recipe (`-Wall -Wextra -Wpedantic` plus the specific flag(s) this fixes), `ctest` (1/1 pass), and a Debug build under AddressSanitizer/UndefinedBehaviorSanitizer running the full `CoinTests` suite with no new findings.

Also verified on Windows (MSVC / Visual Studio 17 2022, x64 Release, /W4): built and tested together with all sibling branches from this audit (merged into a local integration build), 0 errors, full `CoinTests` suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FHRXMxksBcEGfbN5bDVJzb
