### PR TITLE
Fix remaining unused-variable warnings

### DIFF
--- a/src/base/SbBSPTree.cpp
+++ b/src/base/SbBSPTree.cpp
@@ -270,7 +270,13 @@ coin_bspnode::split()
 
   this->dimension = dim; // set the dimension
 
-  float mid = (box.getMin()[dim] + box.getMax()[dim]) / 2.0f;
+  // Also read from in the #if COIN_DEBUG block further down (which
+  // is independent of BSP_SORTED_SPLIT), so it needs declaring
+  // whenever either condition holds.
+#if COIN_DEBUG || defined(BSP_SORTED_SPLIT)
+  const float mid = (box.getMin()[dim] + box.getMax()[dim]) / 2.0f;
+#endif
+
 #ifdef BSP_SORTED_SPLIT
   this->sort(); // sort vertices on ascending dimension values
 

--- a/src/base/SbDPViewVolume.cpp
+++ b/src/base/SbDPViewVolume.cpp
@@ -618,8 +618,7 @@ SbDPViewVolume::getWorldToScreenScale(const SbVec3d& worldCenter,
 
     // Find tangent point of sphere.
     SbVec3f tangentpt;
-    SbBool result = p.intersect(tl, tangentpt);
-    assert(result != FALSE);
+    if (p.intersect(tl, tangentpt) == FALSE) assert(false);
 
     // Return radius (which is equal to the scale factor, since we're
     // dealing with a unit sphere).

--- a/src/caches/SoNormalCache.cpp
+++ b/src/caches/SoNormalCache.cpp
@@ -464,7 +464,9 @@ SoNormalCache::generatePerFace(const SbVec3f * const coords,
   PRIVATE(this)->indices.truncate(0);
   PRIVATE(this)->normalArray.truncate(0, TRUE);
 
+#if COIN_DEBUG
   const int32_t * cstart = cind;
+#endif // COIN_DEBUG
   const int32_t * endptr = cind + nv;
 
   SbVec3f tmpvec;
@@ -619,7 +621,9 @@ SoNormalCache::generatePerFaceStrip(const SbVec3f * const coords,
   PRIVATE(this)->indices.truncate(0);
   PRIVATE(this)->normalArray.truncate(0, TRUE);
 
+#if COIN_DEBUG
   const int32_t * cstart = cind;
+#endif // COIN_DEBUG
   const int32_t * endptr = cind + nv;
 
   const SbVec3f * c0, * c1, * c2;
@@ -778,7 +782,9 @@ SoNormalCache::generatePerStrip(const SbVec3f * const coords,
   PRIVATE(this)->indices.truncate(0);
   PRIVATE(this)->normalArray.truncate(0, TRUE);
 
+#if COIN_DEBUG
   const int32_t * cstart = cind;
+#endif // COIN_DEBUG
   const int32_t * endptr = cind + nv;
 
   const SbVec3f * c0, * c1, * c2;

--- a/src/draggers/SoDirectionalLightDragger.cpp
+++ b/src/draggers/SoDirectionalLightDragger.cpp
@@ -199,10 +199,8 @@ SoDirectionalLightDragger::SoDirectionalLightDragger(void)
   SO_KIT_ADD_FIELD(translation, (0.0f, 0.0f, 0.0f));
   SO_KIT_INIT_INSTANCE();
 
-  SoDragger *pdragger = SO_GET_ANY_PART(this, "translator", SoDragPointDragger);
-  assert(pdragger);
-  SoDragger *sdragger = SO_GET_ANY_PART(this, "rotator", SoDragPointDragger);
-  assert(sdragger);
+  if (!SO_GET_ANY_PART(this, "translator", SoDragPointDragger)) assert(false);
+  if (!SO_GET_ANY_PART(this, "rotator", SoDragPointDragger)) assert(false);
 
   this->setPartAsDefault("material", "directionalLightOverallMaterial");
 

--- a/src/draggers/SoPointLightDragger.cpp
+++ b/src/draggers/SoPointLightDragger.cpp
@@ -154,8 +154,7 @@ SoPointLightDragger::SoPointLightDragger(void)
   SO_KIT_ADD_FIELD(translation, (0.0f, 0.0f, 0.0f));
   SO_KIT_INIT_INSTANCE();
 
-  SoDragger *pdragger = SO_GET_ANY_PART(this, "translator", SoDragPointDragger);
-  assert(pdragger);
+  if (!SO_GET_ANY_PART(this, "translator", SoDragPointDragger)) assert(false);
 
   this->setPartAsDefault("material", "pointLightOverallMaterial");
 

--- a/src/draggers/SoSpotLightDragger.cpp
+++ b/src/draggers/SoSpotLightDragger.cpp
@@ -231,10 +231,8 @@ SoSpotLightDragger::SoSpotLightDragger(void)
   SO_KIT_ADD_FIELD(angle, (1.0f));
   SO_KIT_INIT_INSTANCE();
 
-  SoDragger *pdragger = SO_GET_ANY_PART(this, "translator", SoDragPointDragger);
-  assert(pdragger);
-  SoDragger *sdragger = SO_GET_ANY_PART(this, "rotator", SoDragPointDragger);
-  assert(sdragger);
+  if (!SO_GET_ANY_PART(this, "translator", SoDragPointDragger)) assert(false);
+  if (!SO_GET_ANY_PART(this, "rotator", SoDragPointDragger)) assert(false);
 
   this->setPartAsDefault("beam", "spotLightBeam");
   this->setPartAsDefault("beamActive", "spotLightBeamActive");

--- a/src/elements/GL/SoGLClipPlaneElement.cpp
+++ b/src/elements/GL/SoGLClipPlaneElement.cpp
@@ -118,9 +118,10 @@ SoGLClipPlaneElement::getMaxGLPlanes(void)
   GLint val;
   glGetIntegerv(GL_MAX_CLIP_PLANES, &val);
 
-  GLenum err = sogl_glerror_debugging() ? glGetError() : GL_NO_ERROR;
-  assert(err == GL_NO_ERROR &&
-         "GL error when calling glGetInteger() -- no current GL context?");
+  const GLenum err = sogl_glerror_debugging() ? glGetError() : GL_NO_ERROR;
+  if (err != GL_NO_ERROR) {
+    assert(!"GL error when calling glGetInteger() -- no current GL context?");
+  }
 
   return (int)val;
 }

--- a/src/elements/GL/SoGLLightIdElement.cpp
+++ b/src/elements/GL/SoGLLightIdElement.cpp
@@ -181,9 +181,10 @@ SoGLLightIdElement::getMaxGLSources(void)
   GLint val;
   glGetIntegerv(GL_MAX_LIGHTS, &val);
 
-  GLenum err = sogl_glerror_debugging() ? glGetError() : GL_NO_ERROR;
-  assert(err == GL_NO_ERROR &&
-         "GL error when calling glGetInteger() -- no current GL context?");
+  const GLenum err = sogl_glerror_debugging() ? glGetError() : GL_NO_ERROR;
+  if (err != GL_NO_ERROR) {
+    assert(!"GL error when calling glGetInteger() -- no current GL context?");
+  }
 
   return (int32_t)val;
 }

--- a/src/elements/GL/SoGLVertexAttributeElement.cpp
+++ b/src/elements/GL/SoGLVertexAttributeElement.cpp
@@ -205,9 +205,8 @@ static void enable_vbo(const Key & COIN_UNUSED_ARG(key),
   SoGLRenderAction * action = static_cast<SoGLRenderAction *>(closure);
   const cc_glglue * glue = sogl_glue_instance(action->getState());
 
-  const SoCoordinateElement * coords =
-    SoCoordinateElement::getInstance(action->getState());
-  assert(coords->getNum() == attribdata->data->getNum());
+  assert(SoCoordinateElement::getInstance(action->getState())->getNum() ==
+         attribdata->data->getNum());
 
   const void * dataptr = NULL;
 

--- a/src/engines/SoConvertAll.cpp
+++ b/src/engines/SoConvertAll.cpp
@@ -663,8 +663,7 @@ register_convertfunc(convert_func * f, SoType from, SoType to)
 {
   SoDB::addConverter(from, to, SoConvertAll::getClassTypeId());
   uint32_t val = (static_cast<uint32_t>(from.getKey()) << 16) + to.getKey();
-  SbBool nonexist = convertfunc_dict->put(val, f);
-  assert(nonexist);
+  if (!convertfunc_dict->put(val, f)) assert(false);
 }
 
 extern "C" {

--- a/src/engines/SoEngine.cpp
+++ b/src/engines/SoEngine.cpp
@@ -469,8 +469,8 @@ SoEngine::copy(void) const
   cp->ref();
 
   // Call findCopy() to have copyContents() run once.
-  SoEngine * dummy = coin_assert_cast<SoEngine *>(SoFieldContainer::findCopy(this, TRUE));
-  assert(dummy == cp);
+  const SoEngine * dummy = coin_assert_cast<SoEngine *>(SoFieldContainer::findCopy(this, TRUE));
+  if (dummy != cp) assert(false);
 
   SoFieldContainer::copyDone();
   // unrefNoDelete() so that we return a copy with reference count 0

--- a/src/fields/SoFieldContainer.cpp
+++ b/src/fields/SoFieldContainer.cpp
@@ -937,10 +937,9 @@ SoFieldContainer::findCopy(const SoFieldContainer * orig,
   // here in those cases to be compatible with SGI Inventor.
   if (copydict->copiedinstancestack->getLength() == 0) return NULL;
 
-  SoFieldContainerCopyMap * copiedinstances = (*(copydict->copiedinstancestack))[0];
   ContentsCopiedMap * contentscopied  = (*(copydict->contentscopiedstack))[0];
 
-  assert(copiedinstances);
+  assert((*(copydict->copiedinstancestack))[0]);
   assert(contentscopied);
 
   const SoNode * protonode = coin_safe_cast<const SoNode *>(orig);

--- a/src/fields/SoMField.cpp
+++ b/src/fields/SoMField.cpp
@@ -688,9 +688,9 @@ SoMField::deleteValues(int start, int numarg)
 
   if (numarg == -1) numarg = oldnum - start;
   if (numarg == 0) return;
-  int end = start + numarg; // First element behind the delete block.
 
 #if COIN_DEBUG
+  const int end = start + numarg; // First element behind the delete block.
   if (start < 0 || start >= oldnum || end > oldnum || numarg < -1) {
     SoDebugError::post("SoMField::deleteValues",
                        "invalid indices [%d, %d] for array of size %d",

--- a/src/foreignfiles/SoSTLFileKit.cpp
+++ b/src/foreignfiles/SoSTLFileKit.cpp
@@ -691,8 +691,8 @@ SoSTLFileKit::organizeModel(void)
   SoIndexedFaceSet * facets =
     SO_GET_ANY_PART(this, "facets", SoIndexedFaceSet);
 
-  assert(facets->coordIndex.getNum() == PRIVATE(this)->numfacets*4);
-  assert(facets->normalIndex.getNum() == (PRIVATE(this)->numfacets));
+  if (facets->coordIndex.getNum() != PRIVATE(this)->numfacets*4) assert(false);
+  if (facets->normalIndex.getNum() != (PRIVATE(this)->numfacets)) assert(false);
 
   if ( PRIVATE(this)->numfacets > 300 ) {
     // FIXME: at some number of facets, reorganization for faster

--- a/src/glue/gl.cpp
+++ b/src/glue/gl.cpp
@@ -294,7 +294,9 @@ static cc_list * gl_instance_created_cblist = NULL;
 static int COIN_MAXIMUM_TEXTURE2_SIZE = -1;
 static int COIN_MAXIMUM_TEXTURE3_SIZE = -1;
 static cc_glglue_offscreen_cb_functions* offscreen_cb = NULL;
+#if defined(HAVE_AGL)
 static int COIN_USE_AGL = -1;
+#endif
 static int COIN_USE_EGL = -1;
 
 /* ********************************************************************** */
@@ -2326,8 +2328,7 @@ cc_glglue_instance(int contextid)
       chk = coin_getenv("COIN_GL_NO_CURRENT_CONTEXT_CHECK") ? 0 : 1;
     }
     if (chk) {
-      const void * current_ctx = coin_gl_current_context();
-      assert(current_ctx && "Must have a current GL context when instantiating cc_glglue!! (Note: if you are using an old Mesa GL version, set the environment variable COIN_GL_NO_CURRENT_CONTEXT_CHECK to get around what may be a Mesa bug.)");
+      if (!coin_gl_current_context()) assert(!"Must have a current GL context when instantiating cc_glglue!! (Note: if you are using an old Mesa GL version, set the environment variable COIN_GL_NO_CURRENT_CONTEXT_CHECK to get around what may be a Mesa bug.)");
     }
 
     /* FIXME: this is not free'd until app exit, which is bad because

--- a/src/glue/gl_egl.cpp
+++ b/src/glue/gl_egl.cpp
@@ -267,7 +267,6 @@ void *
 eglglue_context_create_offscreen(unsigned int width, unsigned int height)
 {
   struct eglglue_contextdata * ctx;
-  EGLint format;
   EGLint numConfigs;
   EGLConfig config;
   EGLint attrib[] = {
@@ -474,7 +473,7 @@ eglglue_context_can_render_to_texture(void * ctx)
 SbBool
 eglglue_context_pbuffer_max(void * ctx, unsigned int * lims)
 {
-  int returnval, attribval, i;
+  int attribval, i;
   const int attribs[] = {
     EGL_MAX_PBUFFER_WIDTH, EGL_MAX_PBUFFER_HEIGHT, EGL_MAX_PBUFFER_PIXELS
   };

--- a/src/glue/gl_glx.cpp
+++ b/src/glue/gl_glx.cpp
@@ -635,8 +635,7 @@ glxglue_find_gl_visual(void)
   if (glxglue_get_display() == NULL) { return NULL; }
 
   while (visinfo == NULL && trynum < 8) {
-    int arraysize = glxglue_build_GL_attrs(attrs, trynum);
-    assert(arraysize < ARRAYSIZE);
+    if (glxglue_build_GL_attrs(attrs, trynum) >= ARRAYSIZE) assert(false);
     visinfo = glXChooseVisual(glxglue_get_display(), DefaultScreen(glxglue_get_display()),
                               attrs);
     trynum++;

--- a/src/io/SoWriterefCounter.cpp
+++ b/src/io/SoWriterefCounter.cpp
@@ -213,8 +213,7 @@ SoWriterefCounter::create(SoOutput * out, SoOutput * copyfrom)
 {
   SoWriterefCounter * inst = new SoWriterefCounter(out, copyfrom);
   CC_MUTEX_LOCK(SoWriterefCounterP::mutex);
-  SbBool ret = SoWriterefCounterP::outputdict->put(out, inst);
-  assert(ret && "writeref instance already exists!");
+  if (!SoWriterefCounterP::outputdict->put(out, inst)) assert(!"writeref instance already exists!");
   CC_MUTEX_UNLOCK(SoWriterefCounterP::mutex);
 }
 

--- a/src/misc/SoBaseP.cpp
+++ b/src/misc/SoBaseP.cpp
@@ -115,8 +115,7 @@ SoBase::PImpl::removeName2Obj(SoBase * const base, const char * const name)
 {
   CC_MUTEX_LOCK(SoBase::PImpl::name2obj_mutex);
   SbHash<const char*, SbPList*>::const_iterator iter = SoBase::PImpl::name2obj->find(name);
-  SbBool found = (iter != SoBase::PImpl::name2obj->const_end());
-  assert(found);
+  assert(iter != SoBase::PImpl::name2obj->const_end());
   
   SbPList * l = iter->obj;
 

--- a/src/misc/SoCompactPathList.cpp
+++ b/src/misc/SoCompactPathList.cpp
@@ -63,11 +63,10 @@ SoCompactPathList::SoCompactPathList(const SoPathList & list)
   : stack(256)
 {
   assert(list.getLength());
-  SoNode * head = FULL_PATH(list, 0)->getHead();
   int numnodes = 0;
 
   for (int i = 0; i < list.getLength(); i++) {
-    assert(FULL_PATH(list, i)->getHead() == head);
+    assert(FULL_PATH(list, i)->getHead() == FULL_PATH(list, 0)->getHead());
     numnodes += FULL_PATH(list, i)->getLength() - 1;
   }
   // 3 entries for each node + one extra for the root. This is a

--- a/src/misc/SoContextHandler.cpp
+++ b/src/misc/SoContextHandler.cpp
@@ -258,8 +258,7 @@ SoContextHandler::removeContextDestructionCallback(ContextDestructionCB * func, 
   item.closure = closure;
 
   CC_MUTEX_LOCK(socontexthandler_mutex);
-  size_t didremove = socontexthandler_hashlist->erase(item);
-  assert(didremove);
+  if (!socontexthandler_hashlist->erase(item)) assert(false);
   CC_MUTEX_UNLOCK(socontexthandler_mutex);
 }
 

--- a/src/misc/SoDB.cpp
+++ b/src/misc/SoDB.cpp
@@ -187,7 +187,9 @@ static void cleanup_func(void)
 // rather placed static in a thunk in the DLL/.so. Needs to fetch a
 // value that cannot have been compiled in. 20050506 mortene.
 
+#if COIN_DEBUG
 static uint32_t a_static_variable = 0xdeadbeef;
+#endif // COIN_DEBUG
 
 // *************************************************************************
 
@@ -1242,7 +1244,9 @@ SoDB::readAllWrapper(SoInput * in, const SoType & grouptype)
     return NULL;
   }
 
+#if COIN_DEBUG
   const int stackdepth = in->filestack.getLength();
+#endif // COIN_DEBUG
 
   SoGroup * root = (SoGroup *)grouptype.createInstance();
   SoNode * topnode;

--- a/src/misc/SoJavaScriptEngine.cpp
+++ b/src/misc/SoJavaScriptEngine.cpp
@@ -160,8 +160,7 @@ static void printJSException(JSContext *cx)
   */
   // FIXME: this looks ugly. 20050719 erikgors.
   // FIXME: indeed it does. we shouldn't use stderr directly anywhere, for starters.  -mortene.
-  const size_t wrote = fwrite(cstr, 1, len, stderr);
-  assert(wrote == len);
+  if (fwrite(cstr, 1, len, stderr) != len) assert(false);
   (void)fprintf(stderr, "\n");
   ok = spidermonkey()->JS_RemoveRoot(cx, &s);
   assert(ok && "JS_RemoveRoot failed");

--- a/src/profiler/SbProfilingData.cpp
+++ b/src/profiler/SbProfilingData.cpp
@@ -670,15 +670,13 @@ SbProfilingData::getIndexForwardCreate(const SoFullPath * fullpath, int pathlen,
   assert(parentidx < static_cast<int>(PRIVATE(this)->nodeData.size()));
   assert(pathlen > 1);
 
-  SbProfilingNodeKey parent =
-    static_cast<SbProfilingNodeKey>(fullpath->getNode(pathlen - 2));
-  int pidx = fullpath->getIndex(pathlen - 2);
   SoNode * tailnode = fullpath->getNode(pathlen - 1);
   SbProfilingNodeKey tail = static_cast<SbProfilingNodeKey>(tailnode);
   int tidx = fullpath->getIndex(pathlen - 1);
 
-  assert(parent == PRIVATE(this)->nodeData[parentidx].node);
-  assert(pidx == PRIVATE(this)->nodeData[parentidx].childidx);
+  assert(static_cast<SbProfilingNodeKey>(fullpath->getNode(pathlen - 2)) ==
+         PRIVATE(this)->nodeData[parentidx].node);
+  assert(fullpath->getIndex(pathlen - 2) == PRIVATE(this)->nodeData[parentidx].childidx);
 
   const int nodedatacount = (int)PRIVATE(this)->nodeData.size();
   for (int idx = parentidx + 1; idx < nodedatacount; ++idx) {
@@ -710,15 +708,13 @@ SbProfilingData::getIndexForwardNoCreate(const SoFullPath * fullpath, int pathle
   assert(parentidx != -1); // illegal usage
   assert(pathlen > 1);
 
-  SbProfilingNodeKey parent =
-    static_cast<SbProfilingNodeKey>(fullpath->getNode(pathlen - 2));
-  int pidx = fullpath->getIndex(pathlen - 2);
   SbProfilingNodeKey tail =
     static_cast<SbProfilingNodeKey>(fullpath->getNode(pathlen - 1));
   int tidx = fullpath->getIndex(pathlen - 1);
 
-  assert(parent == PRIVATE(this)->nodeData[parentidx].node);
-  assert(pidx == PRIVATE(this)->nodeData[parentidx].childidx);
+  assert(static_cast<SbProfilingNodeKey>(fullpath->getNode(pathlen - 2)) ==
+         PRIVATE(this)->nodeData[parentidx].node);
+  assert(fullpath->getIndex(pathlen - 2) == PRIVATE(this)->nodeData[parentidx].childidx);
 
   const int nodedatacount = (int)PRIVATE(this)->nodeData.size();
   for (int idx = parentidx + 1; idx < nodedatacount; ++idx) {

--- a/src/rendering/SoOffscreenRenderer.cpp
+++ b/src/rendering/SoOffscreenRenderer.cpp
@@ -887,11 +887,9 @@ SoOffscreenRendererP::renderFromBase(SoBase * base)
 
           FILE * f = fopen(s.getString(), "wb");
 		  if (f) {
-            SbBool w = SoOffscreenRendererP::writeToRGB(f, fullsize[0], fullsize[1],
-                                                        nrcomp, this->buffer);
-            assert(w);
-            const int r = fclose(f);
-            assert(r == 0);
+            if (!SoOffscreenRendererP::writeToRGB(f, fullsize[0], fullsize[1],
+                                                  nrcomp, this->buffer)) assert(false);
+            if (fclose(f) != 0) assert(false);
 		  }
 
           // This is sometimes useful to enable during debugging to
@@ -1123,8 +1121,7 @@ SoOffscreenRendererP::writeToRGB(FILE * fp, unsigned int w, unsigned int h,
   (void)memset(buf, 0, BUFSIZE);
   buf[7] = 255; // set maximum pixel value to 255
   strcpy((char *)buf+8, "https://github.com/coin3d/");
-  const size_t wrote = fwrite(buf, 1, BUFSIZE, fp);
-  assert(wrote == BUFSIZE);
+  if (fwrite(buf, 1, BUFSIZE, fp) != BUFSIZE) assert(false);
 
   unsigned char * tmpbuf = new unsigned char[w];
 

--- a/src/shapenodes/SoNurbsCurve.cpp
+++ b/src/shapenodes/SoNurbsCurve.cpp
@@ -250,10 +250,9 @@ SoNurbsCurve::computeBBox(SoAction * action, SbBox3f & box, SbVec3f & center)
   const SoCoordinateElement * coordelem =
     SoCoordinateElement::getInstance(state);
 
-  int numCoords = coordelem->getNum();
   int num = this->numControlPoints.getValue();
 
-  assert(num <= numCoords);
+  assert(num <= coordelem->getNum());
 
   SbVec3f acccenter(0.0f, 0.0f, 0.0f);
   box.makeEmpty();

--- a/src/tidbits.cpp
+++ b/src/tidbits.cpp
@@ -1404,8 +1404,7 @@ coin_locale_set_portable(cc_string * storeold)
 void
 coin_locale_reset(cc_string * storedold)
 {
-  const char * l = setlocale(LC_NUMERIC, cc_string_get_text(storedold));
-  assert(l != NULL && "could not reset locale");
+  if (!setlocale(LC_NUMERIC, cc_string_get_text(storedold))) assert(!"could not reset locale");
   cc_string_clean(storedold);
 }
 

--- a/src/vrml97/IndexedLine.cpp
+++ b/src/vrml97/IndexedLine.cpp
@@ -87,7 +87,6 @@ SoVRMLIndexedLine::computeBBox(SoAction * COIN_UNUSED_ARG(action),
   SoVRMLCoordinate * node = (SoVRMLCoordinate*) this->coord.getValue();
   if (node == NULL) return;
 
-  int numCoords = node->point.getNum();
   const SbVec3f * coords = node->point.getValues(0);
 
   box.makeEmpty();
@@ -95,7 +94,7 @@ SoVRMLIndexedLine::computeBBox(SoAction * COIN_UNUSED_ARG(action),
   const int32_t * endptr = ptr + coordIndex.getNum();
   while (ptr < endptr) {
     int idx = *ptr++;
-    assert(idx < numCoords);
+    assert(idx < node->point.getNum());
     if (idx >= 0) box.extendBy(coords[idx]);
   }
   if (!box.isEmpty()) center = box.getCenter();

--- a/src/vrml97/TimeSensor.cpp
+++ b/src/vrml97/TimeSensor.cpp
@@ -401,8 +401,7 @@ SoVRMLTimeSensor::inputChanged(SoField * which)
     if (!PRIVATE(this)->running) {
       PRIVATE(this)->starttime = this->startTime.getValue().getValue();
       if (currtime >= PRIVATE(this)->starttime) {
-        SbBool old = this->timeIn.enableNotify(TRUE);
-        assert(old == FALSE);
+        if (this->timeIn.enableNotify(TRUE) != FALSE) assert(false);
         which = &this->timeIn; // warning, hack
       } else {
         // enable to wait for timeIn to be >= starttime

--- a/src/xml/attribute.cpp
+++ b/src/xml/attribute.cpp
@@ -180,7 +180,7 @@ cc_xml_attr_write_to_buffer(const cc_xml_attr * attr, char * buffer, size_t bufs
   // on invalid buffer size allocation before writing.
   const char * const origbufferptr = buffer;
   const size_t assumed = cc_xml_attr_calculate_size(attr);
-  assert(assumed < bufsize);
+  if (assumed >= bufsize) assert(false);
   size_t namelen = strlen(attr->name);
   strcpy(buffer, attr->name);
   buffer += namelen;
@@ -195,7 +195,7 @@ cc_xml_attr_write_to_buffer(const cc_xml_attr * attr, char * buffer, size_t bufs
   buffer[0] = '"';
   buffer += 1;
   size_t used = buffer - origbufferptr;
-  assert(used == assumed);
+  if (used != assumed) assert(false);
   return used;
 }
 

--- a/src/xml/document.cpp
+++ b/src/xml/document.cpp
@@ -759,8 +759,7 @@ cc_xml_doc_write_to_file(const cc_xml_doc * doc, const char * path)
     buffer.reset(bufptr);
   }
 
-  const size_t bytes = strlen(buffer.get());
-  assert(bufsize == bytes);
+  if (bufsize != strlen(buffer.get())) assert(false);
   FILE * fp = NULL;
   if (strcmp(path, "-") == 0)
     fp = stdout;

--- a/src/xml/element.cpp
+++ b/src/xml/element.cpp
@@ -501,8 +501,7 @@ cc_xml_elt_insert_child_x(cc_xml_elt * elt, cc_xml_elt * child, int idx)
     // FIXME: error, child already a child of another element
     return;
   }
-  const int numchildren = elt->children.getLength();
-  assert(idx >= 0 && idx <= numchildren);
+  assert(idx >= 0 && idx <= elt->children.getLength());
   elt->children.insert(child, idx);
   child->parent = elt;
 }
@@ -1197,7 +1196,7 @@ cc_xml_elt_write_to_buffer(const cc_xml_elt * elt, char * buffer, size_t bufsize
 #undef ADVANCE_STRING
 #undef ADVANCE_STRING_LITERAL
 
-  assert(bytes == assumed);
+  if (bytes != assumed) assert(false);
   return bytes;
 }
 


### PR DESCRIPTION
## Summary

Resolve the remaining one-off unused-variable warnings that were intentionally kept separate from the larger assert-only migration.

The final diff against current master touches 31 files. It preserves calls with required side effects, moves pure declarations into the compile-time regions that consume them, and removes declarations that are genuinely dead. The branch was merged with current master without changing the already validated source tree.

## Validation

- GCC 13 Release: full build and 8/8 CTest entries passed.
- Clang 18 Release with Wall, Wextra and Wpedantic: full build and 8/8 CTest entries passed.
- The Coin library itself builds with unused-variable promoted to an error. Pre-existing unused-variable warnings in test sources prevent applying that Werror policy to the entire testsuite.
- Clang 18 Debug with AddressSanitizer and UndefinedBehaviorSanitizer instrumenting both Coin and the test binaries: 8/8 CTest entries passed with UBSan recovery enabled.
- diff check against current master passed.

The sanitizer run also observes a pre-existing SoReorganizeAction downcast diagnostic in the STL round-trip test when UBSan is configured to abort on the first finding. It is outside this PR and is recorded as a validation limitation rather than attributed to this change.

Windows, macOS and optional-feature combinations are covered by CI rather than this local rerun.
