### PR TITLE
Fix use-after-free in SoVRMLScript destructor

### DIFF
--- a/src/vrml97/Script.cpp
+++ b/src/vrml97/Script.cpp
@@ -40,6 +40,8 @@
 
 // *************************************************************************
 
+#include <Inventor/VRMLnodes/SoVRMLScript.h>
+
 #ifdef HAVE_CONFIG_H
 #include <config.h>
 #endif // HAVE_CONFIG_H
@@ -151,7 +153,6 @@
 
 // *************************************************************************
 
-#include <Inventor/VRMLnodes/SoVRMLScript.h>
 #include "coindefs.h"
 
 #include <cassert>
@@ -376,16 +377,10 @@ SoVRMLScript::~SoVRMLScript()
         f != &this->url &&
         f != &this->mustEvaluate) delete f;
   }
-  // Clear the pointer before deleting: url/directOutput/mustEvaluate
-  // are plain data members, so their destructors run implicitly right
-  // after this function body returns, and code reachable from them
-  // (e.g. SoField::setDefault()'s debug tracing) calls getFieldData().
-  // Leaving a dangling this->fielddata would make that a use-after-free;
-  // getFieldData() returning NULL here is already handled gracefully
-  // by callers (e.g. SoFieldContainer::getFieldName()).
-  SoFieldData * fd = this->fielddata;
+  delete this->fielddata;
+  // Built-in field members are destroyed after this body and may query
+  // getFieldData() through debug tracing. Do not leave a dangling pointer.
   this->fielddata = NULL;
-  delete fd;
 }
 
 // *************************************************************************
@@ -1002,3 +997,29 @@ SoVRMLScriptP::executeFunctions(void)
 #undef PUBLIC
 
 #endif // HAVE_VRML97
+
+#ifdef COIN_TEST_SUITE
+
+#include <Inventor/SoType.h>
+#include <Inventor/nodes/SoNode.h>
+#include <Inventor/fields/SoMFString.h>
+
+// To exercise the original dangling-pointer read, compile the library with
+// COIN_DEBUG_EXTRA=1 and run with COIN_WARNING_LEVEL=3 under ASan/UBSan.
+// Use runtime type lookup so builds without VRML97 can still link CoinTests.
+BOOST_AUTO_TEST_CASE(script_member_destruction)
+{
+  const SoType type = SoType::fromName("VRMLScript");
+  if (type == SoType::badType()) return; // VRML97 disabled.
+  SoNode * script = static_cast<SoNode *>(type.createInstance());
+  BOOST_REQUIRE_MESSAGE(script != NULL, "could not create VRML Script");
+  script->ref();
+  SoField * field = script->getField("url");
+  BOOST_REQUIRE_MESSAGE(field && field->isOfType(SoMFString::getClassTypeId()),
+                        "Script must expose its built-in MFString url field");
+  SoMFString * url = static_cast<SoMFString *>(field);
+  url->set1Value(0, "");
+  script->unref(); // Implicit url destruction must not read freed field data.
+}
+
+#endif // COIN_TEST_SUITE

--- a/src/vrml97/Script.cpp
+++ b/src/vrml97/Script.cpp
@@ -376,7 +376,16 @@ SoVRMLScript::~SoVRMLScript()
         f != &this->url &&
         f != &this->mustEvaluate) delete f;
   }
-  delete this->fielddata;
+  // Clear the pointer before deleting: url/directOutput/mustEvaluate
+  // are plain data members, so their destructors run implicitly right
+  // after this function body returns, and code reachable from them
+  // (e.g. SoField::setDefault()'s debug tracing) calls getFieldData().
+  // Leaving a dangling this->fielddata would make that a use-after-free;
+  // getFieldData() returning NULL here is already handled gracefully
+  // by callers (e.g. SoFieldContainer::getFieldName()).
+  SoFieldData * fd = this->fielddata;
+  this->fielddata = NULL;
+  delete fd;
 }
 
 // *************************************************************************


### PR DESCRIPTION
When a VRML Script is destroyed, its built-in `url`, `directOutput`, and `mustEvaluate` fields are destroyed after the destructor body. Debug tracing reached during member destruction can call `getFieldData()`. Previously, that returned the field-data pointer already freed by the destructor, causing a use-after-free.

Delete the per-instance field data, then immediately set `this->fielddata = NULL`. `SoFieldContainer::getFieldName()` already handles a null field-data pointer. As suggested in review, no temporary pointer is needed: `SoFieldData` destroys metadata without callbacks into the owning node, so clearing the pointer after `delete` is sufficient before implicit member destruction begins.

Add a public-API `CoinTests` regression that creates a VRML Script, populates its built-in `url` field, and destroys the node. The component header is now the first include so the test extractor selects the correct header. Runtime type lookup keeps the test linkable when VRML97 is disabled; that configuration skips this case.

Validation on the final diff (Linux):

- GCC and Clang Release builds with `-Wall -Wextra -Wpedantic`; full `ctest` passes under both compilers.
- GCC Debug with `-fsanitize=address,undefined -fno-omit-frame-pointer` on the Coin library and tests. All 327 tests / 83,568 checks pass, but default CTest exits unsuccessfully because LeakSanitizer reports 11,552 bytes in 207 allocations from other suite tests. With `ASAN_OPTIONS=detect_leaks=0`, full CTest passes. The same 11,552 bytes / 207 allocations are reported when the new Script regression is omitted from the test executable. This is not a clean leak-check result.
- Recompiled `SoField.cpp` with `COIN_DEBUG_EXTRA=1` in the fully instrumented library. Ran the exact extracted Script regression alone with an instrumented driver, `COIN_WARNING_LEVEL=3`, and leak detection enabled: passes. Replacing only the destructor with its original version (no null assignment) reproduces ASan heap-use-after-free in `SbList<SoFieldEntry*>::getLength()`, reached via `SoFieldContainer::getFieldName()` and field destruction. Restoring the final destructor passes again.
- Reviewed the field-data destructor, null handling in `getFieldName()`, related per-instance field-data owners, and the remaining delete/reinitialize site in Script. Searched source, headers, documentation, examples and tests for affected lifetime claims and the previous temporary-pointer idiom. No remaining in-scope occurrence requires changing. The other owners destroy their dynamic fields before their metadata and do not combine them with built-in field members in the same way.

Limitations: Windows/MSVC and macOS were not rerun for this revision. VRML97 was enabled in the executed builds; the disabled-feature case was inspected statically. No JavaScript evaluation engine was available, so live JavaScript execution and rendering were not exercised; the Script node/member destruction path was exercised. The debug-specific regression requires the extra tracing configuration above; an ordinary build alone does not reproduce the original invalid read.
