### PR TITLE
Add explicit casts for provably-bounded narrowing in gzmemio.cpp / SoKeyboardEvent.cpp

### DIFF
--- a/src/events/SoKeyboardEvent.cpp
+++ b/src/events/SoKeyboardEvent.cpp
@@ -163,7 +163,8 @@ build_convert_dicts(void)
        i++
        )
     {
-      d->put(i, ('a' + i - static_cast<int>(SoKeyboardEvent::A)));
+      /* i ranges over A..Z here, so this is always a lowercase ASCII letter. */
+      d->put(i, static_cast<char>('a' + i - static_cast<int>(SoKeyboardEvent::A)));
     }
 
   // shift down
@@ -215,7 +216,8 @@ build_convert_dicts(void)
        i++
        )
     {
-    d->put(i, ('A' + i - static_cast<int>(SoKeyboardEvent::A)));
+    /* i ranges over A..Z here, so this is always an uppercase ASCII letter. */
+    d->put(i, static_cast<char>('A' + i - static_cast<int>(SoKeyboardEvent::A)));
   }
 #undef ADD_KEY
 }

--- a/src/io/gzmemio.cpp
+++ b/src/io/gzmemio.cpp
@@ -236,7 +236,9 @@ get_byte(cc_gzm_stream * s)
   if (s->z_eof) return EOF;
   if (s->stream.avail_in == 0) {
     /* errno = 0; */
-    s->stream.avail_in = cc_gzm_fread(s->inbuf, 1, Z_BUFSIZE, s->memfile);
+    /* cc_gzm_fread() can't return more than Z_BUFSIZE here (that's the
+       max it was asked to read), which always fits in an unsigned int. */
+    s->stream.avail_in = (unsigned int)cc_gzm_fread(s->inbuf, 1, Z_BUFSIZE, s->memfile);
     if (s->stream.avail_in == 0) {
       s->z_eof = 1;
       if (cc_gzm_ferror(s->memfile)) s->z_err = Z_ERRNO;
@@ -375,7 +377,9 @@ cc_gzm_read (void * file, void * buf, uint32_t len)
         s->stream.avail_in  -= n;
       }
       if (s->stream.avail_out > 0) {
-        s->stream.avail_out -= cc_gzm_fread(next_out, 1, s->stream.avail_out,
+        /* cc_gzm_fread() can't return more than avail_out here (that's
+           the max it was asked to read), which is itself an unsigned int. */
+        s->stream.avail_out -= (unsigned int)cc_gzm_fread(next_out, 1, s->stream.avail_out,
                                          s->memfile);
       }
       len -= s->stream.avail_out;
@@ -387,7 +391,9 @@ cc_gzm_read (void * file, void * buf, uint32_t len)
     if (s->stream.avail_in == 0 && !s->z_eof) {
 
       /* errno = 0; */
-      s->stream.avail_in = cc_gzm_fread(s->inbuf, 1, Z_BUFSIZE, s->memfile);
+      /* cc_gzm_fread() can't return more than Z_BUFSIZE here (that's
+         the max it was asked to read), which always fits in an unsigned int. */
+      s->stream.avail_in = (unsigned int)cc_gzm_fread(s->inbuf, 1, Z_BUFSIZE, s->memfile);
       if (s->stream.avail_in == 0) {
         s->z_eof = 1;
         if (cc_gzm_ferror(s->memfile)) {
@@ -836,7 +842,10 @@ cc_gzm_fread(void * ptr, size_t size, size_t nmemb, cc_gzm_file * file)
   assert(size == 1); /* to simplify implementation */
 
   remain = file->buflen - file->currpos;
-  if (remain > nmemb) remain = nmemb;
+  /* remain is already a uint32_t here, so "remain > nmemb" being true
+     means nmemb is smaller than that uint32_t value, and therefore
+     itself always fits back into one. */
+  if (remain > nmemb) remain = (uint32_t)nmemb;
   if (remain == 0) return 0;
 
   (void) memcpy(ptr, file->buf + file->currpos, remain);


### PR DESCRIPTION
gzmemio.cpp (all 4 sites, the entirety of this tree's C4267): each
assigns/subtracts the size_t return of cc_gzm_fread() into a uint32_t
or unsigned int, but every call site already bounds that return value
to fit: two are capped by the constant Z_BUFSIZE, one by avail_out
(itself an unsigned int), and the last is only assigned after a
"remain > nmemb" check proves nmemb smaller than a uint32_t already.
No behavior change; casts document why each is safe.

SoKeyboardEvent.cpp: build_convert_dicts() computes a lowercase/
uppercase ASCII letter as 'a'/'A' + int arithmetic, but the loop it's
in only ever runs for i in [A, Z], so the result always fits in a
char. Cast documents that bound.

Verified on Windows (MSVC / Visual Studio 17 2022, x64 Release, /W4):
C4267 drops from 4 to 0, C4244 drops by 2 more, 0 errors, full
CoinTests suite passes (326 tests, 83566 checks).

---
Additionally verified on Linux (GCC and clang), merged together with all sibling warning-cleanup branches from this audit: clean rebuild with no new warnings on the touched lines, full `ctest` suite pass, and a Debug AddressSanitizer/UndefinedBehaviorSanitizer build of the full `CoinTests` suite with no new findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FHRXMxksBcEGfbN5bDVJzb
