### PR TITLE
Cast getNextActionMethodIndex() to uint16_t in internal type-registration macros

### DIFF
--- a/include/Inventor/engines/SoSubNodeEngine.h
+++ b/include/Inventor/engines/SoSubNodeEngine.h
@@ -120,7 +120,7 @@ _class_::createInstance(void) \
       SoType::createType(_parentclass_::getClassTypeId(), \
                          _classname_, \
                          _createfunc_, \
-                         SoNode::getNextActionMethodIndex()); \
+                         (uint16_t)SoNode::getNextActionMethodIndex()); \
     SoNode::incNextActionMethodIndex(); \
  \
     /* Store parent's fielddata pointer for later use in the constructor. */ \

--- a/src/nodes/SoSubNodeP.h
+++ b/src/nodes/SoSubNodeP.h
@@ -58,7 +58,7 @@
       SoType::createType(_parentclass_::getClassTypeId(), \
                          _classname_, \
                          _createfunc_, \
-                         SoNode::getNextActionMethodIndex()); \
+                         (uint16_t)SoNode::getNextActionMethodIndex()); \
     SoNode::incNextActionMethodIndex(); \
  \
     /* Store parent's fielddata pointer for later use in the constructor. */ \


### PR DESCRIPTION
SoType::createType()'s 4th parameter (the type's compatibility/data
tag) is a uint16_t, but SoNode::getNextActionMethodIndex() returns
int -- and the two internal-only class-registration macros used by
every built-in node (SO_NODE_INTERNAL_INIT_CLASS, via
PRIVATE_INTERNAL_COMMON_INIT_CODE in SoSubNodeP.h) and node-engine
(SO_NODEENGINE_INIT_CLASS, via PRIVATE_COMMON_NODEENGINE_INIT_CODE in
SoSubNodeEngine.h) class in Coin passed that int straight through
uncast.

The sibling macro for application-extension node classes
(SO_NODE_INIT_CLASS, in the public SoSubNode.h) already had the
correct (uint16_t) cast in the exact same call -- these two internal
copies were just missed when it was added there. No behavior change:
this index is a monotonically incrementing count of registered
SoType-derived classes application-wide, so it will never remotely
approach 65536.

Because these two macros are expanded in literally every built-in
node and node-engine class's initClass(), this single two-line fix
resolves the large majority of all C4244 warnings under MSVC /W4.

Verified on Windows (MSVC / Visual Studio 17 2022, x64 Release, /W4):
C4244 drops from 373 to ~89 (284 sites resolved across every built-in
node/engine file that calls this macro), 0 errors, full CoinTests
suite passes (326 tests, 83566 checks).

---
Additionally verified on Linux (GCC and clang), merged together with all sibling warning-cleanup branches from this audit: clean rebuild with no new warnings on the touched lines, full `ctest` suite pass, and a Debug AddressSanitizer/UndefinedBehaviorSanitizer build of the full `CoinTests` suite with no new findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FHRXMxksBcEGfbN5bDVJzb
