### PR TITLE
Fix a real size_t underflow and suppress two intentional-dead-code warnings

### DIFF
--- a/src/fields/SoFieldContainer.cpp
+++ b/src/fields/SoFieldContainer.cpp
@@ -1243,8 +1243,12 @@ SoFieldContainer::getFieldsMemorySize(size_t & managed, size_t & unmanaged) cons
       } else if (mftypekey == MFVec4us_string.getString()) {
         elementsize = sizeof(SbTypeInfo<SoMFVec4us>::DataType[2]) / 2;
       } else {
-        // unsupported field type
-        elementsize = -1;
+        // unsupported field type -- contribute nothing to the total
+        // rather than corrupting it: elementsize is a size_t, so the
+        // previous "-1 means unknown" sentinel here actually wrapped
+        // to SIZE_MAX and then overflowed further down in
+        // "managed/unmanaged += elementsize * numelements".
+        elementsize = 0;
       }
 
 #undef SBNAMESTRING

--- a/src/geo/SoGeo.cpp
+++ b/src/geo/SoGeo.cpp
@@ -203,6 +203,10 @@ static SbDPMatrix find_coordinate_system(const SbString * system,
 // Currently not used. Kept here since it might be useful to find and
 // UTM zone from lat/long
 //
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable: 4505) // unreferenced local function removed -- kept intentionally, see comment above
+#endif
 static SbUTMProjection find_utm_projection(const SbString * system,
                                            const int COIN_UNUSED_ARG(numsystem),
                                            const SbVec3d & coords,
@@ -234,6 +238,9 @@ static SbUTMProjection find_utm_projection(const SbString * system,
   projcoords = coords;
   return SbUTMProjection(find_utm_zone(system[1]), SbGeoEllipsoid("WGS84"));
 }
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 
 SbDPMatrix
 SoGeo::calculateDPTransform(const SbString * originsystem,

--- a/src/misc/systemsanity.icc
+++ b/src/misc/systemsanity.icc
@@ -12,6 +12,10 @@
 // will fail) if the compilation environment is not set up correctly - it
 // does not need to be run from anywhere...
 
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable: 4505) // unreferenced local function removed -- deliberately never called, see comment above
+#endif
 static
 void
 SoDB_compileTimeAsserts(void)
@@ -46,6 +50,9 @@ SoDB_compileTimeAsserts(void)
   COIN_CT_ASSERT(sizeof(unsigned long) >= sizeof(void *));
 #endif // OBSOLETED
 }
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 
 // *************************************************************************
 // GCC 3.3.1/3.3.2 contains a bug in builtin_expect() which makes the assert


### PR DESCRIPTION
SoFieldContainer.cpp: getFieldsMemorySize()'s "unsupported field type"
fallback set elementsize (a size_t) to -1, which wraps to SIZE_MAX
rather than signaling "unknown" the way it would for a signed type;
that value then flows straight into "managed/unmanaged += elementsize
* numelements" with no check in between, corrupting this diagnostic
API's memory-usage total for any field of a type this function
doesn't recognize. Fix: contribute 0 instead, matching elementsize's
own already-zero declaration default -- an accurate "we don't know
this type's size" rather than a value that overflows the total.

SoGeo.cpp / systemsanity.icc: find_utm_projection() and
SoDB_compileTimeAsserts() are both intentionally-unused (kept for
future use / exist only to fail compilation if their static asserts
don't hold) and already marked with this codebase's COIN_UNUSED_FUNC
macro -- but that macro is __attribute__((__unused__)) on GCC and
empty everywhere else (src/coindefs.h), so it does nothing to silence
MSVC's C4505 for the same functions. Suppress locally with
#pragma warning(push/disable(4505)/pop) around each, rather than
extend COIN_UNUSED_FUNC itself, since its GNU-attribute placement
(trailing the declaration) isn't where an MSVC pragma can go.

Verified on Windows (MSVC / Visual Studio 17 2022, x64 Release, /W4):
0 errors, full CoinTests suite passes (326 tests, 83566 checks).

---
Additionally verified on Linux (GCC and clang), merged together with all sibling warning-cleanup branches from this audit: clean rebuild with no new warnings on the touched lines, full `ctest` suite pass, and a Debug AddressSanitizer/UndefinedBehaviorSanitizer build of the full `CoinTests` suite with no new findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FHRXMxksBcEGfbN5bDVJzb
