### PR TITLE
Fix MSVC /W4 false positive in SoTexture3::loadFilenames

### DIFF
--- a/src/nodes/SoTexture3.cpp
+++ b/src/nodes/SoTexture3.cpp
@@ -457,7 +457,16 @@ SoTexture3::loadFilenames(SoInput * in)
 {
   SbBool retval = FALSE;
   SbVec3s volumeSize(0,0,0);
-  int volumenc;
+  /* Only read below once this->images.isDefault() is false, which only
+     happens after this->images.setValue() below has run (setValue()
+     implicitly clears the default flag). At the start of every call --
+     first or repeat -- isDefault() is true, since a successful call
+     ends by explicitly setting it back to TRUE ("write filenames, not
+     images", a few lines down); so volumenc is always set on that
+     call's first successfully-read image before any later image in
+     the same call can read it. Initialized only because the compiler
+     can't see that guarantee across the setValue()/isDefault() pair. */
+  int volumenc = 0;
   int numImages = this->filenames.getNum();
   SbBool sizeError = FALSE;
   int i;


### PR DESCRIPTION
volumenc is set on the first image loaded per call (guarded by
this->images.isDefault()) and read on every subsequent one in the
same call, but the compiler can't see the two-part guarantee that
makes this safe across repeat calls: this->images.setValue() clears
the default flag as a side effect (so images 1..N-1 correctly take
the "verify against volumenc" branch within one call), while a
successful call ends by explicitly setting the flag back to TRUE (the
existing "write filenames, not images" comment a few lines down) --
so isDefault() is true again at the start of the next call, and the
next call's first image correctly takes the "set volumenc" branch
again rather than reading a stale value from the previous call.

Initialized only because the compiler can't correlate isDefault()
with whether volumenc was actually set; does not change behavior on
this already-safe path.

Verified on Windows (MSVC / Visual Studio 17 2022, x64 Release, /W4):
this was the single remaining C4701 warning in the tree (after the
four preceding /W4 branches), 0 errors, full CoinTests suite passes
(332 tests, 83688 checks, tested merged into lab/all-fixes-integration).

---
Additionally verified on Linux (GCC and clang), merged together with all sibling warning-cleanup branches from this audit: clean rebuild with no new warnings on the touched lines, full `ctest` suite pass, and a Debug AddressSanitizer/UndefinedBehaviorSanitizer build of the full `CoinTests` suite with no new findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FHRXMxksBcEGfbN5bDVJzb
