### PR TITLE
Clean up dead test-code MSVC /W4 flags in embedded test suites

### DIFF
--- a/src/base/SbDPPlane.cpp
+++ b/src/base/SbDPPlane.cpp
@@ -438,9 +438,6 @@ BOOST_AUTO_TEST_CASE(signCorrect)
 
 BOOST_AUTO_TEST_CASE(equalityToFloatPlane)
 {
-  const float delX = 1;
-  const float delY = .1f;
-
   const float XMax = (float)pow(2.,FLT_MAX_EXP/3.);
   const float XMin = -XMax;
 
@@ -460,8 +457,6 @@ BOOST_AUTO_TEST_CASE(equalityToFloatPlane)
   const int YSteps = 10;
 #endif //TEST_SUITE_EXPANSIVE
 
-  int count=0;
- 
   for (int x1=0;x1<XSteps;++x1) {
     float X1=slew(XMin,XMax,XSteps,x1);
     for (int x2=0;x2<XSteps;++x2) {

--- a/src/base/SbString.cpp
+++ b/src/base/SbString.cpp
@@ -549,11 +549,6 @@ SbString::print(std::FILE * fp) const
 #ifdef COIN_TEST_SUITE
 #include <Inventor/SbString.h>
 
-static void * createInstance(void)
-{
-  return (void *)0x1234;
-}
-
 BOOST_AUTO_TEST_CASE(testAddition)
 {
   SbString str1("First");

--- a/src/misc/SoBaseP.cpp
+++ b/src/misc/SoBaseP.cpp
@@ -620,7 +620,7 @@ BOOST_AUTO_TEST_CASE(realTime_globalfield_import)
   in->setBuffer(scene, strlen(scene));
   SoNode * g = NULL;
   const SbBool readok = SoDB::read(in, g);
-  assert(readok); // that import is ok is tested by a case in SoDB.cpp
+  if (!readok) assert(!"scene import failed"); // that import is ok is tested by a case in SoDB.cpp
   delete in;
 
   // check that the global field is still the same instance

--- a/src/scxml/ScXMLMinimumEvaluator.cpp
+++ b/src/scxml/ScXMLMinimumEvaluator.cpp
@@ -368,9 +368,6 @@ BOOST_AUTO_TEST_CASE(MimimumExpressions)
   std::unique_ptr<ScXMLStateMachine> sm(new ScXMLStateMachine);
   std::unique_ptr<ScXMLEvaluator> evaluator(new ScXMLMinimumEvaluator);
 
-  ScXMLDataObj * res = NULL;
-  ScXMLBoolDataObj * boolobj = NULL;
-
   //FIXME, this test is not finished. BFG 20090831
 
   static const char foo [] =


### PR DESCRIPTION
- SbDPPlane.cpp: delX, delY and count in equalityToFloatPlane are
  declared and never read anywhere in the test case; dead leftovers.
- ScXMLMinimumEvaluator.cpp: res and boolobj are only used by code
  that's entirely commented out in this test case, which is itself
  marked "not finished" (FIXME from 2009); the two declarations are
  dead until that code is written.
- SbString.cpp: createInstance() returns a fixed fake pointer and is
  never called from anywhere in this file; dead leftover.
- SoBaseP.cpp: readok is only referenced inside assert(readok), which
  the preprocessor drops entirely under NDEBUG (Release builds),
  making it genuinely unused there. Same fix already established
  elsewhere in this codebase for this exact pattern (see mutex.cpp):
  move the read into an if() so it survives NDEBUG.

Verified on Windows (MSVC / Visual Studio 17 2022, x64 Release, /W4):
C4189 drops from 68 to 62 and C4505 from 21 to 20 (all 6 targeted
sites gone, no new warnings), 0 errors, full CoinTests suite passes
(326 tests, 83566 checks).

---
Additionally verified on Linux (GCC and clang), merged together with all sibling warning-cleanup branches from this audit: clean rebuild with no new warnings on the touched lines, full `ctest` suite pass, and a Debug AddressSanitizer/UndefinedBehaviorSanitizer build of the full `CoinTests` suite with no new findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FHRXMxksBcEGfbN5bDVJzb
