### PR TITLE
Guard SoQuadMesh's unimplemented 4D-coordinate weight calculation

### DIFF
--- a/src/shapenodes/SoQuadMesh.cpp
+++ b/src/shapenodes/SoQuadMesh.cpp
@@ -479,7 +479,13 @@ namespace { namespace SoGL { namespace QuadMesh {
       SbVec4f ccd4;
       SbVec4f sum234d4,sum134d4,sum124d4,sum123d4;
       SbVec4f vec1d4,vec2d4,vec3d4,vec4d4;
-      float s1,s2,s3,s4;
+      /* Only set on the is3d path below; the else branch (4D
+         coordinates) has its own assert(!"4d coordinates handling
+         unimplemented yet") a few lines down and leaves these unset,
+         yet w1..w4 use them unconditionally right after. Initialized
+         only to avoid reading garbage on that already-documented,
+         not-currently-implemented path. */
+      float s1=0.0f,s2=0.0f,s3=0.0f,s4=0.0f;
       float w1,w2,w3,w4;
       const SbVec3f *n1,*n2,*n3,*n4;
       SbVec3f nc;


### PR DESCRIPTION
The high-quality rendering path computes per-vertex weights (w1..w4)
from squared distances (s1..s4), but s1..s4 are only assigned on the
is3d branch. The else branch (4D/homogeneous coordinates) has all of
its equivalent assignments commented out, with a comment marking the
whole 4D path "not currently implemented" and a matching
assert(!"4d coordinates handling unimplemented yet") a few lines
above -- which, like any assert, is compiled out under NDEBUG
(Release builds), so s1..s4 would silently read indeterminate values
there instead of hitting that assert.

MSVC's /W4 flags this as C4701 across several instantiations of the
surrounding rendering-path code. Since the 4D path is a pre-existing,
explicitly-documented gap rather than something to implement here,
fix by zero-initializing s1..s4, so the already-broken 4D path reads
deterministic zeros instead of stack garbage.

Verified on Windows (MSVC / Visual Studio 17 2022, x64 Release, /W4):
C4701 drops from 97 to 17 (the surrounding code is instantiated
multiple times via macro for different rendering configurations, so
this one fix clears many sites at once), 0 errors, full CoinTests
suite passes (326 tests, 83566 checks).

---
Additionally verified on Linux (GCC and clang), merged together with all sibling warning-cleanup branches from this audit: clean rebuild with no new warnings on the touched lines, full `ctest` suite pass, and a Debug AddressSanitizer/UndefinedBehaviorSanitizer build of the full `CoinTests` suite with no new findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FHRXMxksBcEGfbN5bDVJzb
