### PR TITLE
Fix MSVC /W4 warnings in Windows-only GDI/WGL/dlopen code

### DIFF
--- a/src/base/time.cpp
+++ b/src/base/time.cpp
@@ -95,7 +95,7 @@ cc_internal_queryperformancecounter(cc_time * COIN_UNUSED_ARG(t))
   if (highperf_available) {
     LARGE_INTEGER counter;
     BOOL b = QueryPerformanceCounter(&counter);
-    assert(b && "QueryPerformanceCounter() failed even though QueryPerformanceFrequency() worked");
+    if (!b) assert(!"QueryPerformanceCounter() failed even though QueryPerformanceFrequency() worked");
     *t = (double)counter.QuadPart * highperf_tick + highperf_start;
     return TRUE;
   }

--- a/src/fonts/win32.cpp
+++ b/src/fonts/win32.cpp
@@ -1002,7 +1002,12 @@ flww32_getVerticesFromPath(HDC hdc)
 
   LPPOINT p_points = NULL;
   LPBYTE p_types = NULL;
-  int numpoints, i, lastmoveto;
+  int numpoints, i;
+  /* A GDI path from GetPath() always starts with a PT_MOVETO, so this
+     is always set by the time a PT_CLOSEFIGURE can reference it below.
+     Initialized only as a guard against a malformed/unexpected path,
+     since an uninitialized value here would be used as an array index. */
+  int lastmoveto = 0;
   uintptr_t tmp;
 
   if (FlattenPath(hdc) == 0) {

--- a/src/glue/dl.cpp
+++ b/src/glue/dl.cpp
@@ -776,7 +776,7 @@ cc_dl_open(const char * filename)
 #ifdef HAVE_WINDLL_RUNTIME_BINDING
       char libpath[512];
       DWORD retval = GetModuleFileName((HINSTANCE) h->nativehnd, libpath, sizeof(libpath));
-      assert(retval > 0 && "GetModuleFileName() failed");
+      if (retval == 0) assert(!"GetModuleFileName() failed");
       libpath[sizeof(libpath) - 1] = 0;
       cc_debugerror_postinfo("cc_dl_open", "Opened library '%s'", libpath);
 #elif defined (HAVE_DL_LIB) || defined (HAVE_DLD_LIB)

--- a/src/glue/gl_wgl.cpp
+++ b/src/glue/gl_wgl.cpp
@@ -802,7 +802,11 @@ wglglue_context_create_pbuffer(struct wglglue_contextdata * ctx, SbBool warnoner
   }
 
   {
-    GLint pixformat;
+    /* Always set inside the loop below by wglChoosePixelFormat() before
+       context->hpbuffer (checked further down) can become non-NULL.
+       Initialized only because the compiler can't see that guarantee
+       across the loop's several continue/break paths. */
+    GLint pixformat = 0;
     unsigned int numFormats;
     const float fAttribList[] = { 0 };
 


### PR DESCRIPTION
These four files are only ever compiled on Windows (guarded by
HAVE_WIN32_API / WGL / HAVE_WINDLL_RUNTIME_BINDING), so the Linux/GCC
warning-cleanup pass this session had no way to reach them -- these
warnings surfaced only now, building on Windows with /W4.

win32.cpp: flww32_getVerticesFromPath() uses lastmoveto as an array
index into p_points on a PT_CLOSEFIGURE, but only sets it on a prior
PT_MOVETO. A GDI path always starts with PT_MOVETO per the Win32 docs,
so this can't happen in practice, but an uninitialized index feeding
an array access is worth guarding regardless of how the path was
built; initialized to 0, the same index a leading PT_MOVETO would set.

gl_wgl.cpp: pixformat is always set by wglChoosePixelFormat() in the
same loop iteration that later makes context->hpbuffer non-NULL, but
the compiler can't correlate that across the loop's several
continue/break paths. False positive; initialized to 0.

time.cpp / dl.cpp: BOOL b / DWORD retval are each only referenced
inside their following assert(), which the preprocessor drops
entirely under NDEBUG (Release builds), making the variable
genuinely unused there. Same fix already established elsewhere in
this codebase for this exact pattern (see mutex.cpp): move the read
into an if() so it survives NDEBUG, then assert(!"message") on
failure.

Verified on Windows (MSVC / Visual Studio 17 2022, x64 Release, /W4):
C4701 drops from 97 to 95 and C4189 from 68 to 66 (all 4 targeted
sites gone, no new warnings), 0 errors, full CoinTests suite passes
(326 tests, 83566 checks).

---
Additionally verified on Linux (GCC and clang), merged together with all sibling warning-cleanup branches from this audit: clean rebuild with no new warnings on the touched lines, full `ctest` suite pass, and a Debug AddressSanitizer/UndefinedBehaviorSanitizer build of the full `CoinTests` suite with no new findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FHRXMxksBcEGfbN5bDVJzb
