### PR TITLE
Fix MSVC /W4 potentially-uninitialized false positives

### DIFF
--- a/src/engines/evaluator.c
+++ b/src/engines/evaluator.c
@@ -185,7 +185,12 @@ dot_product(float *v0, float *v1)
 void
 so_eval_traverse(so_eval_node *node, so_eval_param *result, const so_eval_cbdata *cbdata)
 {
-  so_eval_param param1, param2, param3;
+  /* Each param is only read below by opcodes whose arity the grammar
+     (evaluator.y) guarantees matches the number of children set on
+     the node, so e.g. a binary opcode's node always has child1 and
+     child2. Zero-initialized only because the compiler can't see
+     that grammar-level guarantee. */
+  so_eval_param param1 = {0}, param2 = {0}, param3 = {0};
 
   if (node->id != ID_FLT_COND && node->id != ID_VEC_COND &&
       node->id != ID_ASSIGN_FLT && node->id != ID_ASSIGN_VEC) {

--- a/src/fields/SoSFNode.cpp
+++ b/src/fields/SoSFNode.cpp
@@ -175,7 +175,11 @@ SoSFNode::operator==(const SoSFNode & field) const
 SbBool
 SoSFNode::readValue(SoInput * in)
 {
-  SoBase * baseptr;
+  /* Always set below: to NULL for the VRML97 explicit-null case, or by
+     SoBase::read() otherwise. Made explicit here (matching the VRML97
+     case's own value) since the compiler can't see that guarantee
+     across the SoBase::read() call. */
+  SoBase * baseptr = NULL;
   SbBool isVRMLspecialCase = FALSE;
 
   // Note: do *not* simply check for baseptr==NULL here, as that is a

--- a/src/io/SoInput.cpp
+++ b/src/io/SoInput.cpp
@@ -1143,7 +1143,10 @@ SoInput::read(SbName & n, SbBool validIdent)
     SbString s;
     char buf[256];
     char * b = buf;
-    char c;
+    /* Only read below when gotchar is TRUE, which happens only right
+       after fi->get(c) sets both together. Initialized here only
+       because the compiler can't correlate the two variables. */
+    char c = '\0';
     SbBool gotchar = FALSE;
 
     switch (codepath) {

--- a/src/io/SoWriterefCounter.cpp
+++ b/src/io/SoWriterefCounter.cpp
@@ -481,7 +481,11 @@ SoWriterefCounter::addReference(const SoBase * base)
 int
 SoWriterefCounter::findReference(const SoBase * base) const
 {
-  int id;
+  /* Only read below when ok is TRUE, which happens only when get() has
+     set it. Initialized to this function's own "not found" sentinel
+     (see docstring above) since the compiler can't correlate ok with
+     whether id was actually set. */
+  int id = -1;
   const SbBool ok =
     PRIVATE(this)->sobase2id &&
     PRIVATE(this)->sobase2id->get(base, id);

--- a/src/profiler/SoNodeVisualize.cpp
+++ b/src/profiler/SoNodeVisualize.cpp
@@ -698,7 +698,11 @@ SoNodeVisualize::internalAlternating(bool alternate,int direction) {
     ->whichChild=(alternate)?SO_SWITCH_ALL:SO_SWITCH_NONE;
 
   SoNodeList * children=this->getChildGeometry();
-  int l;
+  /* Only read below past the early return, which happens only once the
+     assignment on the next line has run. Initialized to the "no
+     children" value since the compiler can't see that guarantee
+     across the short-circuited condition. */
+  int l = 0;
   if (!children ||
       (l=children->getLength())==0 ||
       static_cast<SoSwitch*>(this->getAnyPart("childrenVisible",FALSE))->whichChild.getValue()==SO_SWITCH_NONE)

--- a/src/rendering/SoGLBigImage.cpp
+++ b/src/rendering/SoGLBigImage.cpp
@@ -405,7 +405,11 @@ SoGLBigImage::applySubImage(SoState * state, const int idx,
                             const SbVec2s & projsize)
 {
   SbVec2s size;
-  int numcomponents;
+  /* If getImage() is NULL, numcomponents is never set by getValue()
+     below, yet it's still used further down to size an allocation.
+     Zero components yields a zero-sized (safe) allocation instead of
+     an indeterminate one in that case. */
+  int numcomponents = 0;
   unsigned char * bytes = this->getImage() ?
     this->getImage()->getValue(size, numcomponents) : NULL;
 

--- a/src/rendering/SoGLImage.cpp
+++ b/src/rendering/SoGLImage.cpp
@@ -1612,7 +1612,11 @@ SoGLDisplayList *
 SoGLImageP::createGLDisplayList(SoState *state)
 {
   SbVec3s size;
-  int numcomponents;
+  /* Only read below once !this->pbuffer is true (see the early return
+     right below), which combined with that check guarantees bytes,
+     and therefore numcomponents, was set. Initialized only because
+     the compiler can't correlate bytes with numcomponents. */
+  int numcomponents = 0;
   unsigned char *bytes =
     this->image ? this->image->getValue(size, numcomponents) : NULL;
 
@@ -1683,7 +1687,10 @@ SoGLImageP::checkTransparency(void)
   this->hastransparency = FALSE;
 
   SbVec3s size;
-  int numcomponents;
+  /* Only read below in the bytes!=NULL branch, which only happens once
+     getValue() has set it. Initialized only because the compiler
+     can't correlate bytes with numcomponents. */
+  int numcomponents = 0;
   unsigned char *bytes = this->image ?
     this->image->getValue(size, numcomponents) : NULL;
 

--- a/src/shapenodes/SoImage.cpp
+++ b/src/shapenodes/SoImage.cpp
@@ -450,7 +450,11 @@ SoImage::GLRender(SoGLRenderAction * action)
   glLoadIdentity();
   glOrtho(0, vpsize[0], 0, vpsize[1], -1.0f, 1.0f);
 
-  float oldzx, oldzy;
+  /* Only read below under the same "orgsize != size" condition that
+     sets them just below. Initialized to GL's own default pixel zoom
+     (1.0, i.e. no zoom) since the compiler can't see that the two
+     conditions are the same. */
+  float oldzx = 1.0f, oldzy = 1.0f;
 
   if (orgsize != size) { // use glPixelZoom to scale image
     glGetFloatv(GL_ZOOM_X, &oldzx);


### PR DESCRIPTION
MSVC's C4701/C4703 flag several variables the compiler can't prove
are always set before use, even though the surrounding control flow
guarantees it in every case: short-circuited conditions that both
assign and test a variable in the same expression (SoNodeVisualize.cpp,
SoWriterefCounter.cpp), a ternary that conditionally calls an
out-param function (SoGLImage.cpp x2, SoGLBigImage.cpp), a value only
read under the same guard that sets it (SoImage.cpp, SoInput.cpp), a
call to an external out-param function the compiler can't see into
(SoSFNode.cpp), and an invariant enforced by a separate grammar file
rather than local control flow (evaluator.c).

Fix each by initializing to the value the surrounding logic already
implies: SoWriterefCounter's own "not found" sentinel, SoSFNode's own
explicit-NULL branch value, GL's own default pixel zoom, zero
components/chars/counts where that's the safe empty-case default.
This does not change behavior on any of these (already-safe) paths;
SoGLBigImage.cpp and SoGLImage.cpp's createGLDisplayList also harden
a narrower path where getImage()/this->image could plausibly be NULL,
turning an indeterminate allocation size into a defined zero.

Verified on Windows (MSVC / Visual Studio 17 2022, x64 Release, /W4):
C4701 drops from 97 to 85 (all 9 targeted sites gone, no new
warnings), 0 errors, full CoinTests suite passes (326 tests, 83566
checks).

---
Additionally verified on Linux (GCC and clang), merged together with all sibling warning-cleanup branches from this audit: clean rebuild with no new warnings on the touched lines, full `ctest` suite pass, and a Debug AddressSanitizer/UndefinedBehaviorSanitizer build of the full `CoinTests` suite with no new findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FHRXMxksBcEGfbN5bDVJzb
