### PR TITLE
Fix clang -Wmissing-braces in heap.cpp's embedded tests

### DIFF
--- a/src/base/heap.cpp
+++ b/src/base/heap.cpp
@@ -407,7 +407,7 @@ public:
 };
 
 BOOST_AUTO_TEST_CASE(min_heap) {
-  mock_up::wrapped_value val[] = {3, 2, 1, 15, 5, 4, 45};
+  mock_up::wrapped_value val[] = {{3}, {2}, {1}, {15}, {5}, {4}, {45}};
   cc_heap* heap = cc_heap_construct(256, reinterpret_cast<cc_heap_compare_cb*>(mock_up::min_heap_compare_cb), TRUE);
   for (int i = 0, n = sizeof(val) / sizeof(val[0]); i < n; ++i)
     cc_heap_add(heap, &val[i]);
@@ -421,7 +421,7 @@ BOOST_AUTO_TEST_CASE(min_heap) {
 }
 
 BOOST_AUTO_TEST_CASE(max_heap) {
-  mock_up::wrapped_value val[] = {3, 2, 1, 15, 5, 4, 45};
+  mock_up::wrapped_value val[] = {{3}, {2}, {1}, {15}, {5}, {4}, {45}};
   cc_heap* heap = cc_heap_construct(256, reinterpret_cast<cc_heap_compare_cb*>(mock_up::max_heap_compare_cb), TRUE);
   for (int i = 0, n = sizeof(val) / sizeof(val[0]); i < n; ++i)
     cc_heap_add(heap, &val[i]);
@@ -435,7 +435,7 @@ BOOST_AUTO_TEST_CASE(max_heap) {
 }
 
 BOOST_AUTO_TEST_CASE(heap_add) {
-  mock_up::wrapped_value val[] = {3, 2, 1, 15, 5, 4, 45};
+  mock_up::wrapped_value val[] = {{3}, {2}, {1}, {15}, {5}, {4}, {45}};
   cc_heap* heap = cc_heap_construct(256, reinterpret_cast<cc_heap_compare_cb*>(mock_up::min_heap_compare_cb), TRUE);
   for (int i = 0, n = sizeof(val) / sizeof(val[0]); i < n; ++i)
     cc_heap_add(heap, &val[i]);
@@ -451,7 +451,7 @@ BOOST_AUTO_TEST_CASE(heap_add) {
 }
 
 BOOST_AUTO_TEST_CASE(heap_remove) {
-  mock_up::wrapped_value val[] = {3, 2, 1, 15, 5, 4, 45};
+  mock_up::wrapped_value val[] = {{3}, {2}, {1}, {15}, {5}, {4}, {45}};
   cc_heap* heap = cc_heap_construct(256, reinterpret_cast<cc_heap_compare_cb*>(mock_up::min_heap_compare_cb), TRUE);
   for (int i = 0, n = sizeof(val) / sizeof(val[0]); i < n; ++i)
     cc_heap_add(heap, &val[i]);
@@ -466,7 +466,7 @@ BOOST_AUTO_TEST_CASE(heap_remove) {
 }
 
 BOOST_AUTO_TEST_CASE(heap_update) {
-  mock_up::wrapped_value val[] = {3, 2, 1, 15, 5, 4, 45};
+  mock_up::wrapped_value val[] = {{3}, {2}, {1}, {15}, {5}, {4}, {45}};
   cc_heap* heap = cc_heap_construct(256, reinterpret_cast<cc_heap_compare_cb*>(mock_up::min_heap_compare_cb), TRUE);
   for (int i = 0, n = sizeof(val) / sizeof(val[0]); i < n; ++i)
     cc_heap_add(heap, &val[i]);


### PR DESCRIPTION
mock_up::wrapped_value is a one-member struct ({ double x; }), so
initializing an array of it with a flat list ("val[] = {3, 2, 1, ...}")
elides the per-element braces clang's -Wmissing-braces wants ("suggest
braces around initialization of subobject") -- GCC accepts this form
silently under -Wall/-Wextra, clang doesn't. Same 7-element literal is
repeated identically across all 5 test cases in this block (35 sites
total).

Fix: brace each element ("{{3}, {2}, {1}, ...}"), which both compilers
accept identically -- no behavior change, this is pure aggregate
initialization syntax.

Verified on Linux (GCC and clang): -Wmissing-braces drops from 35 to 0
on clang (GCC was already silent here), full CoinTests suite passes
under a plain build and under ASan+UBSan, with no new sanitizer
findings.

---
Also verified on Windows (MSVC / Visual Studio 17 2022): builds clean, no changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FHRXMxksBcEGfbN5bDVJzb

