### PR TITLE
Fix -Wsign-compare in SbImage.cpp's embedded copyConstruct test

### DIFF
--- a/src/base/SbImage.cpp
+++ b/src/base/SbImage.cpp
@@ -730,7 +730,7 @@ BOOST_AUTO_TEST_CASE(copyConstruct)
 {
   unsigned char buf [4];
 
-  for (int i=0;i<sizeof(buf); ++i) {
+  for (size_t i=0;i<sizeof(buf); ++i) {
     buf[i]=i;
   }
 


### PR DESCRIPTION
"for (int i=0;i<sizeof(buf); ++i)" compares a signed int against
sizeof()'s unsigned result. The very same loop bound is already
correctly typed as size_t two lines later in the same test case
("for (size_t i=0;i<sizeof(buf); ++i)") -- this one loop was just
missed.

Verified on Linux (GCC and clang): -Wsign-compare drops by 1 (the only
site in the tree), full CoinTests suite passes under a plain build and
under ASan+UBSan, with no new sanitizer findings.

---
Also verified on Windows (MSVC / Visual Studio 17 2022): builds clean, no changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FHRXMxksBcEGfbN5bDVJzb

