### PR TITLE
Fix -Wunused-parameter across testsuite callback signatures

### DIFF
--- a/src/draggers/SoTransformerDragger.cpp
+++ b/src/draggers/SoTransformerDragger.cpp
@@ -2219,7 +2219,7 @@ SoTransformerDragger::setDynamicRotatorSwitches(const SoEvent *event)
 
 static
 SoCallbackAction::Response
-register_cb(void * data, SoCallbackAction * action, const SoNode * node)
+register_cb(void * data, SoCallbackAction *, const SoNode * node)
 {
   assert(data);
   SbDict * dict = static_cast<SbDict *>(data);
@@ -2229,7 +2229,7 @@ register_cb(void * data, SoCallbackAction * action, const SoNode * node)
 
 static
 void
-ensure_unique_cb(uintptr_t entry, void * value, void * data)
+ensure_unique_cb(uintptr_t entry, void *, void * data)
 {
   SbDict * copydict = static_cast<SbDict *>(data);
   void * val = NULL;

--- a/src/fields/SoMFNode.cpp
+++ b/src/fields/SoMFNode.cpp
@@ -635,7 +635,7 @@ SoMFNode::replaceNode(SoNode * oldnode, SoNode * newnode)
 
 // Do-nothing error handler for ignoring read errors while testing.
 static void
-readErrorHandler(const SoError * error, void * data)
+readErrorHandler(const SoError *, void *)
 {
 }
 

--- a/src/misc/SoDB.cpp
+++ b/src/misc/SoDB.cpp
@@ -1719,7 +1719,7 @@ BOOST_AUTO_TEST_CASE(globalRealTimeField)
 
 // Do-nothing error handler for ignoring read errors while testing.
 static void
-readErrorHandler(const SoError * error, void * data)
+readErrorHandler(const SoError *, void *)
 {
 }
 

--- a/testsuite/TestSuiteMain.cpp
+++ b/testsuite/TestSuiteMain.cpp
@@ -40,7 +40,7 @@
 using namespace SIM::Coin3D::Coin;
 
 
-int main(int argc, char* argv[])
+int main(int, char* [])
 {
     SoDB::init();
     SoInteraction::init();

--- a/testsuite/TestSuiteUtils.cpp
+++ b/testsuite/TestSuiteUtils.cpp
@@ -89,7 +89,7 @@ should_filter(const SbString & msg)
 }
 
 void
-debugerrormsg_handler(const SoError * error, void * data)
+debugerrormsg_handler(const SoError * error, void *)
 {
   assert(error);
   const SoDebugError * dbgerror = static_cast<const SoDebugError *>(error);
@@ -111,7 +111,7 @@ debugerrormsg_handler(const SoError * error, void * data)
 }
 
 void
-readerrormsg_handler(const SoError * error, void * data)
+readerrormsg_handler(const SoError * error, void *)
 {
   ++readerrorcount;
   const SbString & msg = error->getDebugString();
@@ -119,7 +119,7 @@ readerrormsg_handler(const SoError * error, void * data)
 }
 
 void
-memoryerrormsg_handler(const SoError * error, void * data)
+memoryerrormsg_handler(const SoError * error, void *)
 {
   ++memoryerrorcount;
   const SbString & msg = error->getDebugString();


### PR DESCRIPTION
11 sites across 5 files, all the same shape: a callback registered
via a *Callback(func, userdata)-style API where the function doesn't
need the userdata (or, in one case, the error object) it's handed.
Each function's signature is fixed by the callback typedef it must
match, so the type stays -- only the now-unused parameter name is
dropped, matching the standard C/C++ idiom for this.

- TestSuiteMain.cpp: main()'s argc/argv (CoinTest::run_all() takes no
  arguments and reads neither).
- TestSuiteUtils.cpp: the data (userdata) parameter of all three
  Coin error-handler callbacks (debug/read/memory) -- each already
  gets what it needs from the error object itself.
- SoTransformerDragger.cpp: the SoCallbackAction parameter of
  register_cb() (SbDict/SoNode are all it needs), and the value
  parameter of ensure_unique_cb() (shadowed by its own local `val`
  a line below -- the two were never the same parameter).
- SoMFNode.cpp / SoDB.cpp: an identical do-nothing readErrorHandler()
  (both error and data unused) duplicated verbatim in each file's own
  embedded test block.

Verified on Linux (GCC and clang): -Wunused-parameter drops from 11 to
0 on both, full CoinTests suite passes under a plain build and under
ASan+UBSan, with no new sanitizer findings.

---
Also verified on Windows (MSVC / Visual Studio 17 2022): builds clean, no changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FHRXMxksBcEGfbN5bDVJzb

