### PR TITLE
Fix unused test locals and conditional scene-graph cleanup

### DIFF
--- a/src/base/SbDPRotation.cpp
+++ b/src/base/SbDPRotation.cpp
@@ -644,6 +644,8 @@ SbDPRotation::print(FILE * fp) const
 #include <Inventor/SbVec3d.h>
 
 BOOST_AUTO_TEST_CASE(tgsCompliance) {
-  SbDPRotation v = SbRotationd(SbVec3d(0,1,2),3);
+  // Compile-only check: SbRotationd (the TGS Inventor-compatible
+  // alias) must be usable wherever an SbDPRotation is expected.
+  (void) SbDPRotation(SbRotationd(SbVec3d(0,1,2),3));
 }
 #endif //COIN_TEST_SUITE

--- a/src/fields/SoSFVec4us.cpp
+++ b/src/fields/SoSFVec4us.cpp
@@ -131,9 +131,8 @@ BOOST_AUTO_TEST_CASE(textinput)
   SoSFVec4us field;
   field.set("1 2 3 4");
   BOOST_CHECK_EQUAL(field.getValue(), SbVec4us(1, 2, 3, 4));
-  const char * filters[] = { "read error", NULL }; // all read error messages
   TestSuite::ResetReadErrorCount();
-  // TestSuite::PushMessageSuppressFilters(filters);
+  // TestSuite::PushMessageSuppressFilters(filters); // filters = { "read error", NULL }
   SbBool ok;
   ok = field.set("-3 4 32 3"); // should emit error message on '-3'
   BOOST_CHECK_EQUAL(ok, FALSE);

--- a/src/misc/SoBase.cpp
+++ b/src/misc/SoBase.cpp
@@ -1842,9 +1842,10 @@ DEF root Separator {
 	   }
 	   
 	
-       root->unref();
 	   newroot->unref();
 #endif
+       // The original graph exists even when VRML97 checks are excluded.
+       root->unref();
  }
 
 #endif // COIN_TEST_SUITE

--- a/src/misc/SoBase.cpp
+++ b/src/misc/SoBase.cpp
@@ -1586,6 +1586,13 @@ SoBase::createNotRec(void)
 #include <Inventor/actions/SoToVRML2Action.h>
 #include <Inventor/VRMLnodes/SoVRMLGroup.h>
 
+// buffer, buffer_size, dont_mangle_output_names() and buffer_realloc()
+// below are only used inside the #ifdef HAVE_VRML97 block further down
+// in checkWriteWithMultiref() -- gated the same way here, since
+// CoinTests (a separate target from the Coin library itself) never
+// gets HAVE_VRML97 defined, so that block, and everything only used
+// by it, is always compiled out in practice.
+#ifdef HAVE_VRML97
  static char * buffer;
   static size_t buffer_size = 0;
 
@@ -1617,16 +1624,15 @@ dont_mangle_output_names(const SoBase *base)
     buffer_size = size;
     return buffer;
   }
+#endif // HAVE_VRML97
 
 
 BOOST_AUTO_TEST_CASE(checkWriteWithMultiref)
 {
 	SoDB::init();
-	   SoNode* scenegraph;
        SoSeparator *root = new SoSeparator;
        root->ref();
        root->setName("root");
-		scenegraph = root;
        SoSeparator *n0 = new SoSeparator;
        SoSeparator *a0 = new SoSeparator;
        SoSeparator *a1 = new SoSeparator;
@@ -1751,6 +1757,7 @@ DEF root Separator {
 
 #ifdef HAVE_VRML97
 	    SoVRMLGroup *newroot;
+	    SoNode * scenegraph = root;
 	   for(int j=0;j<2;j++) {
 		   if(j==1) {
 	SoToVRML2Action tovrml2;

--- a/src/misc/SoType.cpp
+++ b/src/misc/SoType.cpp
@@ -977,7 +977,7 @@ BOOST_AUTO_TEST_CASE(testRemoveType)
 {
   BOOST_CHECK_MESSAGE(SoType::fromName(SbName("MyClass")) == SoType::badType(),
                       "Type didn't init to badType");
-  SoType newtype = SoType::createType(SoNode::getClassTypeId(), SbName("MyClass"), createInstance, 0);
+  SoType::createType(SoNode::getClassTypeId(), SbName("MyClass"), createInstance, 0);
   BOOST_CHECK_MESSAGE(SoType::fromName(SbName("MyClass")) != SoType::badType(),
                       "Type didn't init correctly");
   bool success = SoType::removeType(SbName("MyClass"));

--- a/src/scxml/ScXMLMinimumEvaluator.cpp
+++ b/src/scxml/ScXMLMinimumEvaluator.cpp
@@ -373,9 +373,9 @@ BOOST_AUTO_TEST_CASE(MimimumExpressions)
 
   //FIXME, this test is not finished. BFG 20090831
 
+  /*
   static const char foo [] =
     "<scxml version=\"1.0\" profile=\"minimum\" name=\"foo\" initial=\"active\"><state id=\"active\"></state><state id=\"inactive\"></state></scxml>";
-  /*
   ScXMLDocument * doc = ScXMLDocument::readBuffer(SbByteBuffer(sizeof(foo),foo));
   assert(doc->getRoot());
   sm->setDescription(doc);


### PR DESCRIPTION
Remove or conditionally compile unused variables in the embedded tests for SbDPRotation, SoType, SoSFVec4us, ScXMLMinimumEvaluator and SoBase, preserving required side effects.

In checkWriteWithMultiref, release the original graph outside HAVE_VRML97: it is allocated even when the conditional checks are excluded. The converted VRML graph remains cleaned up inside that block.

## Validation

The distributed changes were validated together in `lab/all-fixes-integration`, with Clang Debug instrumentation on both Coin and C++ test drivers: `-fsanitize=address,undefined,function -fno-omit-frame-pointer`, `ASAN_OPTIONS=detect_leaks=1`, `UBSAN_OPTIONS=halt_on_error=1`, without suppressions. All 8 CTest entries passed (342 CoinTests / 83,759 checks plus seven profiler modes); 31 additional checks passed, including actual rendering, events and the historical-header client. EGL and SpiderMonkey checks were inconclusive.

This is **integration evidence**, not a claim that this isolated PR includes every companion fix or passes the full sanitizer matrix by itself. Global cleanup, STL, test-fixture and GL record fixes are distributed across the related PRs. Windows/macOS and all optional configurations were not rerun for this update. The final per-PR diff passed `git diff --check`.
