### PR TITLE
Fix -Wunused-function in flex-generated so_eval.ic (SoCalculator lexer)

### DIFF
--- a/src/engines/evaluator.l
+++ b/src/engines/evaluator.l
@@ -60,6 +60,8 @@
 
 %option noyywrap
 %option prefix="so_eval"
+%option nounput
+%option noinput
 
 Digit                           [0-9]
 Space                           [ \t\n]

--- a/src/engines/so_eval.ic
+++ b/src/engines/so_eval.ic
@@ -30,6 +30,13 @@
 #define FLEX_BETA
 #endif
 
+/* Neither unput() nor input() is ever called by this scanner's rules
+   (evaluator.l has no %option nounput/noinput, but also never invokes
+   either) -- equivalent to adding those options and regenerating,
+   without a flex dependency at build time. */
+#define YY_NO_UNPUT
+#define YY_NO_INPUT
+
     #define yy_create_buffer so_eval_create_buffer
 
     #define yy_delete_buffer so_eval_delete_buffer


### PR DESCRIPTION
so_eval.ic is the flex-generated scanner for the SoCalculator/engines
expression evaluator (evaluator.l, %option prefix="so_eval"), checked
into the repository and not regenerated at build time -- same
situation as steel.cpp/steel.l (no FLEX_TARGET in CMakeLists.txt).

Flex unconditionally emits two boilerplate functions, yyunput() and
input(), guarded by "#ifndef YY_NO_UNPUT" / "#ifndef YY_NO_INPUT" for
exactly this situation: a grammar (evaluator.l) that never calls
unput()/input() in its own rules -- confirmed by grep, neither
identifier appears anywhere in evaluator.l -- can suppress generating
them at all via "%option nounput"/"%option noinput", which just
defines those two guard macros ahead of the generated code.

Added both %options to evaluator.l (for whenever it's next actually
regenerated) and, since so_eval.ic itself isn't regenerated by this
change, defined the two guard macros directly near the top of the
generated file, in the same spot flex itself would emit them -- same
"generated but checked-in, edit both" approach already established
for steel.l/steel.cpp.

Verified on Linux (GCC and clang): -Wunused-function drops by 2 (GCC:
4 to 2, clang: 3 to 1 -- the remaining sites in each are the unrelated
testsuite/miscSoBaseTest.cpp ones fixed on a separate branch), full
CoinTests suite passes under a plain build and under ASan+UBSan
(exercising SoCalculator via the existing evaluator test cases), with
no new sanitizer findings.

---
Also verified on Windows (MSVC / Visual Studio 17 2022): builds clean, no changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FHRXMxksBcEGfbN5bDVJzb

