### PR TITLE
Fix missing GL_UNPACK_ALIGNMENT in cubemap texture upload

### DIFF
--- a/src/rendering/SoGLCubeMapImage.cpp
+++ b/src/rendering/SoGLCubeMapImage.cpp
@@ -321,6 +321,8 @@ SoGLCubeMapImage::getGLDisplayList(SoState * state)
 
       dl->open(state);
 
+      glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
+
       for (int i = 0; i < 6; i++) {
         const SbImage * img = &PRIVATE(this)->image[i];
         if (img->hasData()) {

--- a/src/rendering/SoGLCubeMapImage.cpp
+++ b/src/rendering/SoGLCubeMapImage.cpp
@@ -346,6 +346,8 @@ SoGLCubeMapImage::getGLDisplayList(SoState * state)
         }
       }
 
+      glPixelStorei(GL_UNPACK_ALIGNMENT, 4); // restore default value
+
       // FIXME: make it possible to configure filter and mipmap on/off
       glTexParameteri(GL_TEXTURE_CUBE_MAP, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
       glTexParameteri(GL_TEXTURE_CUBE_MAP, GL_TEXTURE_MIN_FILTER, GL_LINEAR);

--- a/testsuite/reproducers/CoinCleanup.h
+++ b/testsuite/reproducers/CoinCleanup.h
@@ -1,0 +1,17 @@
+#ifndef COIN_REPRODUCER_CLEANUP_H
+#define COIN_REPRODUCER_CLEANUP_H
+
+#include <Inventor/SoDB.h>
+
+// Declare immediately after SoDB::init(), before local Coin objects, so
+// those objects are destroyed before the library's global resources.
+class CoinReproducerCleanup {
+public:
+  CoinReproducerCleanup() {}
+  ~CoinReproducerCleanup() { SoDB::finish(); }
+private:
+  CoinReproducerCleanup(const CoinReproducerCleanup &);
+  CoinReproducerCleanup & operator=(const CoinReproducerCleanup &);
+};
+
+#endif

--- a/testsuite/reproducers/cubemap-texture-alignment/repro.cpp
+++ b/testsuite/reproducers/cubemap-texture-alignment/repro.cpp
@@ -1,0 +1,133 @@
+// Reproducer for a missing glPixelStorei(GL_UNPACK_ALIGNMENT, 1) in
+// SoGLCubeMapImage::getGLDisplayList() (src/rendering/SoGLCubeMapImage.cpp):
+// unlike SoGLImage.cpp's regular 2D texture upload, the cubemap upload path
+// calls glTexImage2D() directly without ever setting the unpack alignment,
+// so it's stuck with whatever the context's default (or a previous, unrelated
+// draw call's) GL_UNPACK_ALIGNMENT happens to be -- 4 on a fresh context.
+//
+// A cubemap face image whose row byte-width (width * bytes-per-pixel) isn't
+// a multiple of 4 -- e.g. any 3-component (RGB) face with an odd width, or
+// this repro's minimal 2x2 RGB case (2*3 = 6 bytes/row) -- then has each row
+// read with the wrong stride: the driver rounds 6 up to 8 for a 4-byte
+// alignment, so every row after the first is read 2 bytes short of where it
+// actually starts, and the final row reads 2 bytes past the end of the
+// buffer entirely.
+//
+// This renders a plain SoCube with an SoTextureCubeMap whose six faces are
+// each a solid, distinct 2x2 color (unlit, so the rendered pixel is exactly
+// the sampled texture color with no lighting to obscure the effect) and
+// checks that a large sample of pixels across the visible faces are *exact*
+// matches for one of the six expected colors -- with the bug, misaligned
+// reads corrupt a chunk of the uploaded texel data, so sampled colors drift
+// away from the expected six.
+//
+// See run.sh in this directory for how to build and run this against a
+// given libCoin build.
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <Inventor/SoDB.h>
+#include <Inventor/SoOffscreenRenderer.h>
+#include <Inventor/SbViewportRegion.h>
+#include <Inventor/SbColor.h>
+#include <Inventor/nodes/SoSeparator.h>
+#include <Inventor/nodes/SoCube.h>
+#include <Inventor/nodes/SoTextureCubeMap.h>
+#include <Inventor/nodes/SoOrthographicCamera.h>
+#include <Inventor/nodes/SoLightModel.h>
+#include <Inventor/nodes/SoMaterial.h>
+
+static void setSolid(SoSFImage & field, unsigned char r, unsigned char g, unsigned char b)
+{
+  // 2x2 RGB = 6 bytes/row: not a multiple of 4, the shape that
+  // triggers the bug.
+  unsigned char buf[2*2*3];
+  for (int i = 0; i < 4; i++) {
+    buf[i*3+0] = r; buf[i*3+1] = g; buf[i*3+2] = b;
+  }
+  field.setValue(SbVec2s(2, 2), 3, buf);
+}
+
+int main()
+{
+  SoDB::init();
+
+  SoSeparator * root = new SoSeparator;
+  root->ref();
+
+  SoOrthographicCamera * cam = new SoOrthographicCamera;
+  cam->position.setValue(0, 0, 5);
+  cam->nearDistance = 1.0f;
+  cam->farDistance = 10.0f;
+  cam->height = 3.0f;
+  root->addChild(cam);
+
+  SoLightModel * lm = new SoLightModel;
+  lm->model = SoLightModel::BASE_COLOR;
+  root->addChild(lm);
+
+  SoMaterial * mat = new SoMaterial;
+  mat->diffuseColor.setValue(1, 1, 1); // avoid MODULATE's default (0.8,0.8,0.8) dimming
+  root->addChild(mat);
+
+  struct { unsigned char r, g, b; } colors[6] = {
+    {255,0,0}, {0,255,0}, {255,255,0}, {128,0,0}, {0,128,0}, {128,128,0},
+  };
+
+  SoTextureCubeMap * cm = new SoTextureCubeMap;
+  setSolid(cm->imagePosX, colors[0].r, colors[0].g, colors[0].b);
+  setSolid(cm->imageNegX, colors[1].r, colors[1].g, colors[1].b);
+  setSolid(cm->imagePosY, colors[2].r, colors[2].g, colors[2].b);
+  setSolid(cm->imageNegY, colors[3].r, colors[3].g, colors[3].b);
+  setSolid(cm->imagePosZ, colors[4].r, colors[4].g, colors[4].b);
+  setSolid(cm->imageNegZ, colors[5].r, colors[5].g, colors[5].b);
+  root->addChild(cm);
+
+  root->addChild(new SoCube);
+
+  SbViewportRegion vp(256, 256);
+  SoOffscreenRenderer renderer(vp);
+  renderer.setBackgroundColor(SbColor(0.2f, 0.2f, 0.2f));
+  if (!renderer.render(root)) {
+    fprintf(stderr, "[repro] render() failed\n");
+    return 2;
+  }
+
+  unsigned char * buf = renderer.getBuffer();
+  int w = 256, h = 256;
+  int total = 0, matched = 0;
+  for (int y = 0; y < h; y++) {
+    for (int x = 0; x < w; x++) {
+      unsigned char * px = buf + (y*w + x)*3;
+      // skip background pixels (0.2,0.2,0.2 ~= 51,51,51)
+      if (px[0] < 60 && px[1] < 60 && px[2] < 60) continue;
+      total++;
+      for (int c = 0; c < 6; c++) {
+        if (px[0]==colors[c].r && px[1]==colors[c].g && px[2]==colors[c].b) {
+          matched++;
+          break;
+        }
+      }
+    }
+  }
+
+  double frac = total ? (double)matched / total : 0.0;
+  fprintf(stderr, "[repro] %d/%d cube pixels are an exact expected color (%.1f%%)\n",
+          matched, total, frac * 100.0);
+
+  root->unref();
+
+  // Before the fix: misaligned reads corrupt a large fraction of the
+  // uploaded texel data, so well under 100% of pixels match one of the
+  // six exact expected colors. After the fix: every cube pixel is an
+  // exact match (100%), since each 2x2 face is a single solid color
+  // with no lighting or interpolation to blur it -- any exact match
+  // failure is memory corruption, not sampling.
+  if (frac < 0.999) {
+    fprintf(stderr, "[repro] FAIL: expected ~100%% exact matches\n");
+    return 1;
+  }
+  fprintf(stderr, "[repro] PASS\n");
+  return 0;
+}

--- a/testsuite/reproducers/cubemap-texture-alignment/repro.cpp
+++ b/testsuite/reproducers/cubemap-texture-alignment/repro.cpp
@@ -21,6 +21,15 @@
 // reads corrupt a chunk of the uploaded texel data, so sampled colors drift
 // away from the expected six.
 //
+// Also checks (via an SoCallback node placed after the cube, queried with
+// glGetIntegerv during the same render pass) that GL_UNPACK_ALIGNMENT is
+// restored to OpenGL's default (4) once the cubemap upload is done, rather
+// than left permanently at 1 -- every other glPixelStorei(GL_UNPACK_ALIGNMENT,
+// 1) call site in this codebase (SoGLImage.cpp, SoImage.cpp, SoText2.cpp,
+// SoMarkerSet.cpp, SoIndexedMarkerSet.cpp) restores 4 afterward; leaving it
+// at 1 pollutes GL state for whatever renders next, whether that's other
+// Coin code or an embedding application's own direct GL calls.
+//
 // See run.sh in this directory for how to build and run this against a
 // given libCoin build.
 
@@ -31,12 +40,29 @@
 #include <Inventor/SoOffscreenRenderer.h>
 #include <Inventor/SbViewportRegion.h>
 #include <Inventor/SbColor.h>
+#include <Inventor/actions/SoGLRenderAction.h>
 #include <Inventor/nodes/SoSeparator.h>
 #include <Inventor/nodes/SoCube.h>
 #include <Inventor/nodes/SoTextureCubeMap.h>
 #include <Inventor/nodes/SoOrthographicCamera.h>
 #include <Inventor/nodes/SoLightModel.h>
 #include <Inventor/nodes/SoMaterial.h>
+#include <Inventor/nodes/SoCallback.h>
+#include <Inventor/system/gl.h>
+
+static bool g_alignmentChecked = false;
+static GLint g_alignmentAfterUpload = -1;
+
+static void checkAlignmentCB(void *, SoAction * action)
+{
+  if (!action->isOfType(SoGLRenderAction::getClassTypeId())) return;
+  // By this point in the traversal the cube (and its cubemap texture,
+  // uploaded lazily on first GLRender) has already been drawn once --
+  // GL_UNPACK_ALIGNMENT should be back at OpenGL's default (4), not left
+  // at the 1 the cubemap upload needs while it's actually uploading.
+  glGetIntegerv(GL_UNPACK_ALIGNMENT, &g_alignmentAfterUpload);
+  g_alignmentChecked = true;
+}
 
 static void setSolid(SoSFImage & field, unsigned char r, unsigned char g, unsigned char b)
 {
@@ -86,6 +112,10 @@ int main()
 
   root->addChild(new SoCube);
 
+  SoCallback * cb = new SoCallback;
+  cb->setCallback(checkAlignmentCB);
+  root->addChild(cb);
+
   SbViewportRegion vp(256, 256);
   SoOffscreenRenderer renderer(vp);
   renderer.setBackgroundColor(SbColor(0.2f, 0.2f, 0.2f));
@@ -128,6 +158,20 @@ int main()
     fprintf(stderr, "[repro] FAIL: expected ~100%% exact matches\n");
     return 1;
   }
+
+  fprintf(stderr, "[repro] GL_UNPACK_ALIGNMENT after cubemap upload: %d (checked=%d)\n",
+          (int)g_alignmentAfterUpload, (int)g_alignmentChecked);
+  if (!g_alignmentChecked) {
+    fprintf(stderr, "[repro] FAIL: alignment check callback never ran\n");
+    return 1;
+  }
+  if (g_alignmentAfterUpload != 4) {
+    fprintf(stderr, "[repro] FAIL: GL_UNPACK_ALIGNMENT left at %d instead of being "
+                    "restored to OpenGL's default (4) after the cubemap upload\n",
+                    (int)g_alignmentAfterUpload);
+    return 1;
+  }
+
   fprintf(stderr, "[repro] PASS\n");
   return 0;
 }

--- a/testsuite/reproducers/cubemap-texture-alignment/repro.cpp
+++ b/testsuite/reproducers/cubemap-texture-alignment/repro.cpp
@@ -33,6 +33,7 @@
 // See run.sh in this directory for how to build and run this against a
 // given libCoin build.
 
+#include "../CoinCleanup.h"
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -78,6 +79,7 @@ static void setSolid(SoSFImage & field, unsigned char r, unsigned char g, unsign
 int main()
 {
   SoDB::init();
+  CoinReproducerCleanup cleanup;
 
   SoSeparator * root = new SoSeparator;
   root->ref();

--- a/testsuite/reproducers/cubemap-texture-alignment/run.sh
+++ b/testsuite/reproducers/cubemap-texture-alignment/run.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+# Reproducer for the missing GL_UNPACK_ALIGNMENT in
+# SoGLCubeMapImage::getGLDisplayList() (src/rendering/SoGLCubeMapImage.cpp).
+# Run manually against a build tree's shared library:
+#
+#   testsuite/reproducers/cubemap-texture-alignment/run.sh /path/to/build/lib
+#
+# Before the fix: a large fraction of the rendered cube's pixels don't
+# exactly match any of the six solid colors uploaded to the cubemap faces
+# (misaligned texture row reads corrupt the uploaded texel data). After the
+# fix: every pixel is an exact match.
+#
+# Needs a working GLX context. If offscreen rendering fails to get direct
+# rendering (common in headless/sandboxed environments), try:
+#   COIN_GLX_PIXMAP_DIRECT_RENDERING=1 testsuite/reproducers/cubemap-texture-alignment/run.sh ...
+
+cd "$(dirname "$0")"
+
+LIBDIR="$1"
+if [ -z "$LIBDIR" ]; then
+  echo "usage: $0 /path/to/build/lib   (directory containing libCoin.so)" >&2
+  exit 2
+fi
+
+CXX=${CXX:-c++}
+
+"$CXX" -O1 -g repro.cpp -o repro -I"$LIBDIR/../include" -L"$LIBDIR" -lCoin || exit 2
+
+export LD_LIBRARY_PATH="$LIBDIR${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+./repro
+status=$?
+if [ "$status" -ne 0 ]; then
+  echo "=== FAIL: repro exited with status $status ===" >&2
+  exit "$status"
+fi

--- a/testsuite/reproducers/cubemap-texture-alignment/run.sh
+++ b/testsuite/reproducers/cubemap-texture-alignment/run.sh
@@ -24,7 +24,7 @@ fi
 
 CXX=${CXX:-c++}
 
-"$CXX" -O1 -g repro.cpp -o repro -I"$LIBDIR/../include" -L"$LIBDIR" -lCoin || exit 2
+"$CXX" -O1 -g repro.cpp -o repro -I"$LIBDIR/../include" -L"$LIBDIR" -lCoin -lGL || exit 2
 
 export LD_LIBRARY_PATH="$LIBDIR${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
 ./repro


### PR DESCRIPTION
Set GL_UNPACK_ALIGNMENT to 1 for cubemap face uploads so RGB rows whose byte count is not divisible by four are read with the correct stride. The rendering reproducer now releases local objects before Coin shutdown.

## Validation

The distributed changes were validated together in `lab/all-fixes-integration`, with Clang Debug instrumentation on both Coin and C++ test drivers: `-fsanitize=address,undefined,function -fno-omit-frame-pointer`, `ASAN_OPTIONS=detect_leaks=1`, `UBSAN_OPTIONS=halt_on_error=1`, without suppressions. All 8 CTest entries passed (342 CoinTests / 83,759 checks plus seven profiler modes); 31 additional checks passed, including actual rendering, events and the historical-header client. EGL and SpiderMonkey checks were inconclusive.

This is **integration evidence**, not a claim that this isolated PR includes every companion fix or passes the full sanitizer matrix by itself. Global cleanup, STL, test-fixture and GL record fixes are distributed across the related PRs. Windows/macOS and all optional configurations were not rerun for this update. The final per-PR diff passed `git diff --check`.
