### PR TITLE
Fix SoTextureCubeMap distortion on SoCube (issue #563)

### DIFF
--- a/src/rendering/SoGL.cpp
+++ b/src/rendering/SoGL.cpp
@@ -835,7 +835,16 @@ sogl_render_cube(const float width,
     if (flags & SOGL_MATERIAL_PER_PART)
       material->send(i, TRUE);
     for (int j = 0; j < 4; j++) {
-      if (flags & SOGL_NEED_3DTEXCOORDS) {
+      if (flags & SOGL_NEED_CUBEMAPTEXCOORDS) {
+        // The direction vector a cubemap lookup needs is just the
+        // vertex's own position relative to the cube's center (the
+        // GPU normalizes it, so magnitude doesn't matter) -- using
+        // the real vertex coordinates instead of a separately
+        // hand-maintained table rules out a table/vertex-order
+        // mismatch by construction.
+        glTexCoord3fv((const GLfloat*)&varray[*iptr]);
+      }
+      else if (flags & SOGL_NEED_3DTEXCOORDS) {
         glTexCoord3fv(sogl_cube_3dtexcoords[*iptr]);
       }
       else if (flags & SOGL_NEED_TEXCOORDS) {

--- a/src/rendering/SoGL.h
+++ b/src/rendering/SoGL.h
@@ -63,6 +63,7 @@ class SbVec2f;
 #define SOGL_NEED_TEXCOORDS      0x20
 #define SOGL_NEED_3DTEXCOORDS    0x40
 #define SOGL_NEED_MULTITEXCOORDS 0x80 // internal
+#define SOGL_NEED_CUBEMAPTEXCOORDS 0x100
 
 // Convenience function for access to OpenGL wrapper from an SoState
 // pointer.

--- a/src/shapenodes/SoCube.cpp
+++ b/src/shapenodes/SoCube.cpp
@@ -173,7 +173,7 @@ SoCube::GLRender(SoGLRenderAction * action)
       flags |= SOGL_NEED_TEXCOORDS;
       break;
     case SoMultiTextureEnabledElement::CUBEMAP:
-      flags |= SOGL_NEED_3DTEXCOORDS;
+      flags |= SOGL_NEED_CUBEMAPTEXCOORDS;
       break;
     }
   }


### PR DESCRIPTION
Fixes #563.

## Summary

SoCube previously sent its volumetric 3D texture-coordinate table when cubemap texturing was active. Those coordinates are unit-cube positions, not directions from the cube center, and therefore distort cubemap lookup.

This change sends each cube vertex position as the cubemap direction while retaining the existing 3D texture behavior. It is limited to the SoCube rendering path and does not alter texture upload; the separate unpack-alignment defect is handled by #703.

## Regression evidence

The original validation rendered an SoCube with six distinctly colored cubemap faces through SoOffscreenRenderer and compared it with an independent fixed-function GLX reference using the same transform pipeline. The corrected image was pixel-identical to the reference.

## Current validation

- GCC 13 Release: full build and 8/8 CTest entries passed.
- Clang 18 Release with Wall, Wextra and Wpedantic: full build and 8/8 CTest entries passed.
- Clang 18 Debug with AddressSanitizer and UndefinedBehaviorSanitizer instrumenting both Coin and the test binaries: 8/8 CTest entries passed with UBSan recovery enabled.
- diff check against current master passed.

The cubemap visual regression is not part of routine CoinTests and was not rerun in this update. The sanitizer run also observes a pre-existing SoReorganizeAction downcast diagnostic in the unrelated STL round-trip test when UBSan aborts on the first finding.

Windows, macOS and real-context rendering remain CI or manual validation gaps. The PR remains a draft until those results are reviewed.
