### PR TITLE
Fix off-by-one loop bound in SoGLMultiTextureImageElement::hasTransparency

### DIFF
--- a/src/elements/GL/SoGLMultiTextureImageElement.cpp
+++ b/src/elements/GL/SoGLMultiTextureImageElement.cpp
@@ -294,7 +294,7 @@ SoGLMultiTextureImageElement::hasTransparency(SoState * state)
   const SoGLMultiTextureImageElement * elem = (const SoGLMultiTextureImageElement*)
     getConstElement(state, classStackIndex);
   
-  for (int i = 0; i <= PRIVATE(elem)->unitdata.getLength(); i++) {
+  for (int i = 0; i < PRIVATE(elem)->unitdata.getLength(); i++) {
     if (elem->hasTransparency(i)) return TRUE;
   }
   return FALSE;


### PR DESCRIPTION
## Summary

The static `hasTransparency(SoState *)` overload in
`SoGLMultiTextureImageElement` loops with `i <= unitdata.getLength()`,
one past the valid unit index range.

This is a cosmetic/robustness cleanup, not a behavior fix: the per-unit
`hasTransparency(int)` it calls already guards with
`unit < unitdata.getLength()` before touching the underlying array, so the
extra loop iteration was harmless in practice (it falls through the guard
and returns `FALSE`). Found incidentally while investigating #526; not the
cause of that issue.

Tightening the bound removes a redundant iteration and an off-by-one that
reads as riskier than it is on inspection — worth fixing even though it's
not user-visible.

## Test plan

- [x] Verified the loop bound is harmless: built a synthetic scene with 8
      texture units, exactly filling the internal `SbList`'s backing array
      to zero spare capacity, and ran under AddressSanitizer against both
      the unfixed and fixed code — no out-of-bounds access reported either
      way, confirming the inner bounds check is what actually protects
      this path.
- [x] Clean build with no new warnings on GCC 13 and Clang 18.
- [x] `ctest` passes on both compilers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FHRXMxksBcEGfbN5bDVJzb