### PR TITLE
Fix segfault from non-reentrant SoGLLazyElement caching bookkeeping

### DIFF
--- a/include/Inventor/elements/SoGLLazyElement.h
+++ b/include/Inventor/elements/SoGLLazyElement.h
@@ -185,7 +185,7 @@ private:
   mutable const uint32_t * packedpointer;
   uint32_t transpmask;
   SoState * state;
-  SoGLLazyElementP * pimpl; // for future use
+  SoGLLazyElementP * pimpl; // holds a stack of saved caching scopes, see beginCaching()/endCaching()
 };
 
 #endif // !COIN_SOGLLAZYELEMENT_H

--- a/src/elements/GL/SoGLLazyElement.cpp
+++ b/src/elements/GL/SoGLLazyElement.cpp
@@ -195,7 +195,25 @@ create_matrix_bitmap(int intensity, unsigned char * bitmap,
 }
 
 
-SO_ELEMENT_SOURCE(SoGLLazyElement);
+SO_ELEMENT_CUSTOM_CONSTRUCTOR_SOURCE(SoGLLazyElement);
+
+// SO_ELEMENT_SOURCE's generated default constructor doesn't initialize
+// any data members beyond type/stack index -- fine for every other
+// member here, since init() (for the root, depth-0 instance) or push()
+// (for every instance created afterwards, see SoState::getElement())
+// always assigns them all before they're read. pimpl is the one
+// exception: push() needs to tell whether this same, possibly-reused
+// C++ instance (SoState reuses element instances across many push()/
+// pop() cycles rather than reallocating) already owns a pimpl from an
+// earlier cycle, which means reading it -- so it must start out reliably
+// NULL rather than whatever the default constructor happened to leave on
+// the heap.
+SoGLLazyElement::SoGLLazyElement(void)
+{
+  this->setTypeId(SoGLLazyElement::classTypeId);
+  this->setStackIndex(SoGLLazyElement::classStackIndex);
+  this->pimpl = NULL;
+}
 
 /*!
   \copydetails SoElement::initClass(void)
@@ -472,7 +490,20 @@ SoGLLazyElement::push(SoState * stateptr)
   this->didntsetbitmask = prev->didntsetbitmask;
   this->cachebitmask = prev->cachebitmask;
   this->opencacheflags = prev->opencacheflags;
-  this->pimpl = new SoGLLazyElementP;
+
+  // SoState reuses this same C++ instance across many push()/pop() cycles
+  // over its lifetime (see SoState::getElement()) rather than allocating a
+  // fresh one every time, so pimpl may already be set from an earlier
+  // cycle -- reset it in place instead of leaking it by overwriting the
+  // pointer with a new allocation. The caching-scope stack should already
+  // be empty at this point (beginCaching()/endCaching() calls are always
+  // balanced), but truncate defensively rather than assume it.
+  if (this->pimpl == NULL) {
+    this->pimpl = new SoGLLazyElementP;
+  }
+  else {
+    this->pimpl->cachingstack.truncate(0);
+  }
 }
 
 void

--- a/src/elements/GL/SoGLLazyElement.cpp
+++ b/src/elements/GL/SoGLLazyElement.cpp
@@ -67,6 +67,7 @@
 #include <Inventor/misc/SoState.h>
 #include <Inventor/nodes/SoNode.h>
 #include <Inventor/C/tidbits.h>
+#include <Inventor/lists/SbList.h>
 #include "rendering/SoVBO.h"
 #include <coindefs.h> // COIN_OBSOLETED
 
@@ -76,6 +77,27 @@
 
 #define FLAG_FORCE_DIFFUSE      0x0001
 #define FLAG_DIFFUSE_DEPENDENCY 0x0002
+
+// beginCaching()/endCaching() are not reentrant: a nested call (e.g. a
+// SoShape validating its SoPrimitiveVertexCache while an ancestor
+// SoSeparator's SoGLCacheList recording is already open, see issue #402)
+// would otherwise overwrite the enclosing scope's bookkeeping in-place,
+// and the enclosing endCaching() would then dereference NULL once the
+// inner endCaching() has already cleared it. Save/restore the bookkeeping
+// that's local to one caching scope on a small stack so nested scopes
+// can't clobber their enclosing scope's.
+class SoGLLazyElementP {
+public:
+  struct CachingScope {
+    SoGLLazyElement::GLState * precachestate;
+    SoGLLazyElement::GLState * postcachestate;
+    uint32_t didsetbitmask;
+    uint32_t didntsetbitmask;
+    uint32_t cachebitmask;
+    uint32_t opencacheflags;
+  };
+  SbList<CachingScope> cachingstack;
+};
 
 #if COIN_DEBUG
 // #define GLLAZY_DEBUG(_x_) (SoDebugError::postInfo(COIN_STUB_FUNC, _x_))
@@ -201,6 +223,7 @@ SoGLLazyElement::initClass()
 
 SoGLLazyElement::~SoGLLazyElement()
 {
+  delete this->pimpl;
 }
 
 //! FIXME: write doc
@@ -415,6 +438,7 @@ SoGLLazyElement::init(SoState * stateptr)
   this->precachestate = NULL;
   this->postcachestate = NULL;
   this->opencacheflags = 0;
+  this->pimpl = new SoGLLazyElementP;
 
   // initialize this here to avoid UMR reports from
   // Purify. cachebitmask is updated even when there are no open
@@ -448,6 +472,7 @@ SoGLLazyElement::push(SoState * stateptr)
   this->didntsetbitmask = prev->didntsetbitmask;
   this->cachebitmask = prev->cachebitmask;
   this->opencacheflags = prev->opencacheflags;
+  this->pimpl = new SoGLLazyElementP;
 }
 
 void
@@ -1002,6 +1027,20 @@ SoGLLazyElement::beginCaching(SoState * state, GLState * prestate,
 {
   SoGLLazyElement * elem = getInstance(state);
   elem->send(state, ALL_MASK); // send lazy state before starting to build cache
+
+  // save the enclosing caching scope (if any -- e.g. an ancestor
+  // SoGLCacheList's recording that this call is nested inside of), so the
+  // matching endCaching() can restore it instead of leaving it clobbered.
+  // See issue #402.
+  SoGLLazyElementP::CachingScope saved;
+  saved.precachestate = elem->precachestate;
+  saved.postcachestate = elem->postcachestate;
+  saved.didsetbitmask = elem->didsetbitmask;
+  saved.didntsetbitmask = elem->didntsetbitmask;
+  saved.cachebitmask = elem->cachebitmask;
+  saved.opencacheflags = elem->opencacheflags;
+  elem->pimpl->cachingstack.append(saved);
+
   *prestate = elem->glstate; // copy current GL state
   prestate->diffusenodeid = elem->coinstate.diffusenodeid;
   prestate->transpnodeid = elem->coinstate.transpnodeid;
@@ -1033,9 +1072,17 @@ SoGLLazyElement::endCaching(SoState * state)
     elem->precachestate->cachebitmask |= DIFFUSE_MASK;
   }
 
-  elem->precachestate = NULL;
-  elem->postcachestate = NULL;
-  elem->opencacheflags = 0;
+  // restore the enclosing caching scope this call was nested inside of
+  // (if any), rather than unconditionally clearing the bookkeeping --
+  // see the matching save in beginCaching() and issue #402.
+  assert(elem->pimpl->cachingstack.getLength() > 0);
+  SoGLLazyElementP::CachingScope saved = elem->pimpl->cachingstack.pop();
+  elem->precachestate = saved.precachestate;
+  elem->postcachestate = saved.postcachestate;
+  elem->didsetbitmask = saved.didsetbitmask;
+  elem->didntsetbitmask = saved.didntsetbitmask;
+  elem->cachebitmask = saved.cachebitmask;
+  elem->opencacheflags = saved.opencacheflags;
 }
 
 void

--- a/testsuite/reproducers/CoinCleanup.h
+++ b/testsuite/reproducers/CoinCleanup.h
@@ -1,0 +1,17 @@
+#ifndef COIN_REPRODUCER_CLEANUP_H
+#define COIN_REPRODUCER_CLEANUP_H
+
+#include <Inventor/SoDB.h>
+
+// Declare immediately after SoDB::init(), before local Coin objects, so
+// those objects are destroyed before the library's global resources.
+class CoinReproducerCleanup {
+public:
+  CoinReproducerCleanup() {}
+  ~CoinReproducerCleanup() { SoDB::finish(); }
+private:
+  CoinReproducerCleanup(const CoinReproducerCleanup &);
+  CoinReproducerCleanup & operator=(const CoinReproducerCleanup &);
+};
+
+#endif

--- a/testsuite/reproducers/lazyelement-nested-caching-crash/repro.cpp
+++ b/testsuite/reproducers/lazyelement-nested-caching-crash/repro.cpp
@@ -38,6 +38,7 @@
 // See run.sh in this directory for how to build and run this against a
 // given libCoin build.
 
+#include "../CoinCleanup.h"
 #include <cstdio>
 #include <Inventor/SoDB.h>
 #include <Inventor/SoOffscreenRenderer.h>
@@ -79,6 +80,7 @@ static void checkCB(void *, SoAction * action)
 int main()
 {
   SoDB::init();
+  CoinReproducerCleanup cleanup;
 
   SoSeparator * root = new SoSeparator;
   root->ref();

--- a/testsuite/reproducers/lazyelement-nested-caching-crash/repro.cpp
+++ b/testsuite/reproducers/lazyelement-nested-caching-crash/repro.cpp
@@ -1,0 +1,114 @@
+// Reproducer for issue #402: segfault in SoGLLazyElement::endCaching().
+//
+// SoGLLazyElement::beginCaching()/endCaching() are called from two
+// independent places in Coin:
+//   - src/caches/SoGLCacheList.cpp (SoSeparator's display-list cache)
+//   - src/caches/SoPrimitiveVertexCache.cpp (SoShape's per-shape vertex
+//     cache, only used when transparency type is one of the
+//     SORTED_OBJECT_SORTED_TRIANGLE_* modes)
+//
+// These two call sites legitimately nest: a SoShape inside a SoSeparator
+// whose SoGLCacheList recording is already open (beginCaching() already
+// called) will validate/rebuild its own SoPrimitiveVertexCache -- which
+// calls beginCaching()/endCaching() again, nested inside the still-open
+// outer scope.
+//
+// Before the fix, SoGLLazyElement::beginCaching()/endCaching() stored the
+// currently-open scope's bookkeeping (precachestate, postcachestate, and
+// related bitmasks) in plain scalar fields, not a stack. So:
+//   1. outer beginCaching()  -- sets precachestate/postcachestate to the
+//      outer (separator) scope's GLState pointers.
+//   2. inner beginCaching()  -- OVERWRITES precachestate/postcachestate
+//      with the inner (shape) scope's pointers, losing the outer ones.
+//   3. inner endCaching()    -- finishes, then sets precachestate and
+//      postcachestate to NULL.
+//   4. outer endCaching()    -- dereferences postcachestate, which is now
+//      NULL -- SIGSEGV.
+//
+// This reproducer calls the public beginCaching()/endCaching() API
+// directly, nested, from within a real SoGLRenderAction traversal (via an
+// SoCallback node), to exercise exactly this sequence without needing to
+// coax Coin's cache-creation heuristics (frame-count thresholds,
+// dependency invalidation, etc.) into aligning naturally -- which is
+// possible (see the original issue, reproduced via SoQt + a
+// SoCenterballDragger added to a live scene under
+// SORTED_OBJECT_SORTED_TRIANGLE_BLEND) but timing-sensitive and awkward to
+// force deterministically in a small headless test.
+//
+// See run.sh in this directory for how to build and run this against a
+// given libCoin build.
+
+#include <cstdio>
+#include <Inventor/SoDB.h>
+#include <Inventor/SoOffscreenRenderer.h>
+#include <Inventor/SbViewportRegion.h>
+#include <Inventor/SbColor.h>
+#include <Inventor/actions/SoGLRenderAction.h>
+#include <Inventor/elements/SoGLLazyElement.h>
+#include <Inventor/nodes/SoSeparator.h>
+#include <Inventor/nodes/SoOrthographicCamera.h>
+#include <Inventor/nodes/SoMaterial.h>
+#include <Inventor/nodes/SoCallback.h>
+#include <Inventor/nodes/SoCube.h>
+
+static void checkCB(void *, SoAction * action)
+{
+  if (!action->isOfType(SoGLRenderAction::getClassTypeId())) return;
+  SoState * state = action->getState();
+
+  // outer scope: e.g. SoGLCacheList::open() for an ancestor SoSeparator
+  SoGLLazyElement::GLState outer_pre, outer_post;
+  SoGLLazyElement::beginCaching(state, &outer_pre, &outer_post);
+
+  // inner scope, nested: e.g. SoPrimitiveVertexCache's constructor for a
+  // descendant SoShape validating its cache while the outer scope is open
+  SoGLLazyElement::GLState inner_pre, inner_post;
+  SoGLLazyElement::beginCaching(state, &inner_pre, &inner_post);
+
+  // inner scope closes first: e.g. SoPrimitiveVertexCache::close()
+  SoGLLazyElement::endCaching(state);
+
+  // outer scope closes: e.g. SoGLCacheList::close() -- this dereferenced
+  // a NULL postcachestate before the fix, since the inner endCaching()
+  // call had already zeroed it out from under the outer scope.
+  SoGLLazyElement::endCaching(state);
+
+  fprintf(stderr, "[repro] PASS: nested beginCaching()/endCaching() survived\n");
+}
+
+int main()
+{
+  SoDB::init();
+
+  SoSeparator * root = new SoSeparator;
+  root->ref();
+
+  SoOrthographicCamera * cam = new SoOrthographicCamera;
+  cam->position.setValue(0, 0, 5);
+  cam->height = 4.0f;
+  root->addChild(cam);
+
+  SoMaterial * mat = new SoMaterial;
+  root->addChild(mat);
+
+  SoCallback * cb = new SoCallback;
+  cb->setCallback(checkCB);
+  root->addChild(cb);
+
+  SoCube * cube = new SoCube;
+  root->addChild(cube);
+
+  SbViewportRegion vp(64, 64);
+  SoOffscreenRenderer renderer(vp);
+  renderer.setBackgroundColor(SbColor(0, 0, 0));
+  SbBool ok = renderer.render(root);
+
+  root->unref();
+
+  if (!ok) {
+    fprintf(stderr, "[repro] render() failed (no GL context available in this "
+                     "environment) -- inconclusive, not a pass or a fail\n");
+    return 2;
+  }
+  return 0;
+}

--- a/testsuite/reproducers/lazyelement-nested-caching-crash/run.sh
+++ b/testsuite/reproducers/lazyelement-nested-caching-crash/run.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+# Reproducer for issue #402: SoGLLazyElement::beginCaching()/endCaching()
+# were not reentrant, so a nested caching scope (a SoShape's
+# SoPrimitiveVertexCache validating while an ancestor SoSeparator's
+# SoGLCacheList recording is already open) clobbered the enclosing scope's
+# bookkeeping, causing the enclosing endCaching() to dereference a NULL
+# pointer. Run manually against a build tree's shared library:
+#
+#   testsuite/reproducers/lazyelement-nested-caching-crash/run.sh /path/to/build/lib
+#
+# Before the fix: crashes (SIGSEGV) inside the second (outer) endCaching()
+# call. After the fix: prints PASS and exits 0.
+#
+# Needs a working GLX context. If offscreen rendering fails to get direct
+# rendering (common in headless/sandboxed environments), try:
+#   COIN_GLX_PIXMAP_DIRECT_RENDERING=1 testsuite/reproducers/lazyelement-nested-caching-crash/run.sh ...
+
+cd "$(dirname "$0")"
+
+LIBDIR="$1"
+if [ -z "$LIBDIR" ]; then
+  echo "usage: $0 /path/to/build/lib   (directory containing libCoin.so)" >&2
+  exit 2
+fi
+
+CXX=${CXX:-c++}
+
+"$CXX" -O1 -g repro.cpp -o repro -I"$LIBDIR/../include" -L"$LIBDIR" -lCoin || exit 2
+
+export LD_LIBRARY_PATH="$LIBDIR${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+./repro
+status=$?
+if [ "$status" -ne 0 ] && [ "$status" -ne 2 ]; then
+  echo "=== FAIL: repro exited with status $status ===" >&2
+  exit "$status"
+fi

--- a/testsuite/reproducers/lazyelement-nested-caching-crash/run.sh
+++ b/testsuite/reproducers/lazyelement-nested-caching-crash/run.sh
@@ -30,7 +30,10 @@ CXX=${CXX:-c++}
 export LD_LIBRARY_PATH="$LIBDIR${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
 ./repro
 status=$?
-if [ "$status" -ne 0 ] && [ "$status" -ne 2 ]; then
+if [ "$status" -eq 2 ]; then
+  echo "=== INCONCLUSIVE: repro couldn't get a GL context in this environment ===" >&2
+  exit 2
+elif [ "$status" -ne 0 ]; then
   echo "=== FAIL: repro exited with status $status ===" >&2
   exit "$status"
 fi


### PR DESCRIPTION
Correct non-reentrant SoGLLazyElement cache bookkeeping for nested cache recording/replay. The rendering reproducer checks the nested path and now calls SoDB::finish after destroying local objects.

## Validation

The distributed changes were validated together in `lab/all-fixes-integration`, with Clang Debug instrumentation on both Coin and C++ test drivers: `-fsanitize=address,undefined,function -fno-omit-frame-pointer`, `ASAN_OPTIONS=detect_leaks=1`, `UBSAN_OPTIONS=halt_on_error=1`, without suppressions. All 8 CTest entries passed (342 CoinTests / 83,759 checks plus seven profiler modes); 31 additional checks passed, including actual rendering, events and the historical-header client. EGL and SpiderMonkey checks were inconclusive.

This is **integration evidence**, not a claim that this isolated PR includes every companion fix or passes the full sanitizer matrix by itself. Global cleanup, STL, test-fixture and GL record fixes are distributed across the related PRs. Windows/macOS and all optional configurations were not rerun for this update. The final per-PR diff passed `git diff --check`.
