### PR TITLE
Fix NULL-pointer crash in nested-cache replay behind COIN_NESTED_CACHING

### DIFF
--- a/src/caches/SoGLRenderCache.cpp
+++ b/src/caches/SoGLRenderCache.cpp
@@ -147,7 +147,12 @@ SoGLRenderCache::call(SoState * state)
       SoGLRenderCache* parentCache = static_cast<SoGLRenderCache *>(
         SoCacheElement::getCurrentCache(state)
        );
-      parentCache->addNestedCache(PRIVATE(this)->displaylist);
+      // state->isCacheOpen() and getCurrentCache() are backed by the same
+      // ancestor-walking lookup, so this should never be NULL here -- but
+      // guard against it rather than dereferencing a NULL pointer through
+      // a virtual call if that invariant is ever broken.
+      assert(parentCache != NULL);
+      if (parentCache) parentCache->addNestedCache(PRIVATE(this)->displaylist);
     }
     else {
       PRIVATE(this)->displaylist->call(state);

--- a/src/elements/SoCacheElement.cpp
+++ b/src/elements/SoCacheElement.cpp
@@ -329,5 +329,20 @@ SoCacheElement::setInvalid(const SbBool newvalue)
 SoCache *
 SoCacheElement::getCurrentCache(SoState * const state)
 {
-  return (coin_assert_cast<const SoCacheElement *>(state->getElementNoPush(classStackIndex)))->cache;
+  // walk up the element stack the same way anyOpen()/invalidate()/
+  // addCacheDependency() do: a cache opened by an ancestor is still the
+  // current one even if state->push() was called since (which creates a
+  // fresh SoCacheElement instance at the new depth, with cache == NULL,
+  // for that depth to record its own, distinct cache into -- see
+  // SoCacheElement::push()). Looking only at the current depth's instance
+  // could return NULL here while state->isCacheOpen() (which does track
+  // this correctly, see set()/pop()) still reports TRUE.
+  const SoCacheElement * elem = coin_assert_cast<const SoCacheElement *>
+    (
+     state->getElementNoPush(classStackIndex)
+     );
+  while (elem && !elem->cache) {
+    elem = coin_safe_cast<const SoCacheElement *>(elem->getNextInStack());
+  }
+  return elem ? elem->cache : NULL;
 }

--- a/testsuite/reproducers/CoinCleanup.h
+++ b/testsuite/reproducers/CoinCleanup.h
@@ -1,0 +1,17 @@
+#ifndef COIN_REPRODUCER_CLEANUP_H
+#define COIN_REPRODUCER_CLEANUP_H
+
+#include <Inventor/SoDB.h>
+
+// Declare immediately after SoDB::init(), before local Coin objects, so
+// those objects are destroyed before the library's global resources.
+class CoinReproducerCleanup {
+public:
+  CoinReproducerCleanup() {}
+  ~CoinReproducerCleanup() { SoDB::finish(); }
+private:
+  CoinReproducerCleanup(const CoinReproducerCleanup &);
+  CoinReproducerCleanup & operator=(const CoinReproducerCleanup &);
+};
+
+#endif

--- a/testsuite/reproducers/cacheelement-getcurrentcache-nesting/repro.cpp
+++ b/testsuite/reproducers/cacheelement-getcurrentcache-nesting/repro.cpp
@@ -1,0 +1,130 @@
+// Reproducer for a NULL-pointer virtual call in SoGLRenderCache::call(),
+// reachable only when the experimental COIN_NESTED_CACHING env var is
+// enabled (off by default).
+//
+// SoCacheElement::anyOpen()/invalidate()/addCacheDependency() all walk up
+// the SoElement stack (via getNextInStack()) to find an ancestor's open
+// cache -- this is what makes state->isCacheOpen() correctly report TRUE
+// even several state->push() calls below where a cache was actually
+// SoCacheElement::set(). SoCacheElement::getCurrentCache() did NOT do
+// this: it only looked at the SoCacheElement instance for the CURRENT
+// depth, which is freshly reset to cache=NULL on every state->push()
+// (see SoCacheElement::push()).
+//
+// SoGLRenderCache::call(), when COIN_NESTED_CACHING is enabled, trusts
+// state->isCacheOpen() to decide whether to look up "the current cache"
+// via getCurrentCache(), then unconditionally does a virtual call through
+// it: `static_cast<SoGLRenderCache*>(getCurrentCache(state))->
+// addNestedCache(...)`. Whenever the open cache was set() at a
+// shallower depth than the current one (an entirely ordinary situation --
+// it's exactly what happens once child nodes push additional state depths
+// while an ancestor SoSeparator's own cache recording is still open),
+// getCurrentCache() returned NULL while isCacheOpen() was TRUE, so this
+// dereferences a NULL pointer for the virtual dispatch.
+//
+// This builds the exact call sequence via the public SoCacheElement/
+// SoGLRenderCache APIs, matching the documented SoCache usage pattern
+// (see the class doc comment in src/caches/SoCache.cpp), instead of
+// relying on Coin's own cache-creation heuristics to naturally line up.
+//
+// See run.sh in this directory for how to build and run this against a
+// given libCoin build. Needs COIN_NESTED_CACHING=1 in the environment.
+
+#include <cstdio>
+#include <cstdlib>
+#include <Inventor/SoDB.h>
+#include <Inventor/SoOffscreenRenderer.h>
+#include <Inventor/SbViewportRegion.h>
+#include <Inventor/SbColor.h>
+#include <Inventor/actions/SoGLRenderAction.h>
+#include <Inventor/caches/SoGLRenderCache.h>
+#include <Inventor/elements/SoCacheElement.h>
+#include <Inventor/misc/SoState.h>
+#include <Inventor/nodes/SoSeparator.h>
+#include <Inventor/nodes/SoOrthographicCamera.h>
+#include <Inventor/nodes/SoMaterial.h>
+#include <Inventor/nodes/SoCallback.h>
+#include <Inventor/nodes/SoCube.h>
+
+static void checkCB(void *, SoAction * action)
+{
+  if (!action->isOfType(SoGLRenderAction::getClassTypeId())) return;
+  SoState * state = action->getState();
+
+  // Outer cache scope: e.g. a SoSeparator's SoGLCacheList recording.
+  state->push();
+  SoGLRenderCache * outer = new SoGLRenderCache(state);
+  outer->ref();
+  SoCacheElement::set(state, outer);
+  outer->open(state);
+  outer->close();
+  // Deliberately not popped/closed off the element stack yet -- the
+  // outer cache is still "current" for any deeper state depth, matching
+  // SoSeparator::GLRenderBelowPath keeping its own cache set() while
+  // traversing (and further push()ing into) its children.
+
+  // A child scope one level deeper, e.g. entered by a descendant node.
+  state->push();
+
+  // Give this depth its own, genuinely fresh SoCacheElement instance with
+  // cache == NULL -- SoElement only creates a per-depth copy on a WRITE
+  // access (SoCacheElement::set()), not merely from state->push(), so we
+  // need at least one set() call at this depth to reproduce the same
+  // situation as e.g. SoFaceSet.cpp's "SoCacheElement::set(state, NULL);
+  // // close cache" (used after building/discarding its convex-triangle
+  // cache) while nested inside an ancestor's still-open cache scope.
+  SoCacheElement::set(state, NULL);
+
+  SoGLRenderCache * inner = new SoGLRenderCache(state);
+  inner->ref();
+  inner->open(state);
+  inner->close();
+
+  fprintf(stderr, "[repro] isCacheOpen()=%d, about to call inner->call() nested inside the still-open outer scope\n",
+          state->isCacheOpen());
+  inner->call(state);
+  fprintf(stderr, "[repro] PASS: inner->call() survived while nested inside an ancestor's open cache\n");
+
+  inner->unref();
+  state->pop();
+  outer->unref();
+  state->pop();
+}
+
+int main()
+{
+  setenv("COIN_NESTED_CACHING", "1", 1);
+  SoDB::init();
+
+  SoSeparator * root = new SoSeparator;
+  root->ref();
+
+  SoOrthographicCamera * cam = new SoOrthographicCamera;
+  cam->position.setValue(0, 0, 5);
+  cam->height = 4.0f;
+  root->addChild(cam);
+
+  SoMaterial * mat = new SoMaterial;
+  root->addChild(mat);
+
+  SoCallback * cb = new SoCallback;
+  cb->setCallback(checkCB);
+  root->addChild(cb);
+
+  SoCube * cube = new SoCube;
+  root->addChild(cube);
+
+  SbViewportRegion vp(64, 64);
+  SoOffscreenRenderer renderer(vp);
+  renderer.setBackgroundColor(SbColor(0, 0, 0));
+  SbBool ok = renderer.render(root);
+
+  root->unref();
+
+  if (!ok) {
+    fprintf(stderr, "[repro] render() failed (no GL context available in this "
+                     "environment) -- inconclusive, not a pass or a fail\n");
+    return 2;
+  }
+  return 0;
+}

--- a/testsuite/reproducers/cacheelement-getcurrentcache-nesting/repro.cpp
+++ b/testsuite/reproducers/cacheelement-getcurrentcache-nesting/repro.cpp
@@ -30,6 +30,7 @@
 // See run.sh in this directory for how to build and run this against a
 // given libCoin build. Needs COIN_NESTED_CACHING=1 in the environment.
 
+#include "../CoinCleanup.h"
 #include <cstdio>
 #include <cstdlib>
 #include <Inventor/SoDB.h>
@@ -95,6 +96,7 @@ int main()
 {
   setenv("COIN_NESTED_CACHING", "1", 1);
   SoDB::init();
+  CoinReproducerCleanup cleanup;
 
   SoSeparator * root = new SoSeparator;
   root->ref();

--- a/testsuite/reproducers/cacheelement-getcurrentcache-nesting/run.sh
+++ b/testsuite/reproducers/cacheelement-getcurrentcache-nesting/run.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+# Reproducer for a NULL-pointer virtual call in SoGLRenderCache::call(),
+# caused by SoCacheElement::getCurrentCache() not walking up the element
+# stack the way anyOpen()/invalidate()/addCacheDependency() do -- so it
+# can return NULL even while state->isCacheOpen() correctly reports TRUE.
+# Only reachable with the experimental COIN_NESTED_CACHING=1 env var (off
+# by default). Run manually against a build tree's shared library:
+#
+#   testsuite/reproducers/cacheelement-getcurrentcache-nesting/run.sh /path/to/build/lib
+#
+# Before the fix: crashes (SIGSEGV) inside inner->call(). After the fix:
+# prints PASS and exits 0.
+#
+# Needs a working GLX context. If offscreen rendering fails to get direct
+# rendering (common in headless/sandboxed environments), try:
+#   COIN_GLX_PIXMAP_DIRECT_RENDERING=1 testsuite/reproducers/cacheelement-getcurrentcache-nesting/run.sh ...
+
+cd "$(dirname "$0")"
+
+LIBDIR="$1"
+if [ -z "$LIBDIR" ]; then
+  echo "usage: $0 /path/to/build/lib   (directory containing libCoin.so)" >&2
+  exit 2
+fi
+
+CXX=${CXX:-c++}
+
+"$CXX" -O1 -g repro.cpp -o repro -I"$LIBDIR/../include" -L"$LIBDIR" -lCoin || exit 2
+
+export LD_LIBRARY_PATH="$LIBDIR${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+./repro
+status=$?
+if [ "$status" -ne 0 ] && [ "$status" -ne 2 ]; then
+  echo "=== FAIL: repro exited with status $status ===" >&2
+  exit "$status"
+fi

--- a/testsuite/reproducers/cacheelement-getcurrentcache-nesting/run.sh
+++ b/testsuite/reproducers/cacheelement-getcurrentcache-nesting/run.sh
@@ -30,7 +30,10 @@ CXX=${CXX:-c++}
 export LD_LIBRARY_PATH="$LIBDIR${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
 ./repro
 status=$?
-if [ "$status" -ne 0 ] && [ "$status" -ne 2 ]; then
+if [ "$status" -eq 2 ]; then
+  echo "=== INCONCLUSIVE: repro couldn't get a GL context in this environment ===" >&2
+  exit 2
+elif [ "$status" -ne 0 ]; then
   echo "=== FAIL: repro exited with status $status ===" >&2
   exit "$status"
 fi


### PR DESCRIPTION
Find the nearest open ancestor cache when the current SoCacheElement depth is empty, and guard the nested-cache call against a missing parent. This prevents a NULL dereference with COIN_NESTED_CACHING. The rendering reproducer now performs orderly Coin cleanup.

## Validation

The distributed changes were validated together in `lab/all-fixes-integration`, with Clang Debug instrumentation on both Coin and C++ test drivers: `-fsanitize=address,undefined,function -fno-omit-frame-pointer`, `ASAN_OPTIONS=detect_leaks=1`, `UBSAN_OPTIONS=halt_on_error=1`, without suppressions. All 8 CTest entries passed (342 CoinTests / 83,759 checks plus seven profiler modes); 31 additional checks passed, including actual rendering, events and the historical-header client. EGL and SpiderMonkey checks were inconclusive.

This is **integration evidence**, not a claim that this isolated PR includes every companion fix or passes the full sanitizer matrix by itself. Global cleanup, STL, test-fixture and GL record fixes are distributed across the related PRs. Windows/macOS and all optional configurations were not rerun for this update. The final per-PR diff passed `git diff --check`.
