### PR TITLE
Fix memory leak (and UAF on self-rename) in SoDB::renameGlobalField()

### DIFF
--- a/src/fields/SoGlobalField.cpp
+++ b/src/fields/SoGlobalField.cpp
@@ -198,9 +198,14 @@ SoGlobalField::addGlobalFieldContainer(SoGlobalField * fieldcontainer)
 
 // Remove the given global field from the internal list.
 //
-// Note that this will decrease the reference count of the
-// SoGlobalField node, causing it to be destructed unless it has been
-// ref()'ed outside of this class.
+// Note that this does *not* affect the reference count of the
+// SoGlobalField node: allcontainers is set up in initClass() with
+// addReferences(FALSE) precisely so that removing an item from it here
+// does not implicitly ref()/unref() -- callers that actually want the
+// fieldcontainer deleted need to unref() it themselves (which will, in
+// turn, remove it from this list via ~SoGlobalField() -- calling this
+// method first is both unnecessary and unsafe, since the destructor's
+// own removal would then find nothing to remove).
 void
 SoGlobalField::removeGlobalFieldContainer(SoGlobalField * fieldcontainer)
 {

--- a/src/misc/SoDB.cpp
+++ b/src/misc/SoDB.cpp
@@ -955,6 +955,13 @@ SoDB::renameGlobalField(const SbName & from, const SbName & to)
   }
 #endif // COIN_DEBUG
 
+  // Renaming a field to its own current name is a no-op -- and must be
+  // handled as one: otherwise, "old" below (found by looking up "to")
+  // would be this very same gf, and unref()'ing it out from under
+  // ourselves before the gf->setName(to) call further down would be a
+  // use-after-free.
+  if (from == to) return;
+
   if (to == "") { // Empty string is a special case, remove field.
     assert(gf->getRefCount() == 1);
     // SoGlobalField::removeGlobalFieldContainer(gf) would only remove gf

--- a/src/misc/SoDB.cpp
+++ b/src/misc/SoDB.cpp
@@ -957,7 +957,14 @@ SoDB::renameGlobalField(const SbName & from, const SbName & to)
 
   if (to == "") { // Empty string is a special case, remove field.
     assert(gf->getRefCount() == 1);
-    SoGlobalField::removeGlobalFieldContainer(gf);
+    // SoGlobalField::removeGlobalFieldContainer(gf) would only remove gf
+    // from the internal list without dropping its refcount (see that
+    // method's own doc comment vs. SoGlobalField::initClass(), which sets
+    // up the list with addReferences(FALSE) precisely so it does *not*
+    // do that) -- so it would leak gf here. unref() triggers the actual
+    // deletion, and ~SoGlobalField() removes the container from the list
+    // itself, same fix as SoDBP::removeRealTimeFieldCB() (Coin issue #73).
+    gf->unref();
     return;
   }
 
@@ -965,7 +972,7 @@ SoDB::renameGlobalField(const SbName & from, const SbName & to)
   SoGlobalField * old = SoGlobalField::getGlobalFieldContainer(to);
   if (old) {
     assert(old->getRefCount() == 1);
-    SoGlobalField::removeGlobalFieldContainer(old);
+    old->unref(); // see comment above
   }
 
   gf->setName(to);

--- a/testsuite/reproducers/sodb-renameglobalfield-leak/repro.cpp
+++ b/testsuite/reproducers/sodb-renameglobalfield-leak/repro.cpp
@@ -1,0 +1,90 @@
+// Reproducer for a memory leak in SoDB::renameGlobalField()
+// (src/misc/SoDB.cpp), the documented way to discard a global field
+// created via SoDB::createGlobalField() ("If \a to is an empty name, the
+// \a from field gets deleted. If another global field already goes by
+// the name \a to, that field will get deleted before the rename
+// operation.").
+//
+// Traced by hand (src/misc/SoDB.cpp, src/fields/SoGlobalField.cpp,
+// src/lists/SoBaseList.cpp): both "delete" branches of
+// renameGlobalField() called only SoGlobalField::removeGlobalFieldContainer(),
+// which does allcontainers->removeItem(fieldcontainer) -- and
+// SoGlobalField::initClass() creates that list with addReferences(FALSE),
+// so SoBaseList::remove()/removeItem() take the "unless addReferences()
+// has been set to FALSE" branch and never call unref(). Nothing else in
+// either code path unref()s or deletes the field container -- it is just
+// silently dropped from the only list that was tracking it, at whatever
+// refcount it already had. This is the exact same bug class fixed for
+// SoDBP::removeRealTimeFieldCB() in 2014 (Coin issue #73 / commit
+// 3695870b88) -- but renameGlobalField(), the function that fix's own
+// explanatory comment and SoGlobalField::clean()'s shutdown warning both
+// point applications at as *the* correct way to discard a global field,
+// was never itself touched, and has zero callers anywhere in Coin's own
+// source tree or test suite to have ever exercised it.
+//
+// SoDB::init() itself demonstrates the intended ownership protocol for
+// "realTime": ref() the container right after creating it, hold that
+// single reference for as long as you want to keep the field, then
+// release it exactly once via the delete path. This repro follows the
+// same protocol (via SoField::getContainer(), the public way to reach
+// the field container without needing the unexported SoGlobalField
+// type), then relies on LeakSanitizer (run this under an ASan build) to
+// report any SoField/SoGlobalField allocations still reachable -- i.e.
+// never freed -- when the process exits.
+//
+// Exercises both leak sites in renameGlobalField(): renaming to an empty
+// name (delete outright), and renaming onto an existing name (which
+// deletes the pre-existing field by that name).
+//
+// See run.sh in this directory for how to build and run this against a
+// given libCoin build.
+
+#include <cstdio>
+#include <Inventor/SoDB.h>
+#include <Inventor/fields/SoSFFloat.h>
+#include <Inventor/fields/SoFieldContainer.h>
+
+int main()
+{
+  SoDB::init();
+
+  const int n = 100;
+
+  // Branch 1: renameGlobalField(name, "") -- delete outright.
+  for (int i = 0; i < n; i++) {
+    char name[32];
+    snprintf(name, sizeof(name), "leaktest_empty_%d", i);
+    SoField * f = SoDB::createGlobalField(SbName(name), SoSFFloat::getClassTypeId());
+    f->getContainer()->ref(); // same protocol SoDB::init() uses for "realTime"
+    SoDB::renameGlobalField(SbName(name), SbName("")); // documented way to delete it
+  }
+
+  // Branch 2: renameGlobalField(newname, oldname) where oldname already
+  // exists -- the pre-existing "oldname" field is documented to "get
+  // deleted before the rename operation".
+  for (int i = 0; i < n; i++) {
+    char oldname[32], newname[32];
+    snprintf(oldname, sizeof(oldname), "leaktest_old_%d", i);
+    snprintf(newname, sizeof(newname), "leaktest_new_%d", i);
+    SoField * of = SoDB::createGlobalField(SbName(oldname), SoSFFloat::getClassTypeId());
+    of->getContainer()->ref();
+    SoField * nf = SoDB::createGlobalField(SbName(newname), SoSFFloat::getClassTypeId());
+    nf->getContainer()->ref();
+    // "oldname"'s pre-existing field container should get deleted here;
+    // "newname"'s survives, renamed to "oldname".
+    SoDB::renameGlobalField(SbName(newname), SbName(oldname));
+    // Clean up the survivor too via the same documented delete path, so
+    // this loop doesn't itself leave anything dangling for
+    // SoDB::finish() to (correctly) warn about and not free.
+    SoDB::renameGlobalField(SbName(oldname), SbName(""));
+  }
+
+  fprintf(stderr, "[repro] exercised both renameGlobalField() delete paths "
+                  "%d times each\n", n);
+
+  SoDB::finish(); // exercise the documented cleanup path (also frees "realTime")
+
+  fprintf(stderr, "[repro] done -- run under LeakSanitizer/valgrind to see "
+                  "whether the discarded fields were actually freed\n");
+  return 0;
+}

--- a/testsuite/reproducers/sodb-renameglobalfield-leak/repro.cpp
+++ b/testsuite/reproducers/sodb-renameglobalfield-leak/repro.cpp
@@ -36,6 +36,13 @@
 // name (delete outright), and renaming onto an existing name (which
 // deletes the pre-existing field by that name).
 //
+// Also exercises renaming a field to its own current name: the "onto an
+// existing name" lookup then finds the very same container being
+// renamed, so unref()'ing it as if it were a distinct pre-existing entry
+// is a use-after-free (the subsequent gf->setName(to) dereferences the
+// now-deleted object) -- caught by ASan on the very first fix attempt at
+// this leak (which did not special-case from == to).
+//
 // See run.sh in this directory for how to build and run this against a
 // given libCoin build.
 
@@ -79,8 +86,24 @@ int main()
     SoDB::renameGlobalField(SbName(oldname), SbName(""));
   }
 
+  // Branch 3: renameGlobalField(name, name) -- renaming a field to its
+  // own current name must be a no-op, not a use-after-free.
+  for (int i = 0; i < n; i++) {
+    char name[32];
+    snprintf(name, sizeof(name), "leaktest_self_%d", i);
+    SoField * f = SoDB::createGlobalField(SbName(name), SoSFFloat::getClassTypeId());
+    f->getContainer()->ref();
+    SoDB::renameGlobalField(SbName(name), SbName(name));
+    // Field must still be alive and findable under its own name.
+    if (SoDB::getGlobalField(SbName(name)) != f) {
+      fprintf(stderr, "[repro] FAIL: self-rename lost or corrupted the field\n");
+      return 1;
+    }
+    SoDB::renameGlobalField(SbName(name), SbName("")); // clean up
+  }
+
   fprintf(stderr, "[repro] exercised both renameGlobalField() delete paths "
-                  "%d times each\n", n);
+                  "%d times each, plus %d self-renames\n", n, n);
 
   SoDB::finish(); // exercise the documented cleanup path (also frees "realTime")
 

--- a/testsuite/reproducers/sodb-renameglobalfield-leak/run.sh
+++ b/testsuite/reproducers/sodb-renameglobalfield-leak/run.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+# Investigation repro for a suspected leak in
+# SoDB::renameGlobalField(name, "") -- see repro.cpp for the full
+# explanation. Run against an ASan build (LeakSanitizer enabled) to see
+# whether the discarded global fields were actually freed:
+#
+#   testsuite/reproducers/sodb-renameglobalfield-leak/run.sh /path/to/asan-build/lib
+#
+# If leaked: LeakSanitizer reports "SUMMARY: ... byte(s) leaked" with a
+# stack trace through SoDB::createGlobalField() / SoGlobalField::
+# SoGlobalField() on exit, and this script exits non-zero.
+# If not leaked: prints PASS and exits 0.
+
+cd "$(dirname "$0")"
+
+LIBDIR="$1"
+if [ -z "$LIBDIR" ]; then
+  echo "usage: $0 /path/to/asan-build/lib   (directory containing libCoin.so)" >&2
+  exit 2
+fi
+
+CXX=${CXX:-c++}
+SRCINCLUDE="$(cd "$(dirname "$0")/../../.." && pwd)/include"
+
+"$CXX" -O1 -g repro.cpp -o repro -I"$SRCINCLUDE" -I"$LIBDIR/../include" -L"$LIBDIR" -lCoin || exit 2
+
+export LD_LIBRARY_PATH="$LIBDIR${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+./repro
+status=$?
+if [ "$status" -ne 0 ]; then
+  echo "=== leak detected (or crash): repro exited with status $status ===" >&2
+  exit "$status"
+fi
+echo "=== PASS: no leak detected ==="

--- a/testsuite/reproducers/sodb-renameglobalfield-leak/run.sh
+++ b/testsuite/reproducers/sodb-renameglobalfield-leak/run.sh
@@ -11,7 +11,7 @@
 # SoGlobalField() on exit, and this script exits non-zero.
 # If not leaked: prints PASS and exits 0.
 
-cd "$(dirname "$0")"
+CDPATH= cd "$(dirname "$0")" || exit 2
 
 LIBDIR="$1"
 if [ -z "$LIBDIR" ]; then
@@ -20,7 +20,8 @@ if [ -z "$LIBDIR" ]; then
 fi
 
 CXX=${CXX:-c++}
-SRCINCLUDE="$(cd "$(dirname "$0")/../../.." && pwd)/include"
+# The current directory is already the reproducer directory.
+SRCINCLUDE="$(CDPATH= cd ../../.. && pwd)/include" || exit 2
 
 "$CXX" -O1 -g repro.cpp -o repro -I"$SRCINCLUDE" -I"$LIBDIR/../include" -L"$LIBDIR" -lCoin || exit 2
 


### PR DESCRIPTION
## Summary

`SoDB::renameGlobalField()` is documented as the way to discard a global field created via `SoDB::createGlobalField()`: "If \a to is an empty name, the \a from field gets deleted. If another global field already goes by the name \a to, that field will get deleted before the rename operation." Both of those "delete" branches only called `SoGlobalField::removeGlobalFieldContainer()`, which removes the item from the internal tracking list without ever touching its refcount (`SoGlobalField::initClass()` sets that list up with `addReferences(FALSE)` precisely so it doesn't) — so the field container was just dropped from the only list tracking it, never freed, regardless of its refcount.

This is the exact same bug class fixed for `SoDBP::removeRealTimeFieldCB()` in 2014 (Coin issue #73 / commit 3695870b88), whose own explanatory comment already correctly identified the mechanism. `renameGlobalField()` — the very function that fix's comment, and `SoGlobalField::clean()`'s shutdown warning, both point applications at as *the* correct way to discard a global field — was never itself touched, and has zero callers anywhere in Coin's own source tree or test suite to have ever exercised it.

Fix: call `unref()` on the field container instead (matching the 2014 fix exactly) — `~SoGlobalField()` already removes itself from `allcontainers`, so the explicit `removeGlobalFieldContainer()` call is both unnecessary and unsafe to keep.

Also corrected `SoGlobalField::removeGlobalFieldContainer()`'s own doc comment, which claimed (incorrectly, given `addReferences(FALSE)`) that it decreases the refcount — likely the source of the original mistake.

## Review fix (second commit)

A review of the first commit caught two more issues before this was ready:

1. **Use-after-free renaming a field to its own current name.** `renameGlobalField(name, name)` looks up `old` by the `to` name — when `from == to`, that lookup finds the very same container being renamed. `unref()`'ing it as if it were a distinct pre-existing entry destroys the object; the following `gf->setName(to)` then dereferences freed memory. Confirmed with ASan (heap-use-after-free). Fixed by returning immediately when `from == to` (a documented-contract no-op).
2. `testsuite/reproducers/sodb-renameglobalfield-leak/run.sh` had the same include-path bug already fixed on the `fix/null-dereference` branch (commit 8f2e897966) — recomputed the source include path via a second `dirname "$0"` lookup after already `cd`-ing into the reproducer's own directory, which breaks for relative-path invocation from elsewhere (e.g. the repo root, the exact usage shown in the script's own header comment). Applied the identical fix.

## Verification

New reproducer at `testsuite/reproducers/sodb-renameglobalfield-leak/`, exercising all three scenarios (delete via empty name, delete via renaming onto an existing name, self-rename no-op) via the documented `ref()`-then-delete ownership protocol (the same one `SoDB::init()` itself uses for `"realTime"`).

- Confirmed each bug reproduces cleanly before its respective fix and passes clean after, under GCC Debug, clang Debug, and Debug ASan+UBSan+LeakSanitizer together.
- Full `ctest` 100% pass in all three configurations (leak detection off for that broader run — an unrelated pre-existing leak in `SoBase_TestSuite::checkWriteWithMultiref`, which never `unref()`s its test scene graph, is out of scope here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FHRXMxksBcEGfbN5bDVJzb