### PR TITLE
Remove remaining non-ASCII characters from source comments

### DIFF
--- a/src/base/SbCylinder.cpp
+++ b/src/base/SbCylinder.cpp
@@ -180,7 +180,7 @@ SbCylinder::intersect(const SbLine& l, SbVec3f& enter, SbVec3f& exit) const
   // be written as
   //                     Qc = Pc + x*U0 + y*U1 + z*U2
   //
-  // The points on the cylinder is then those matching x²+y²=r².
+  // The points on the cylinder is then those matching x^2+y^2=r^2.
   //
   // For the ray, we project it into the coordinate system by
   // rewriting the line equation   Qr = Pr + t*Dr  as
@@ -189,13 +189,13 @@ SbCylinder::intersect(const SbLine& l, SbVec3f& enter, SbVec3f& exit) const
   //
   // The intersection is then determined by
   //
-  //    (x0 + t*x1)² + (y0 + t*y1)² = r²
+  //    (x0 + t*x1)^2 + (y0 + t*y1)^2 = r^2
   //
-  // => (x1²+y1²)*t² + 2*(x0*x1+y0*y1)*t + (x1²+y1²-r²) = 0
+  // => (x1^2+y1^2)*t^2 + 2*(x0*x1+y0*y1)*t + (x1^2+y1^2-r^2) = 0
   //
   // Which can be solved by:
-  // t = (-b ± sqrt(b² - 4ac))/2a, a = x1² + y1², b = 2*(x0*x1+y0*y1),
-  //                               c = (x1²+y1²-r²),
+  // t = (-b +/- sqrt(b^2 - 4ac))/2a, a = x1^2 + y1^2, b = 2*(x0*x1+y0*y1),
+  //                               c = (x1^2+y1^2-r^2),
   //
   // ...
   //                                                        19980824 mortene.

--- a/src/base/SbDPLine.cpp
+++ b/src/base/SbDPLine.cpp
@@ -150,17 +150,17 @@ SbDPLine::getClosestPoints(const SbDPLine& line2,
   // the solution line q2 - q1 is orthogonal to d1 and d2 
   // (or a null vector if the lines intersect), which yields:
   //
-  // (u + t2*d2 - t1*d1) · d1 = 0                    (2)
-  // (u + t2*d2 - t1*d1) · d2 = 0
+  // (u + t2*d2 - t1*d1) dot d1 = 0                    (2)
+  // (u + t2*d2 - t1*d1) dot d2 = 0
   //
-  // we know |d1| and |d2| == 1, and set d1 · d2 = t
+  // we know |d1| and |d2| == 1, and set d1 dot d2 = t
   //
-  // t1 - t*t2 = u · d1
-  // t*t1 - t2 = u · d2
+  // t1 - t*t2 = u dot d1
+  // t*t1 - t2 = u dot d2
   //
   // Solve for t1, and find q1 using (0):
   //
-  // t1 = (u·d1 - t * (u·d2))/ (1 - t^2)
+  // t1 = (u dot d1 - t * (u dot d2))/ (1 - t^2)
   //
   // just find q2 by using line2.getClosestPoint(q1)
 
@@ -203,7 +203,7 @@ SbDPLine::getClosestPoints(const SbDPLine& line2,
   // From the discussion on getClosestPoint(), we know that the point
   // we wish to find on a line can be expressed as:
   //
-  //                  (Q1-P0)·D0
+  //                  (Q1-P0) dot D0
   //   Q0 = P0 + D0 * ----------
   //                     |D0|
   //
@@ -212,8 +212,8 @@ SbDPLine::getClosestPoints(const SbDPLine& line2,
   // we get two equations with two unknowns. By substituting for
   // Q1 we get a new equation with a single unknown, Q0:
   //
-  //                   (         (Q0 - P1)·D1    )
-  //                   (P1 + D1 * ------------ - P0) · D0
+  //                   (         (Q0 - P1) dot D1    )
+  //                   (P1 + D1 * ------------ - P0) dot D0
   //                   (             |D1|        )
   //   Q0 = P0 + D0 * ------------------------------------
   //                                |D0|
@@ -228,14 +228,14 @@ SbDPLine::getClosestPoints(const SbDPLine& line2,
   //
   //   f(t0, t1) = |Q1 - Q0| = |P1+D1*t1 - (P0+D0*t0)|
   //
-  //                         (t1*D1 - P0)·D0
+  //                         (t1*D1 - P0) dot D0
   // t0 can be expressed as  ---------------  which gives us
   //                               |D0|
   //
-  //   f(t) = |P1 + D1*t - P0 - D0N * ((t*D1 - P0)·D0)|, t = t1
+  //   f(t) = |P1 + D1*t - P0 - D0N * ((t*D1 - P0) dot D0)|, t = t1
   //                                                     D0N = D0 normalized
   //                               _____________
-  // ..which is eual to   f(t) = \/Þ² + ß² + ð²  , where Þ, ß, and ð
+  // ..which is eual to   f(t) = \/X^2 + Y^2 + Z^2  , where X, Y, and Z
   // is the full expression above with the x, y, and z components
   // of the vectors.
   //
@@ -243,19 +243,19 @@ SbDPLine::getClosestPoints(const SbDPLine& line2,
   // ignore the square root. We'll do the next parts of the math on a
   // general components case, since it's the same for the x, y and z parts.
   //
-  // Expanding any of the Þ, ß, or ð expressions, we get this:
+  // Expanding any of the X, Y, or Z expressions, we get this:
   //   (P1[i] - D1[i]*t - P0[i] - D0N[i]*D0[x]*D1[x]*t + D0N[i]*D0[x]*P0[x]
   //      - D0N[i]*D0[y]*D1[y]*t + D0N[i]*D0[y]*P0[y] - D0N[i]*D0[z]*D1[z]*t
-  //      + D0N[i]*D0[z]*P0[z])² ,
+  //      + D0N[i]*D0[z]*P0[z])^2 ,
   // where i=[x|y|z].
   //
-  // Deriving this by using the chain rule (i.e. g(t)² = 2*g(t)*g'(t)), we'll
+  // Deriving this by using the chain rule (i.e. g(t)^2 = 2*g(t)*g'(t)), we'll
   // get this equation for finding the t yielding the minimum distance
   // between two points Q0 and Q1 on the lines:
   //
   //      -(cx*dx+cy*dy+cz*dz)
   //  t = --------------------
-  //        dx² + dy² + dz²
+  //        dx^2 + dy^2 + dz^2
   //
   //  di = D1[i] - D0N[i] * (D0[x]*D1[x] + D0[y]*D1[y] + D0[z]*D1[z])
   // and
@@ -316,7 +316,7 @@ SbDPLine::getClosestPoint(const SbVec3d& point) const
   // Q = point to find.
   //
   // Solved by:
-  //                         a·b
+  //                         a dot b
   //             comp_b(a) = ---   , a = P-SP, b = D, comp_b(a) = |Q-SP|
   //                         |b|
   //

--- a/src/base/SbDPPlane.cpp
+++ b/src/base/SbDPPlane.cpp
@@ -105,9 +105,9 @@ SbDPPlane::SbDPPlane(const SbVec3d & p0, const SbVec3d & p1, const SbVec3d & p2)
   // we test and warn about a null vector above
   (void) this->normal.normalize();
 
-  //     N·point
+  //     N dot point
   // d = -------, |N| == 1
-  //       |N|²
+  //       |N|^2
 
   this->distance = this->normal.dot(p0);
 }
@@ -129,9 +129,9 @@ SbDPPlane::SbDPPlane(const SbVec3d & normalref, const SbVec3d & point)
   // we test and warn about a null vector above
   (void) this->normal.normalize();
 
-  //     N·point
+  //     N dot point
   // d = -------, |N| == 1
-  //       |N|²
+  //       |N|^2
 
   this->distance = this->normal.dot(point);
 }
@@ -172,15 +172,15 @@ SbDPPlane::intersect(const SbDPLine & l, SbVec3d & intersection) const
   //
   // We can also easily see that a point must satisfy this equation to lie
   // in the plane:
-  //                    N·(Q - d*N) = 0, where N is the normal vector,
+  //                    N dot (Q - d*N) = 0, where N is the normal vector,
   //                                     Q is the point and d the offset
   //                                     from the origin.
   //
   // Combining these two equations and simplifying we get:
   //
-  //                          d*|N|² - N·P
+  //                          d*|N|^2 - N dot P
   //                    t = ----------------, |N| == 1
-  //                               N·D
+  //                               N dot D
   //
   // Substituting t back in (1), we've solved the problem.
   //                                                         19980816 mortene.
@@ -231,7 +231,7 @@ SbDPPlane::isInHalfSpace(const SbVec3d & point) const
   // This one is dead easy, we just take the dot product of the normal
   // vector and the vector going from the plane base point to the
   // point we're checking against, and see if the angle between the
-  // vectors are within 90° (which is the same as checking the sign
+  // vectors are within 90 degree (which is the same as checking the sign
   // of the dot product).
   //                                                    19980816 mortene.
 #if 0 // not very efficient code, disabled 19991012 pederb

--- a/src/base/SbLine.cpp
+++ b/src/base/SbLine.cpp
@@ -174,17 +174,17 @@ SbLine::getClosestPoints(const SbLine& line2,
   // the solution line q2 - q1 is orthogonal to d1 and d2 
   // (or a null vector if the lines intersect), which yields:
   //
-  // (u + t2*d2 - t1*d1) · d1 = 0                    (2)
-  // (u + t2*d2 - t1*d1) · d2 = 0
+  // (u + t2*d2 - t1*d1) dot d1 = 0                    (2)
+  // (u + t2*d2 - t1*d1) dot d2 = 0
   //
-  // we know |d1| and |d2| == 1, and set d1 · d2 = t
+  // we know |d1| and |d2| == 1, and set d1 dot d2 = t
   //
-  // t1 - t*t2 = u · d1
-  // t*t1 - t2 = u · d2
+  // t1 - t*t2 = u dot d1
+  // t*t1 - t2 = u dot d2
   //
   // Solve for t1, and find q1 using (0):
   //
-  // t1 = (u·d1 - t * (u·d2))/ (1 - t^2)
+  // t1 = (u dot d1 - t * (u dot d2))/ (1 - t^2)
   //
   // just find q2 by using line2.getClosestPoint(q1)
 
@@ -226,7 +226,7 @@ SbLine::getClosestPoints(const SbLine& line2,
   // From the discussion on getClosestPoint(), we know that the point
   // we wish to find on a line can be expressed as:
   //
-  //                  (Q1-P0)·D0
+  //                  (Q1-P0) dot D0
   //   Q0 = P0 + D0 * ----------
   //                     |D0|
   //
@@ -235,8 +235,8 @@ SbLine::getClosestPoints(const SbLine& line2,
   // we get two equations with two unknowns. By substituting for
   // Q1 we get a new equation with a single unknown, Q0:
   //
-  //                   (         (Q0 - P1)·D1    )
-  //                   (P1 + D1 * ------------ - P0) · D0
+  //                   (         (Q0 - P1) dot D1    )
+  //                   (P1 + D1 * ------------ - P0) dot D0
   //                   (             |D1|        )
   //   Q0 = P0 + D0 * ------------------------------------
   //                                |D0|
@@ -251,14 +251,14 @@ SbLine::getClosestPoints(const SbLine& line2,
   //
   //   f(t0, t1) = |Q1 - Q0| = |P1+D1*t1 - (P0+D0*t0)|
   //
-  //                         (t1*D1 - P0)·D0
+  //                         (t1*D1 - P0) dot D0
   // t0 can be expressed as  ---------------  which gives us
   //                               |D0|
   //
-  //   f(t) = |P1 + D1*t - P0 - D0N * ((t*D1 - P0)·D0)|, t = t1
+  //   f(t) = |P1 + D1*t - P0 - D0N * ((t*D1 - P0) dot D0)|, t = t1
   //                                                     D0N = D0 normalized
   //                               _____________
-  // ..which is eual to   f(t) = \/Þ² + ß² + ð²  , where Þ, ß, and ð
+  // ..which is eual to   f(t) = \/X^2 + Y^2 + Z^2  , where X, Y, and Z
   // is the full expression above with the x, y, and z components
   // of the vectors.
   //
@@ -266,19 +266,19 @@ SbLine::getClosestPoints(const SbLine& line2,
   // ignore the square root. We'll do the next parts of the math on a
   // general components case, since it's the same for the x, y and z parts.
   //
-  // Expanding any of the Þ, ß, or ð expressions, we get this:
+  // Expanding any of the X, Y, or Z expressions, we get this:
   //   (P1[i] - D1[i]*t - P0[i] - D0N[i]*D0[x]*D1[x]*t + D0N[i]*D0[x]*P0[x]
   //      - D0N[i]*D0[y]*D1[y]*t + D0N[i]*D0[y]*P0[y] - D0N[i]*D0[z]*D1[z]*t
-  //      + D0N[i]*D0[z]*P0[z])² ,
+  //      + D0N[i]*D0[z]*P0[z])^2 ,
   // where i=[x|y|z].
   //
-  // Derivating this by using the chain rule (i.e. g(t)² =
+  // Derivating this by using the chain rule (i.e. g(t)^2 =
   // 2*g(t)*g'(t)), we'll get this equation for finding the t yielding
   // the minimum distance between two points Q0 and Q1 on the lines:
   //
   //      -(cx*dx+cy*dy+cz*dz)
   //  t = --------------------
-  //        dx² + dy² + dz²
+  //        dx^2 + dy^2 + dz^2
   //
   //  di = D1[i] - D0N[i] * (D0[x]*D1[x] + D0[y]*D1[y] + D0[z]*D1[z])
   // and
@@ -366,7 +366,7 @@ SbLine::getClosestPoint(const SbVec3f & point) const
   // Q = point to find.
   //
   // Solved by:
-  //                         a·b
+  //                         a dot b
   //             comp_b(a) = ---   , a = P-SP, b = D, comp_b(a) = |Q-SP|
   //                         |b|
   //

--- a/src/base/SbPlane.cpp
+++ b/src/base/SbPlane.cpp
@@ -109,9 +109,9 @@ SbPlane::SbPlane(const SbVec3f& p0, const SbVec3f& p1, const SbVec3f& p2)
 
   // we test and warn about a null vector above
   (void) this->normal.normalize();
-  //     N·point
+  //     N dot point
   // d = -------, |N| == 1
-  //       |N|²
+  //       |N|^2
 
   this->distance = this->normal.dot(p0);
 }
@@ -134,9 +134,9 @@ SbPlane::SbPlane(const SbVec3f& normalref, const SbVec3f& point)
   // we test and warn about a null vector above
   (void) this->normal.normalize();
 
-  //     N·point
+  //     N dot point
   // d = -------, |N| == 1
-  //       |N|²
+  //       |N|^2
 
   this->distance = this->normal.dot(point);
 }
@@ -183,15 +183,15 @@ SbPlane::intersect(const SbLine& l, SbVec3f& intersection) const
   //
   // We can also easily see that a point must satisfy this equation to lie
   // in the plane:
-  //                    N·(Q - d*N) = 0, where N is the normal vector,
+  //                    N dot (Q - d*N) = 0, where N is the normal vector,
   //                                     Q is the point and d the offset
   //                                     from the origin.
   //
   // Combining these two equations and simplifying we get:
   //
-  //                          d*|N|² - N·P
+  //                          d*|N|^2 - N dot P
   //                    t = ----------------, |N| == 1
-  //                               N·D
+  //                               N dot D
   //
   // Substituting t back in (1), we've solved the problem.
   //                                                         19980816 mortene.

--- a/src/base/SbVec3d.cpp
+++ b/src/base/SbVec3d.cpp
@@ -136,7 +136,7 @@ SbVec3d::SbVec3d(const SbDPPlane & p0, const SbDPPlane & p1, const SbDPPlane & p
 
   // The equation for a point in a plane can be:
   //
-  //                N·(P - P0) = 0    , N is the plane's normal vectors,
+  //                N dot (P - P0) = 0    , N is the plane's normal vectors,
   //                                    P is the point and P0 is the "root
   //                                    point" of the plane (i.e. the point
   //                                    in the plane closest to the coordinate
@@ -144,13 +144,13 @@ SbVec3d::SbVec3d(const SbDPPlane & p0, const SbDPPlane & p1, const SbDPPlane & p
   //
   // Simplifying and substituting, we get this:
   //
-  //                N·P = d           , d is the distance from the origin to
+  //                N dot P = d           , d is the distance from the origin to
   //                                    the closest point on the plane
   //
   // Using this for all three given planes:
-  //                N0·P = d0
-  //                N1·P = d1
-  //                N2·P = d2
+  //                N0 dot P = d0
+  //                N1 dot P = d1
+  //                N2 dot P = d2
   //
   // Taking the dot products we get a set of linear equations:
   //
@@ -183,7 +183,7 @@ SbVec3d::SbVec3d(const SbDPPlane & p0, const SbDPPlane & p1, const SbDPPlane & p
 
 
   int i, j;
-  const int n = 3; // Input matrix dimensions are n × (n+1).
+  const int n = 3; // Input matrix dimensions are n * (n+1).
 
   for (int k=0; k < n-1; k++) {
     j=k;

--- a/src/base/SbVec3f.cpp
+++ b/src/base/SbVec3f.cpp
@@ -139,7 +139,7 @@ SbVec3f::SbVec3f(const SbPlane & p0, const SbPlane & p1, const SbPlane & p2)
 
   // The equation for a point in a plane can be:
   //
-  //                N·(P - P0) = 0    , N is the plane's normal vectors,
+  //                N dot (P - P0) = 0    , N is the plane's normal vectors,
   //                                    P is the point and P0 is the "root
   //                                    point" of the plane (i.e. the point
   //                                    in the plane closest to the coordinate
@@ -147,13 +147,13 @@ SbVec3f::SbVec3f(const SbPlane & p0, const SbPlane & p1, const SbPlane & p2)
   //
   // Simplifying and substituting, we get this:
   //
-  //                N·P = d           , d is the distance from the origin to
+  //                N dot P = d           , d is the distance from the origin to
   //                                    the closest point on the plane
   //
   // Using this for all three given planes:
-  //                N0·P = d0
-  //                N1·P = d1
-  //                N2·P = d2
+  //                N0 dot P = d0
+  //                N1 dot P = d1
+  //                N2 dot P = d2
   //
   // Taking the dot products we get a set of linear equations:
   //
@@ -186,7 +186,7 @@ SbVec3f::SbVec3f(const SbPlane & p0, const SbPlane & p1, const SbPlane & p2)
 
 
   int i, j;
-  const int n = 3; // Input matrix dimensions are n × (n+1).
+  const int n = 3; // Input matrix dimensions are n * (n+1).
 
   for (int k=0; k < n-1; k++) {
     j=k;

--- a/src/fonts/fontlib_wrapper.cpp
+++ b/src/fonts/fontlib_wrapper.cpp
@@ -674,7 +674,8 @@ cc_flw_get_glyph(int font, unsigned int character)
            a superset of the chars in the default font. (The default
            font characters being rendered was due to a bug in the
            character mapping, causing failure to find special chars such
-           as 'ØÆÅ'. The bug has since been fixed).  20030327 preng */
+           as Scandinavian O-slash/AE/A-ring. The bug has since been
+           fixed).  20030327 preng */
 
         if (cc_font_debug()) {
           cc_debugerror_postwarning("cc_flw_get_glyph",

--- a/src/fonts/freetype.cpp
+++ b/src/fonts/freetype.cpp
@@ -30,7 +30,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 \**************************************************************************/
 
-/* FIXME: problem reported by Jan Peèiva on coin-dicuss: if there's a
+/* FIXME: problem reported by Jan Peeiva on coin-dicuss: if there's a
    freetype.dll installed as part of Cygwin, and Coin has been built
    with MSVC (and not Cygwin GCC), trying to use the Cygwin FreeType
    DLL leads to a crash. Should detect this problem and avoid a

--- a/src/io/SoInput_FileInfo.h
+++ b/src/io/SoInput_FileInfo.h
@@ -194,7 +194,7 @@ public:
     // ANSI C isspace() takes the current locale into account. Under
     // Microsoft Windows, this can lead to "interesting" artifacts, like a
     // case with RR tracked down and fixed by <thammer@sim.no> where a
-    // character (was it ü?) with ASCII value > 127 made isspace()
+    // character (was it u-umlaut?) with ASCII value > 127 made isspace()
     // return non-nil on a German system. So we're using our own
     // locale-independent isspace() implementation instead.
     return coin_isspace(c) || (this->vrml2file && c == ',');

--- a/src/nodekits/SoBaseKit.cpp
+++ b/src/nodekits/SoBaseKit.cpp
@@ -802,7 +802,7 @@ skip_spaces(const char * ptr)
   // ANSI C isspace() takes the current locale into account. Under
   // Microsoft Windows, this can lead to "interesting" artifacts, like a case
   // with RR tracked down and fixed by <thammer@sim.no> where a
-  // character (was it ü?) with ASCII value > 127 made isspace()
+  // character (was it u-umlaut?) with ASCII value > 127 made isspace()
   // return non-nil on a German system. So we're using our own
   // locale-independent isspace() implementation instead.
   while (coin_isspace(*ptr)) ptr++;

--- a/src/nodes/SoSpotLight.cpp
+++ b/src/nodes/SoSpotLight.cpp
@@ -106,7 +106,7 @@
 
   The angle in radians from the direction vector where there will be
   no light outside (i.e. the angle of the "lampshade"). Default value
-  is PI/4.0 (i.e. 45°). The value of this field will be clamped to
+  is PI/4.0 (i.e. 45 degree). The value of this field will be clamped to
   [0.0, PI/2] before it is used.
 */
 

--- a/src/tidbits.cpp
+++ b/src/tidbits.cpp
@@ -121,7 +121,7 @@
       - http://www.apache.org
 
 
-   6) Caolán McNamara's (GNU GPL?):
+   6) Caolan McNamara's (GNU GPL?):
 
       - http://www.csn.ul.ie/~caolan/publink/snprintf-1.1.tar.gz
 

--- a/src/vrml97/Cone.cpp
+++ b/src/vrml97/Cone.cpp
@@ -78,8 +78,8 @@
   the cone. The texture has a vertical seam at the back in the X=0
   plane, from the apex (0, height/2, 0) to the point (0, -height/2, -
   bottomRadius). For the bottom cap, a circle is cut out of the
-  texture square centred at (0, -height/2, 0) with dimensions (2 ×
-  bottomRadius) by (2 × bottomRadius).  The bottom cap texture appears
+  texture square centred at (0, -height/2, 0) with dimensions (2 *
+  bottomRadius) by (2 * bottomRadius).  The bottom cap texture appears
   right side up when the top of the cone is rotated towards the
   -Z-axis. SoVRMLTextureTransform affects the texture coordinates of
   the Cone.

--- a/src/vrml97/Cylinder.cpp
+++ b/src/vrml97/Cylinder.cpp
@@ -81,7 +81,7 @@
   cylinder. The texture has a vertical seam at the back, intersecting
   the X=0 plane. For the top and bottom caps, a circle is cut out of
   the unit texture squares centred at (0, +/- height/2, 0) with
-  dimensions 2 × radius by 2 × radius.  The top texture appears right
+  dimensions 2 * radius by 2 * radius.  The top texture appears right
   side up when the top of the cylinder is tilted toward the +Z-axis,
   and the bottom texture appears right side up when the top of the
   cylinder is tilted toward the -Z-axis. SoVRMLTextureTransform

--- a/src/vrml97/ElevationGrid.cpp
+++ b/src/vrml97/ElevationGrid.cpp
@@ -89,7 +89,7 @@
   \verbatim
     P[i,j].x = xSpacing * i
     P[i,j].y = height[ i + j * xDimension]
-    P[i,j].z = zSpacing * j     
+    P[i,j].z = zSpacing * j
 
     where 0 <= i < xDimension and 0 <= j < zDimension, and 
     P[0,0] is height[0] units above/below the origin of the local
@@ -119,7 +119,7 @@
     where 0 <= i < xDimension-1 and 0 <= j < zDimension-1, and
     QuadColor[i,j] is the colour for the quadrilateral defined by
     height[i+j*xDimension], height[(i+1)+j*xDimension],
-    height[(i+1)+(j+1)*xDimension] and height[i+(j+1)*xDimension] 
+    height[(i+1)+(j+1)*xDimension] and height[i+(j+1)*xDimension]
   \endverbatim
   
   If
@@ -128,11 +128,11 @@
   zDimension colours, one for each vertex, ordered as follows:
 
   \verbatim
-    VertexColor[i,j] = Color[ i + j * xDimension] 
+    VertexColor[i,j] = Color[ i + j * xDimension]
 
     where 0 <= i < xDimension and 0 <= j < zDimension, and 
     VertexColor[i,j] is the colour for the vertex defined by 
-    height[i+j*xDimension] 
+    height[i+j*xDimension]
   \endverbatim
 
   The normal field specifies per-vertex or per-quadrilateral normals
@@ -150,12 +150,12 @@
   ordered as follows: 
 
   \verbatim
-    QuadNormal[i,j] = Normal[ i + j * (xDimension-1)] 
+    QuadNormal[i,j] = Normal[ i + j * (xDimension-1)]
 
     where 0 <= i < xDimension-1 and 0 <= j < zDimension-1, and 
     QuadNormal[i,j] is the normal for the quadrilateral 
-    defined by height[i+j*xDimension], height[(i+1)+j*xDimension], 
-    height[(i+1)+(j+1)*xDimension] and height[i+(j+1)*xDimension] 
+    defined by height[i+j*xDimension], height[(i+1)+j*xDimension],
+    height[(i+1)+(j+1)*xDimension] and height[i+(j+1)*xDimension]
   \endverbatim
 
   If normalPerVertex is TRUE and the normal field is not NULL, the
@@ -164,11 +164,11 @@
   follows:
 
   \verbatim
-    VertexNormal[i,j] = Normal[ i + j * xDimension] 
+    VertexNormal[i,j] = Normal[ i + j * xDimension]
     
     where 0 <= i < xDimension and 0 <= j < zDimension, and
     VertexNormal[i,j] is the normal for the vertex defined by
-    height[i+j*xDimension] 
+    height[i+j*xDimension]
   \endverbatim
 
   The texCoord field specifies per-vertex texture coordinates for the
@@ -182,11 +182,11 @@
   ordered as follows:
 
   \verbatim
-    VertexTexCoord[i,j] = TextureCoordinate[ i + j * xDimension] 
+    VertexTexCoord[i,j] = TextureCoordinate[ i + j * xDimension]
 
     where 0 <= i < xDimension and 0 <= j < zDimension, and 
     VertexTexCoord[i,j] is the texture coordinate for the vertex 
-    defined by height[i+j*xDimension] 
+    defined by height[i+j*xDimension]
   \endverbatim
 
   The ccw, solid, and creaseAngle fields are described in 4.6.3,

--- a/src/vrml97/ElevationGrid.cpp
+++ b/src/vrml97/ElevationGrid.cpp
@@ -87,9 +87,9 @@
   placed at:
 
   \verbatim
-    P[i,j].x = xSpacing × i
-    P[i,j].y = height[ i + j × xDimension]
-    P[i,j].z = zSpacing × j     
+    P[i,j].x = xSpacing * i
+    P[i,j].y = height[ i + j * xDimension]
+    P[i,j].z = zSpacing * j     
 
     where 0 <= i < xDimension and 0 <= j < zDimension, and 
     P[0,0] is height[0] units above/below the origin of the local
@@ -110,29 +110,29 @@
   to each vertex or each quadrilateral of the ElevationGrid node. If
   colorPerVertex is FALSE and the color field is not NULL, the color
   field shall specify a Color node containing at least
-  (xDimension-1)×(zDimension-1) colours; one for each quadrilateral,
+  (xDimension-1)*(zDimension-1) colours; one for each quadrilateral,
   ordered as follows: 
 
   \verbatim
-    QuadColor[i,j] = Color[ i + j × (xDimension-1)]
+    QuadColor[i,j] = Color[ i + j * (xDimension-1)]
 
     where 0 <= i < xDimension-1 and 0 <= j < zDimension-1, and
     QuadColor[i,j] is the colour for the quadrilateral defined by
-    height[i+j×xDimension], height[(i+1)+j×xDimension],
-    height[(i+1)+(j+1)×xDimension] and height[i+(j+1)×xDimension] 
+    height[i+j*xDimension], height[(i+1)+j*xDimension],
+    height[(i+1)+(j+1)*xDimension] and height[i+(j+1)*xDimension] 
   \endverbatim
   
   If
   colorPerVertex is TRUE and the color field is not NULL, the color
-  field shall specify a Color node containing at least xDimension ×
+  field shall specify a Color node containing at least xDimension *
   zDimension colours, one for each vertex, ordered as follows:
 
   \verbatim
-    VertexColor[i,j] = Color[ i + j × xDimension] 
+    VertexColor[i,j] = Color[ i + j * xDimension] 
 
     where 0 <= i < xDimension and 0 <= j < zDimension, and 
     VertexColor[i,j] is the colour for the vertex defined by 
-    height[i+j×xDimension] 
+    height[i+j*xDimension] 
   \endverbatim
 
   The normal field specifies per-vertex or per-quadrilateral normals
@@ -146,29 +146,29 @@
   depending on the value of normalPerVertex. If normalPerVertex is
   FALSE and the normal node is not NULL, the normal field shall
   specify a Normal node containing at least
-  (xDimension-1)×(zDimension-1) normals; one for each quadrilateral,
+  (xDimension-1)*(zDimension-1) normals; one for each quadrilateral,
   ordered as follows: 
 
   \verbatim
-    QuadNormal[i,j] = Normal[ i + j × (xDimension-1)] 
+    QuadNormal[i,j] = Normal[ i + j * (xDimension-1)] 
 
     where 0 <= i < xDimension-1 and 0 <= j < zDimension-1, and 
     QuadNormal[i,j] is the normal for the quadrilateral 
-    defined by height[i+j×xDimension], height[(i+1)+j×xDimension], 
-    height[(i+1)+(j+1)×xDimension] and height[i+(j+1)×xDimension] 
+    defined by height[i+j*xDimension], height[(i+1)+j*xDimension], 
+    height[(i+1)+(j+1)*xDimension] and height[i+(j+1)*xDimension] 
   \endverbatim
 
   If normalPerVertex is TRUE and the normal field is not NULL, the
   normal field shall specify a Normal node containing at least
-  xDimension × zDimension normals; one for each vertex, ordered as
+  xDimension * zDimension normals; one for each vertex, ordered as
   follows:
 
   \verbatim
-    VertexNormal[i,j] = Normal[ i + j × xDimension] 
+    VertexNormal[i,j] = Normal[ i + j * xDimension] 
     
     where 0 <= i < xDimension and 0 <= j < zDimension, and
     VertexNormal[i,j] is the normal for the vertex defined by
-    height[i+j×xDimension] 
+    height[i+j*xDimension] 
   \endverbatim
 
   The texCoord field specifies per-vertex texture coordinates for the
@@ -178,15 +178,15 @@
   texture coordinate is aligned with the positive X-axis, and the T
   texture coordinate with positive Z-axis. If texCoord is not NULL, it
   shall specify a TextureCoordinate node containing at least
-  (xDimension)×(zDimension) texture coordinates; one for each vertex,
+  (xDimension)*(zDimension) texture coordinates; one for each vertex,
   ordered as follows:
 
   \verbatim
-    VertexTexCoord[i,j] = TextureCoordinate[ i + j × xDimension] 
+    VertexTexCoord[i,j] = TextureCoordinate[ i + j * xDimension] 
 
     where 0 <= i < xDimension and 0 <= j < zDimension, and 
     VertexTexCoord[i,j] is the texture coordinate for the vertex 
-    defined by height[i+j×xDimension] 
+    defined by height[i+j*xDimension] 
   \endverbatim
 
   The ccw, solid, and creaseAngle fields are described in 4.6.3,

--- a/src/vrml97/Extrusion.cpp
+++ b/src/vrml97/Extrusion.cpp
@@ -140,14 +140,14 @@
   cross-product:
 
   \verbatim
-  Z = (spine[i+1] - spine[i]) * (spine[i-1] - spine[i])
+  Z = cross(spine[i+1] - spine[i], spine[i-1] - spine[i])
   \endverbatim
 
   \li If the spine curve is closed: The SCP for the first and last
   points is the same and is found by taking the following cross- product:
 
   \verbatim
-  Z = (spine[1] - spine[0]) * (spine[n-2] - spine[0])
+  Z = cross(spine[1] - spine[0], spine[n-2] - spine[0])
   \endverbatim
 
   \li If the spine curve is not closed: The Z-axis used for the first

--- a/src/vrml97/Extrusion.cpp
+++ b/src/vrml97/Extrusion.cpp
@@ -140,14 +140,14 @@
   cross-product:
 
   \verbatim
-  Z = (spine[i+1] - spine[i]) × (spine[i-1] - spine[i])
+  Z = (spine[i+1] - spine[i]) * (spine[i-1] - spine[i])
   \endverbatim
 
   \li If the spine curve is closed: The SCP for the first and last
   points is the same and is found by taking the following cross- product:
 
   \verbatim
-  Z = (spine[1] - spine[0]) × (spine[n-2] - spine[0])
+  Z = (spine[1] - spine[0]) * (spine[n-2] - spine[0])
   \endverbatim
 
   \li If the spine curve is not closed: The Z-axis used for the first

--- a/src/vrml97/Material.cpp
+++ b/src/vrml97/Material.cpp
@@ -68,7 +68,7 @@
     light sources this surface shall reflect. Ambient light is
     omnidirectional and depends only on the number of light sources, not
     their positions with respect to the surface. Ambient colour is
-    calculated as ambientIntensity × diffuseColor.
+    calculated as ambientIntensity * diffuseColor.
  
   - The diffuseColor field reflects all VRML light sources depending
     on the angle of the surface with respect to the light source. The more

--- a/src/vrml97/PointLight.cpp
+++ b/src/vrml97/PointLight.cpp
@@ -74,7 +74,7 @@
   The \e radius field shall be greater than or equal to zero.
   PointLight node's illumination falls off with distance as specified
   by three attenuation coefficients. The attenuation factor is 1/
-  max(attenuation[0] + attenuation[1]×r + attenuation[2]×r2, 1), where
+  max(attenuation[0] + attenuation[1]*r + attenuation[2]*r2, 1), where
   r is the distance from the light to the surface being illuminated.
   The default is no attenuation. An attenuation value of (0, 0, 0) is
   identical to (1, 0, 0). Attenuation values shall be greater than or

--- a/src/vrml97/Sound.cpp
+++ b/src/vrml97/Sound.cpp
@@ -137,7 +137,7 @@
 
   Between the two ellipsoids, there shall be a linear attenuation ramp
   in loudness, from 0 dB at the minimum ellipsoid to -20 dB at the
-  maximum ellipsoid: attenuation = -20 × (d' / d") where d' is the
+  maximum ellipsoid: attenuation = -20 * (d' / d") where d' is the
   distance along the location-to-viewer vector, measured from the
   transformed minimum ellipsoid boundary to the viewer, and d" is the
   distance along the location-to-viewer vector from the transformed

--- a/src/vrml97/SpotLight.cpp
+++ b/src/vrml97/SpotLight.cpp
@@ -121,7 +121,7 @@
   else:
     multiplier = (angle - cutOffAngle) / (beamWidth - cutOffAngle)
 
-  intensity(angle) = SpotLight.intensity × multiplier
+  intensity(angle) = SpotLight.intensity * multiplier
   \endverbatim
 
   If the beamWidth
@@ -143,7 +143,7 @@
   attenuation coefficients. The attenuation factor is
 
   \verbatim
-  1/max(attenuation[0] + attenuation[1]×r + attenuation[2]×r^2 , 1),
+  1/max(attenuation[0] + attenuation[1]*r + attenuation[2]*r^2 , 1),
   \endverbatim
 
   where r is the distance from the light to the surface being

--- a/src/vrml97/TextureCoordinate.cpp
+++ b/src/vrml97/TextureCoordinate.cpp
@@ -67,7 +67,7 @@
   map that has N pixels in the given direction as follows:
 
   \verbatim
-  Texture map location = (C - floor(C)) * N 
+  Texture map location = (C - floor(C)) * N
   \endverbatim
 
   If the texture map is not repeated, the texture coordinates are

--- a/src/vrml97/TextureCoordinate.cpp
+++ b/src/vrml97/TextureCoordinate.cpp
@@ -67,7 +67,7 @@
   map that has N pixels in the given direction as follows:
 
   \verbatim
-  Texture map location = (C - floor(C)) × N 
+  Texture map location = (C - floor(C)) * N 
   \endverbatim
 
   If the texture map is not repeated, the texture coordinates are
@@ -76,7 +76,7 @@
   \verbatim
   Texture map location = N, if C > 1.0, 
                        = 0.0, if C < 0.0, 
-                       = C × N, if 0.0 <= C <= 1.0.
+                       = C * N, if 0.0 <= C <= 1.0.
   \endverbatim
 
   Details on repeating textures are specific to texture map node types

--- a/src/vrml97/TextureTransform.cpp
+++ b/src/vrml97/TextureTransform.cpp
@@ -92,7 +92,7 @@
   intermediate transformation matrices, 
   
   \verbatim
-  Tc' = -C × S × R × C × T × Tc
+  Tc' = -C * S * R * C * T * Tc
   \endverbatim
 
   Note that this transformation order is the reverse of the Transform

--- a/src/vrml97/Transform.cpp
+++ b/src/vrml97/Transform.cpp
@@ -113,7 +113,7 @@
   S (scale) are the equivalent transformation matrices,
 
   \verbatim
-  P' = T × C × R × SR × S × -SR × -C × P
+  P' = T * C * R * SR * S * -SR * -C * P
   \endverbatim
 
   The following Transform node:


### PR DESCRIPTION
## Summary

Coin issue #149 (2018) reported that a non-ASCII character (a Latin-1 degree sign, U+00B0) sitting as the last character on a line in `SbSphereSheetProjector.cpp` made two lines merge into one under MSVC 2017 with a Chinese-Simplified system locale, producing a compile error. This is a known MSVC behavior: without a BOM or an explicit `/utf-8` (or `/source-charset:utf-8`) flag, source files are decoded using the active code page for non-Unicode programs, so a non-ASCII byte sequence near a line ending can, under a code page it wasn't written for, get reinterpreted such that the CR/LF bytes are consumed as part of a bogus multi-byte character — silently deleting the line break as far as the tokenizer is concerned.

The maintainer fixed only that one file (commit 3edeb8a332), reasoning "I changed only the file in question, as it is the only one with non ASCII characters at the end of line" — true for the reported crash, but he also wrote in the same issue thread: "I've seen some other files in Coin containing also non ASCII characters (especially when expressing formulae). Maybe it's time to get rid of it." That broader cleanup never happened.

23 files (106 lines) still had non-ASCII bytes — all valid UTF-8 today (no mixed-encoding issue currently), but the same MSVC code-page misinterpretation risk applies to any of them, not just ones sitting exactly at end-of-line: mostly hand-written formula comments using × (multiplication/cross product), · (dot product), ² (squared), ° (degree) and ± (plus-minus), plus a handful of one-off cases (two accented personal names, a font-bug comment quoting three Scandinavian letters, and three exotic letters used purely as fanciful placeholder symbols for x/y/z sub-expressions in a formula comment).

Replaced all of them with ASCII equivalents, matching conventions already used elsewhere in the very same comment blocks (e.g. `*` and `^2` both already appear alongside `×` and `²` in the same formula derivations) or the exact wording the 2019 fix used for the degree sign ("45 degree").

Auto-generated bitmap font tables under `src/fonts/*.icc` (glyph-index comments spanning the full Latin-1 range) were deliberately left out of scope: they are machine-generated, not hand-written prose, and their non-ASCII bytes are never the last character on a physical line (always followed by a closing `*/`), so the specific EOL-merge mechanism from #149 does not apply to them.

## Review fixes (second commit)

Two editorial issues found on review before this was ready:

1. 12 lines carried trailing whitespace preserved from the original text (`git diff --check` flagged them) — stripped.
2. Two formulas in `Extrusion.cpp` used `*` for what the surrounding prose explicitly calls a cross-product, inherited from the blanket `×` → `*` substitution (which was correct for the scalar-multiplication uses elsewhere but not this one). Changed to `cross(a, b)` notation to keep the operation unambiguous.

## Verification

Comment-only change (confirmed with a diff review — no non-comment lines changed). Byte-level scan confirms zero non-ASCII bytes remain in the touched files. Clean build + `ctest` pass under both GCC and clang Debug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FHRXMxksBcEGfbN5bDVJzb