### PR TITLE
Document how to construct shaders programmatically (issue #103)

### DIFF
--- a/src/shaders/SoShader.cpp
+++ b/src/shaders/SoShader.cpp
@@ -68,6 +68,53 @@
   installed). However, we recommend using GLSL since we will focus
   mostly on support this shader language.
 
+  \e Constructing \e shaders \e at \e run-time
+
+  The scene graph above can just as well be built up programmatically
+  instead of read from an \c .iv file -- there is no separate "runtime
+  loading" API for shaders, since they are just ordinary nodes:
+
+  \code
+  SoSeparator * root = new SoSeparator;
+
+  SoShaderProgram * program = new SoShaderProgram;
+  root->addChild(program);
+
+  SoVertexShader * vshader = new SoVertexShader;
+  vshader->sourceProgram.setValue("myvertexshader.glsl");
+
+  SoFragmentShader * fshader = new SoFragmentShader;
+  fshader->sourceProgram.setValue("myfragmentshader.glsl");
+
+  program->shaderObject.set1Value(0, vshader);
+  program->shaderObject.set1Value(1, fshader);
+
+  root->addChild(new SoCube);
+  \endcode
+
+  \c sourceProgram defaults to being interpreted as a filename
+  (SoShaderObject::sourceType defaults to
+  SoShaderObject::FILENAME). If the shader source itself is only
+  available at run-time -- generated on the fly, downloaded, extracted
+  from an archive, or otherwise not sitting in a plain file Coin can
+  open by path -- set \c sourceType to
+  SoShaderObject::GLSL_PROGRAM and pass the actual GLSL source text to
+  \c sourceProgram instead of a filename:
+
+  \code
+  SbString glslsource = "..."; // built up or loaded however you like
+
+  SoVertexShader * vshader = new SoVertexShader;
+  vshader->sourceType = SoShaderObject::GLSL_PROGRAM;
+  vshader->sourceProgram.setValue(glslsource);
+  \endcode
+
+  Since the shader program is just a node like any other, this works
+  identically regardless of which action ends up traversing the scene
+  graph -- rendering straight to screen with SoGLRenderAction, or
+  rendering to an SoOffscreenRenderer -- there is nothing
+  render-target-specific about setting up shaders.
+
   Coin defines some named parameters that can be added by the
   application programmer, and which will be automatically updated by
   Coin while traversing the scene graph.


### PR DESCRIPTION
## Summary

Coin issue #103 (2015) pointed out that "Shaders in Coin" (`coin_shaders_page`, in `src/shaders/SoShader.cpp`) only shows the `.iv` file syntax for setting up an `SoShaderProgram`, with nothing on how to build the same scene graph in code, or how to supply shader source that isn't sitting in a plain file on disk (generated at run-time, downloaded, extracted from an archive, etc.) -- the reporter's actual use case, loading a shader "used to get the z-buffer" for a custom `SoGLRenderAction`/`SoOffscreenRenderer` setup.

The question got a good answer in the issue thread from Roy Walmsley (insert an `SoShaderProgram` node into the scene graph; it works identically whether rendering to screen or to an `SoOffscreenRenderer`, since shaders are just ordinary nodes) -- but that answer was never folded into the actual documentation, so the page still doesn't cover it today, ten years later.

Added a "Constructing shaders at run-time" section right after the existing `.iv`-file example:
- the equivalent scene graph built with the C++ API (`SoShaderProgram`/`SoVertexShader`/`SoFragmentShader`), and
- the specific piece the reporter was actually asking about: `SoShaderObject::sourceType` defaults to `FILENAME`, so `sourceProgram` is interpreted as a path; setting `sourceType` to `GLSL_PROGRAM` instead makes `sourceProgram` hold the literal GLSL source text, which is how to hand Coin a shader that was never a file on disk in the first place.

No functional code change -- comment-only, inside the Doxygen block.

## Test plan

- `cmake --build --target documentation` (Doxygen 1.9.8): regenerates `coin_shaders_page.html` cleanly, with both new code examples rendered correctly and every referenced symbol (`SoShaderProgram`, `SoVertexShader`, `SoFragmentShader`, `SbString`, `SoShaderObject::sourceType`/`FILENAME`/`GLSL_PROGRAM`) auto-linked to its own documentation.
- Additionally built the documented `GLSL_PROGRAM` example as a standalone program against a real (non-offscreen) hardware GLX context (AMD Radeon/radeonsi via Mesa, GL 4.6 compatibility profile) to confirm the documented mechanism actually works end-to-end, not just that it compiles as C++: an `SoShaderProgram` with an `SoVertexShader`/`SoFragmentShader` pair using `sourceType = GLSL_PROGRAM` and literal GLSL source text (no `.glsl` file involved) was applied to a cube. `glGetError()` was clean after rendering, and the read-back pixel showed the shader's fragment color (pure green) rather than the node's own `SoMaterial` color (grey) -- confirming the shader source really compiled, linked, and ran on the GPU exactly as documented.