### PR TITLE
Fix redundant ray-pick re-traversal in SoHandleEventAction::getPickedPoint() (issue #106)

### DIFF
--- a/src/actions/SoHandleEventAction.cpp
+++ b/src/actions/SoHandleEventAction.cpp
@@ -344,7 +344,19 @@ const SoPickedPoint *
 SoHandleEventAction::getPickedPoint(void)
 {
   SoRayPickAction * ra = PRIVATE(this)->getPickAction();
-  if (!PRIVATE(this)->pickvalid || PRIVATE(this)->didpickall) {
+  // Note: unlike getPickedPointList() below, this does *not* also check
+  // PRIVATE(this)->didpickall. A pick-all result already contains the
+  // single closest point: getPickedPoint() (no args) forwards to
+  // getPickedPoint(0), and getPickedPointList() sorts its result by
+  // distance before returning it, so index 0 is exactly the same point
+  // a PICK_ALL=FALSE pick would have found. Redoing the pick here
+  // whenever the last one happened to be a pick-all was therefore never
+  // necessary -- just an unconditional full re-traversal of the scene
+  // graph every time application code (e.g. independently-written
+  // nodes/draggers) alternates calls to this method and
+  // getPickedPointList() within the same SoHandleEventAction traversal.
+  // See Coin issue #106.
+  if (!PRIVATE(this)->pickvalid) {
     ra->setPickAll(FALSE);
     PRIVATE(this)->doPick(ra);
   }

--- a/testsuite/reproducers/CoinCleanup.h
+++ b/testsuite/reproducers/CoinCleanup.h
@@ -1,0 +1,17 @@
+#ifndef COIN_REPRODUCER_CLEANUP_H
+#define COIN_REPRODUCER_CLEANUP_H
+
+#include <Inventor/SoDB.h>
+
+// Declare immediately after SoDB::init(), before local Coin objects, so
+// those objects are destroyed before the library's global resources.
+class CoinReproducerCleanup {
+public:
+  CoinReproducerCleanup() {}
+  ~CoinReproducerCleanup() { SoDB::finish(); }
+private:
+  CoinReproducerCleanup(const CoinReproducerCleanup &);
+  CoinReproducerCleanup & operator=(const CoinReproducerCleanup &);
+};
+
+#endif

--- a/testsuite/reproducers/handleeventaction-redundant-repick/repro.cpp
+++ b/testsuite/reproducers/handleeventaction-redundant-repick/repro.cpp
@@ -1,0 +1,157 @@
+// Reproducer for Coin issue #106 ("getPickedPoint() and
+// getPickedPointList() should not change picking condition").
+//
+// SoHandleEventAction::getPickedPoint() redid the whole ray-pick scene
+// graph traversal (SoRayPickAction::apply()) with PICK_ALL=FALSE
+// whenever the *previous* pick on this same action instance had been a
+// PICK_ALL=TRUE one (tracked via the private didpickall flag) -- even
+// though a valid, already-computed pick-all result already contains
+// the answer: getPickedPoint() (no args) forwards to getPickedPoint(0),
+// and getPickedPointList() sorts its result by distance before
+// returning it, so index 0 of an existing pick-all result is
+// *identical* to what a fresh PICK_ALL=FALSE pick would produce.
+//
+// Reported real-world impact: independently-written scene graph nodes
+// (e.g. two different draggers/custom SoEventCallback handlers) that
+// alternate calling SoHandleEventAction::getPickedPoint() and
+// getPickedPointList() during the *same* event-handling traversal each
+// force a full extra ray-pick scene graph re-traversal, even though
+// nothing about the pick geometry changed between those calls -- pure
+// wasted work, reported as a real performance problem for large scene
+// graphs with many independent event-handling nodes.
+//
+// This repro places two SoEventCallback nodes under the same
+// SoSeparator, one calling getPickedPointList() (as some hypothetical
+// "Node A") followed by another calling getPickedPoint() (as
+// hypothetical "Node B") -- exactly the interleaving described in the
+// issue -- and counts how many times the ray-pick action actually
+// re-traverses the pickable geometry (via an SoCallback node inside it
+// that only counts SoRayPickAction visits), plus checks that the two
+// calls agree on which point/node was hit (correctness unaffected by
+// the fix).
+//
+// See run.sh in this directory for how to build and run this against a
+// given libCoin build.
+
+#include <cstdio>
+#include <Inventor/SoDB.h>
+#include <Inventor/actions/SoHandleEventAction.h>
+#include <Inventor/actions/SoRayPickAction.h>
+#include <Inventor/events/SoLocation2Event.h>
+#include <Inventor/nodes/SoSeparator.h>
+#include <Inventor/nodes/SoCube.h>
+#include <Inventor/nodes/SoTranslation.h>
+#include <Inventor/nodes/SoPerspectiveCamera.h>
+#include <Inventor/nodes/SoEventCallback.h>
+#include <Inventor/nodes/SoCallback.h>
+#include <Inventor/SoPickedPoint.h>
+#include <Inventor/SbViewportRegion.h>
+
+static int repick_count = 0;
+
+static void
+count_raypick_visits_cb(void *, SoAction * action)
+{
+  if (action->isOfType(SoRayPickAction::getClassTypeId())) {
+    repick_count++;
+  }
+}
+
+static SoNode * hit_from_list = NULL;
+static SoNode * hit_from_point = NULL;
+
+// "Node A": some independent scene graph node that only ever wants the
+// full list of intersections.
+static void
+nodeA_getlist_cb(void *, SoEventCallback * node)
+{
+  const SoPickedPointList & ppl = node->getAction()->getPickedPointList();
+  if (ppl.getLength() > 0) {
+    hit_from_list = ppl[0]->getPath()->getTail();
+  }
+}
+
+// "Node B": a different, independently-written node that only ever
+// wants the single closest intersection.
+static void
+nodeB_getpoint_cb(void *, SoEventCallback * node)
+{
+  const SoPickedPoint * pp = node->getAction()->getPickedPoint();
+  if (pp) {
+    hit_from_point = pp->getPath()->getTail();
+  }
+}
+
+int main()
+{
+  SoDB::init();
+
+  SoSeparator * root = new SoSeparator;
+  root->ref();
+
+  SoPerspectiveCamera * camera = new SoPerspectiveCamera;
+  camera->position.setValue(0, 0, 5);
+  root->addChild(camera);
+
+  SoSeparator * geom = new SoSeparator;
+  root->addChild(geom);
+
+  SoCallback * counter = new SoCallback;
+  counter->setCallback(count_raypick_visits_cb);
+  geom->addChild(counter);
+
+  SoCube * cube = new SoCube;
+  geom->addChild(cube);
+
+  SoEventCallback * nodeA = new SoEventCallback;
+  nodeA->addEventCallback(SoLocation2Event::getClassTypeId(), nodeA_getlist_cb);
+  root->addChild(nodeA);
+
+  SoEventCallback * nodeB = new SoEventCallback;
+  nodeB->addEventCallback(SoLocation2Event::getClassTypeId(), nodeB_getpoint_cb);
+  root->addChild(nodeB);
+
+  SbViewportRegion vp(400, 400);
+  camera->viewAll(root, vp);
+
+  SoLocation2Event ev;
+  ev.setPosition(SbVec2s(200, 200)); // dead center -- should hit the cube
+
+  SoHandleEventAction action(vp);
+  action.setEvent(&ev);
+  repick_count = 0;
+  hit_from_list = NULL;
+  hit_from_point = NULL;
+  action.apply(root);
+
+  root->unref();
+
+  fprintf(stderr, "[repro] ray-pick re-traversals for one list-then-point "
+                  "call sequence: %d\n", repick_count);
+  fprintf(stderr, "[repro] hit node from getPickedPointList(): %p\n", (void*)hit_from_list);
+  fprintf(stderr, "[repro] hit node from getPickedPoint():     %p\n", (void*)hit_from_point);
+
+  int failures = 0;
+  if (hit_from_list == NULL || hit_from_point == NULL) {
+    fprintf(stderr, "[repro] FAIL: expected both calls to hit the cube, got a NULL\n");
+    failures++;
+  }
+  else if (hit_from_list != hit_from_point) {
+    fprintf(stderr, "[repro] FAIL: getPickedPoint() and getPickedPointList() "
+                    "disagree on which node was hit\n");
+    failures++;
+  }
+  if (repick_count != 1) {
+    fprintf(stderr, "[repro] FAIL: expected exactly 1 ray-pick re-traversal "
+                    "(the redundant repick from issue #106 should be gone), got %d\n",
+                    repick_count);
+    failures++;
+  }
+
+  if (failures > 0) {
+    fprintf(stderr, "[repro] FAIL: %d check(s) failed\n", failures);
+    return 1;
+  }
+  fprintf(stderr, "[repro] PASS\n");
+  return 0;
+}

--- a/testsuite/reproducers/handleeventaction-redundant-repick/repro.cpp
+++ b/testsuite/reproducers/handleeventaction-redundant-repick/repro.cpp
@@ -33,6 +33,7 @@
 // See run.sh in this directory for how to build and run this against a
 // given libCoin build.
 
+#include "../CoinCleanup.h"
 #include <cstdio>
 #include <Inventor/SoDB.h>
 #include <Inventor/actions/SoHandleEventAction.h>
@@ -85,6 +86,7 @@ nodeB_getpoint_cb(void *, SoEventCallback * node)
 int main()
 {
   SoDB::init();
+  CoinReproducerCleanup cleanup;
 
   SoSeparator * root = new SoSeparator;
   root->ref();

--- a/testsuite/reproducers/handleeventaction-redundant-repick/run.sh
+++ b/testsuite/reproducers/handleeventaction-redundant-repick/run.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+# Reproducer for Coin issue #106 -- see repro.cpp for the full
+# explanation. Confirms both that the redundant ray-pick re-traversal
+# is gone (exactly one, not two, for a list-then-point call sequence
+# within the same SoHandleEventAction traversal) and that the two
+# accessors still agree on which node was hit.
+#
+#   testsuite/reproducers/handleeventaction-redundant-repick/run.sh /path/to/build/lib
+#
+# Prints PASS and exits 0 if both checks hold.
+
+CDPATH= cd "$(dirname "$0")" || exit 2
+
+LIBDIR="$1"
+if [ -z "$LIBDIR" ]; then
+  echo "usage: $0 /path/to/build/lib   (directory containing libCoin.so)" >&2
+  exit 2
+fi
+
+CXX=${CXX:-c++}
+# The current directory is already the reproducer directory.
+SRCINCLUDE="$(CDPATH= cd ../../.. && pwd)/include" || exit 2
+
+"$CXX" -O1 -g repro.cpp -o repro -I"$SRCINCLUDE" -I"$LIBDIR/../include" -L"$LIBDIR" -lCoin || exit 2
+
+export LD_LIBRARY_PATH="$LIBDIR${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+./repro
+status=$?
+if [ "$status" -ne 0 ]; then
+  echo "=== FAIL: repro exited with status $status ===" >&2
+  exit "$status"
+fi


### PR DESCRIPTION
Reuse an existing pick-all result for SoHandleEventAction::getPickedPoint instead of repeating the ray-pick traversal. The pick list already contains the nearest result. The reproducer now destroys local objects before calling SoDB::finish, allowing leak checks to assess the full lifecycle.

## Validation

The distributed changes were validated together in `lab/all-fixes-integration`, with Clang Debug instrumentation on both Coin and C++ test drivers: `-fsanitize=address,undefined,function -fno-omit-frame-pointer`, `ASAN_OPTIONS=detect_leaks=1`, `UBSAN_OPTIONS=halt_on_error=1`, without suppressions. All 8 CTest entries passed (342 CoinTests / 83,759 checks plus seven profiler modes); 31 additional checks passed, including actual rendering, events and the historical-header client. EGL and SpiderMonkey checks were inconclusive.

This is **integration evidence**, not a claim that this isolated PR includes every companion fix or passes the full sanitizer matrix by itself. Global cleanup, STL, test-fixture and GL record fixes are distributed across the related PRs. Windows/macOS and all optional configurations were not rerun for this update. The final per-PR diff passed `git diff --check`.
