### PR TITLE
Fail cleanly at configure time for SpiderMonkey link-time linking (issue #173)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -491,16 +491,25 @@ if(HAVE_VRML97 AND COIN_HAVE_JAVASCRIPT)
   if(NOT SPIDERMONKEY_RUNTIME_LINKING)
     find_package(SpiderMonkey)
     if(SPIDERMONKEY_FOUND)
-      set(HAVE_SPIDERMONKEY_VIA_LINKTIME_LINKING 1)
-      set(HAVE_SPIDERMONKEY_H 1)
-      if(NOT TARGET SpiderMonkey::SpiderMonkey)
-        add_library(SpiderMonkey::SpiderMonkey UNKNOWN IMPORTED)
-        set_target_properties(SpiderMonkey::SpiderMonkey PROPERTIES
-          IMPORTED_LOCATION "${SPIDERMONKEY_LIBRARIES}"
-          INTERFACE_INCLUDE_DIRECTORIES "${SPIDERMONKEY_INCLUDE_DIRS}"
-        )
-      endif()
-      list(APPEND COIN_TARGET_LINK_LIBRARIES SpiderMonkey::SpiderMonkey)
+      message(FATAL_ERROR
+        "SPIDERMONKEY_RUNTIME_LINKING=OFF (link-time SpiderMonkey linking) "
+        "found a SpiderMonkey at '${SPIDERMONKEY_INCLUDE_DIR}', but this "
+        "configuration cannot work: Coin's SpiderMonkey glue "
+        "(src/glue/spidermonkey.cpp, include/Inventor/C/glue/spidermonkey.h) "
+        "targets the SpiderMonkey C API as it existed around 2007 (JSBool, "
+        "jsval as a plain integer, no JS::Rooted<>/JS::PropertyKey), and no "
+        "SpiderMonkey release still available today exports that API -- "
+        "compiling against a real, modern <jsapi.h> fails with hundreds of "
+        "conflicting-declaration errors (JSContext, JSType, jsid, ... "
+        "redefined) rather than the intended type reuse (see Coin issue "
+        "#173). Porting this glue to a current SpiderMonkey embedding API "
+        "is out of scope here (see PR #673's rationale). "
+        "Use the default SPIDERMONKEY_RUNTIME_LINKING=ON instead: it loads "
+        "SpiderMonkey dynamically at run-time and safely reports JavaScript "
+        "support as unavailable if no compatible library is found, instead "
+        "of failing the whole Coin build. To disable JavaScript/VRML97 "
+        "\"javascript:\" URL support (SoJavaScriptEngine) entirely, "
+        "configure with -DCOIN_HAVE_JAVASCRIPT=OFF instead.")
     endif()
   endif()
 endif()

--- a/cmake/FindSpiderMonkey.cmake
+++ b/cmake/FindSpiderMonkey.cmake
@@ -34,6 +34,14 @@ if(SPIDERMONKEY_INCLUDE_DIR)
   string(REGEX REPLACE "^.*js-([0-9]+[.]?[0-9]?[.]?[0-9]?).*" "\\1" SPIDERMONKEY_VERSION ${SPIDERMONKEY_INCLUDE_DIR})
   # dedicated workaround to find version string when not embedded in the includedir (<= 1.8.5)
   if(${SPIDERMONKEY_VERSION} STREQUAL ${SPIDERMONKEY_INCLUDE_DIR})
+    # The path suffix didn't carry a version, so the regex above left
+    # SPIDERMONKEY_VERSION as a plain copy of SPIDERMONKEY_INCLUDE_DIR --
+    # useless (and actively wrong) as a library-name suffix in the
+    # find_library() call below. Clear it so an unresolved version falls
+    # back to the plain, unversioned names already in that NAMES list,
+    # rather than searching for a library literally named e.g.
+    # "mozjs-/usr/include/mozjs-102".
+    set(SPIDERMONKEY_VERSION "")
     unset(VERS_FILE)
     if(EXISTS ${SPIDERMONKEY_INCLUDE_DIR}/jsversion.h)
       set(VERS_FILE "${SPIDERMONKEY_INCLUDE_DIR}/jsversion.h")
@@ -44,7 +52,11 @@ if(SPIDERMONKEY_INCLUDE_DIR)
     endif()
     if(VERS_FILE)
       file(STRINGS ${VERS_FILE} VERS_STRING REGEX "#define JS_VERSION .*")
-      string(REGEX REPLACE "#define JS_VERSION \(.*\)" "\\1" SPIDERMONKEY_VERSION ${VERS_STRING})
+      if(VERS_STRING)
+        string(REGEX REPLACE "#define JS_VERSION \(.*\)" "\\1" SPIDERMONKEY_VERSION ${VERS_STRING})
+      else()
+        message(WARNING "SpiderMonkey found at ${SPIDERMONKEY_INCLUDE_DIR}, but ${VERS_FILE} does not define JS_VERSION. Falling back to unversioned library names.")
+      endif()
     endif()
   endif()
 

--- a/cmake/FindSpiderMonkey.cmake
+++ b/cmake/FindSpiderMonkey.cmake
@@ -25,25 +25,35 @@ find_path(
     js-1.7.0 js
 )
 
-string(REGEX REPLACE "^.*js-([0-9]+[.]?[0-9]?[.]?[0-9]?).*" "\\1" SPIDERMONKEY_VERSION ${SPIDERMONKEY_INCLUDE_DIR})
-# dedicated workaround to find version string when not embedded in the includedir (<= 1.8.5)
-if(${SPIDERMONKEY_VERSION} STREQUAL ${SPIDERMONKEY_INCLUDE_DIR})
-  if(EXISTS ${SPIDERMONKEY_INCLUDE_DIR}/jsversion.h)
-    set(VERS_FILE "${SPIDERMONKEY_INCLUDE_DIR}/jsversion.h")
-  elseif(EXISTS ${SPIDERMONKEY_INCLUDE_DIR}/jsconfig.h)
-    set(VERS_FILE "${SPIDERMONKEY_INCLUDE_DIR}/jsconfig.h")
-  else()
-    message(ERROR "unknown location of the header with the version string")
+# Everything below needs a real SPIDERMONKEY_INCLUDE_DIR to look at. When
+# jsapi.h isn't found anywhere, find_path() leaves it set to
+# "SPIDERMONKEY_INCLUDE_DIR-NOTFOUND" (a false value in CMake's boolean
+# context), and none of the version detection below is meaningful -- skip
+# straight to find_package_handle_standard_args() reporting NOT FOUND.
+if(SPIDERMONKEY_INCLUDE_DIR)
+  string(REGEX REPLACE "^.*js-([0-9]+[.]?[0-9]?[.]?[0-9]?).*" "\\1" SPIDERMONKEY_VERSION ${SPIDERMONKEY_INCLUDE_DIR})
+  # dedicated workaround to find version string when not embedded in the includedir (<= 1.8.5)
+  if(${SPIDERMONKEY_VERSION} STREQUAL ${SPIDERMONKEY_INCLUDE_DIR})
+    unset(VERS_FILE)
+    if(EXISTS ${SPIDERMONKEY_INCLUDE_DIR}/jsversion.h)
+      set(VERS_FILE "${SPIDERMONKEY_INCLUDE_DIR}/jsversion.h")
+    elseif(EXISTS ${SPIDERMONKEY_INCLUDE_DIR}/jsconfig.h)
+      set(VERS_FILE "${SPIDERMONKEY_INCLUDE_DIR}/jsconfig.h")
+    else()
+      message(WARNING "SpiderMonkey found at ${SPIDERMONKEY_INCLUDE_DIR}, but its version could not be determined (no js-<version> path suffix, and no jsversion.h/jsconfig.h to read JS_VERSION from). Falling back to unversioned library names.")
+    endif()
+    if(VERS_FILE)
+      file(STRINGS ${VERS_FILE} VERS_STRING REGEX "#define JS_VERSION .*")
+      string(REGEX REPLACE "#define JS_VERSION \(.*\)" "\\1" SPIDERMONKEY_VERSION ${VERS_STRING})
+    endif()
   endif()
-  file(STRINGS ${VERS_FILE} VERS_STRING REGEX "#define JS_VERSION .*")
-  string(REGEX REPLACE "#define JS_VERSION \(.*\)" "\\1" SPIDERMONKEY_VERSION ${VERS_STRING})
-endif()
 
-find_library(
-  SPIDERMONKEY_LIBRARY
-  NAMES mozjs-${SPIDERMONKEY_VERSION} mozjs${SPIDERMONKEY_VERSION} mozjs js js${SPIDERMONKEY_VERSION}
-  ${library_PATHS}
-)
+  find_library(
+    SPIDERMONKEY_LIBRARY
+    NAMES mozjs-${SPIDERMONKEY_VERSION} mozjs${SPIDERMONKEY_VERSION} mozjs js js${SPIDERMONKEY_VERSION}
+    ${library_PATHS}
+  )
+endif()
 
 
 include(FindPackageHandleStandardArgs)


### PR DESCRIPTION
## Summary

Coin issue #173 reported that building with `SPIDERMONKEY_RUNTIME_LINKING=OFF` (link-time linking against a real SpiderMonkey, as opposed to the default run-time `dlopen` path) fails to compile against any modern SpiderMonkey/mozjs with hundreds of conflicting-declaration errors (`JSContext`, `JSType`, `jsid`, `JSGCStatus`, ... all redefined).

Root-caused by actually reproducing it: downloaded and extracted the real `libmozjs-102-dev` package (no root needed, via `apt-get download` + `dpkg-deb -x`) and compiled `<jsapi.h>` followed by `<Inventor/C/glue/spidermonkey.h>` directly. Confirmed the reported errors verbatim. Coin's own header guards its fallback declarations with `#ifndef JSVERSION_IS_ECMA`, meant to detect "the real jsapi.h was already included" -- but that macro was removed from SpiderMonkey upstream in 2013 and no longer exists in any release available today, so the guard always takes the fallback branch and always redeclares types the real header already provides.

I tried the "obvious" fix first (gate the fallback block on the existing, CMake-provided `HAVE_SPIDERMONKEY_VIA_LINKTIME_LINKING` macro instead) and it does **not** work: doing so only clears the first layer of conflicts. A second, much larger wave of errors follows, because Coin's function-pointer typedefs (`JS_EvaluateScript_t`, `JS_SetProperty_t`, ...) are declared in terms of types (`JSBool`, `uintN`, `jsval`-as-integer, `intN`) that don't just live under a different guard in modern SpiderMonkey -- they don't exist at all anymore (confirmed by grepping the real mozjs-102 headers: zero matches for any of them). The entire glue in `src/glue/spidermonkey.cpp` targets the SpiderMonkey C API as it existed around 2007, which is exactly what #673 (merged into this repo) already independently found and documented while fixing the run-time (`dlopen`) path's availability check -- that PR explicitly scoped out porting this glue to a current SpiderMonkey embedding API as a separate, much larger decision.

Given that, the fix here is to make the doomed configuration fail loudly and immediately at `cmake` configure time -- before hundreds of compiler errors -- with a message explaining why and pointing at the working default, rather than attempting an actual port of the glue.

While testing the "SpiderMonkey not found" case for comparison, also found (and fixed) two separate, pre-existing bugs in `cmake/FindSpiderMonkey.cmake`, confirmed to reproduce identically on unmodified master:
- It hard-crashes (`file STRINGS given unknown argument`) instead of reporting `SPIDERMONKEY_FOUND=FALSE` when no SpiderMonkey is present at all and `SPIDERMONKEY_RUNTIME_LINKING=OFF`.
- If a SpiderMonkey's `jsversion.h`/`jsconfig.h` exists but doesn't define `JS_VERSION`, `string(REGEX REPLACE ...)` is called with a missing argument and CMake rejects it outright. Also, whenever the version couldn't be determined by any path, `SPIDERMONKEY_VERSION` was left holding the raw include-dir path, which then leaked into `find_library()`'s `NAMES` list instead of falling back to the plain, unversioned names already there.

## Test plan

- Reproduced the original #173 compile failure with a real `libmozjs-102-dev` package.
- Verified the new `FATAL_ERROR` fires correctly against that same package when `SPIDERMONKEY_RUNTIME_LINKING=OFF`, with no compiler ever invoked.
- Verified the default (`SPIDERMONKEY_RUNTIME_LINKING=ON`) and `COIN_HAVE_JAVASCRIPT=OFF` configurations are unaffected.
- Verified all `FindSpiderMonkey.cmake` fixes with synthetic include directories isolating each case: SpiderMonkey missing entirely, a version embedded in the include path, a version read from `jsversion.h`, `jsversion.h` present without `JS_VERSION`, and neither version file present -- each configures cleanly with the correct `SPIDERMONKEY_VERSION` (or a clean fallback), no crashes.
- Full clean rebuild under GCC and Clang (Debug), `ctest` (1/1 pass) on both, and a Debug build under AddressSanitizer/UndefinedBehaviorSanitizer running the full `CoinTests` suite (330 tests, 83677 checks, zero UBSan findings, the same 207 pre-existing leak allocations as the established baseline from #673) -- across all three commits on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FHRXMxksBcEGfbN5bDVJzb