### PR TITLE
Fix off-by-one in SbProfilingData::getIndexNoCreate()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build*/
 .cache/
+tmp/

--- a/src/profiler/SbProfilingData.cpp
+++ b/src/profiler/SbProfilingData.cpp
@@ -506,7 +506,9 @@ SbProfilingData::isPathMatch(const SoFullPath * fullpath, int pathlen, int idx)
 
 /*!
   Return the index of the tail node in the path.
-  If node is not registered, add it and return that index.
+  If the path is not registered, return -1 unless create is TRUE.
+  With create set to TRUE, register the path and return its index.
+  Entries distinguish child indices and ancestors, including shared nodes.
 */
 
 int
@@ -682,7 +684,8 @@ SbProfilingData::getIndexForwardCreate(const SoFullPath * fullpath, int pathlen,
 
   const int nodedatacount = (int)PRIVATE(this)->nodeData.size();
   for (int idx = parentidx + 1; idx < nodedatacount; ++idx) {
-    if ((PRIVATE(this)->nodeData[idx].node == tail) &&
+    if ((PRIVATE(this)->nodeData[idx].parentidx == parentidx) &&
+        (PRIVATE(this)->nodeData[idx].node == tail) &&
         (PRIVATE(this)->nodeData[idx].childidx == tidx)) { // found it!
       return idx;
     }
@@ -722,7 +725,8 @@ SbProfilingData::getIndexForwardNoCreate(const SoFullPath * fullpath, int pathle
 
   const int nodedatacount = (int)PRIVATE(this)->nodeData.size();
   for (int idx = parentidx + 1; idx < nodedatacount; ++idx) {
-    if ((PRIVATE(this)->nodeData[idx].node == tail) &&
+    if ((PRIVATE(this)->nodeData[idx].parentidx == parentidx) &&
+        (PRIVATE(this)->nodeData[idx].node == tail) &&
         (PRIVATE(this)->nodeData[idx].childidx == tidx)) { // found it!
       return idx;
     }
@@ -1258,3 +1262,103 @@ SbProfilingData::operator != (const SbProfilingData & rhs) const
 // *************************************************************************
 
 #undef PRIVATE
+
+#ifdef COIN_TEST_SUITE
+
+#include <Inventor/misc/SoTempPath.h>
+#include <Inventor/nodes/SoSeparator.h>
+
+BOOST_AUTO_TEST_CASE(path_lookup_reaches_tail_without_creating_entries)
+{
+  SoSeparator * root = new SoSeparator;
+  root->ref();
+  SoSeparator * branch = new SoSeparator;
+  root->addChild(branch);
+  SoSeparator * leaf = new SoSeparator;
+  // The same node at different child indices represents distinct paths.
+  branch->addChild(leaf);
+  branch->addChild(leaf);
+  branch->addChild(new SoSeparator);
+  {
+    // Real SoFullPath subclasses avoid the separate downcast issue in #714.
+    SoTempPath first(3), second(3), missing(3), prefix(2);
+    first.setHead(root); first.append(0); first.append(0);
+    second.setHead(root); second.append(0); second.append(1);
+    missing.setHead(root); missing.append(0); missing.append(2);
+    prefix.setHead(root); prefix.append(0);
+    SbProfilingData data;
+    BOOST_CHECK_EQUAL(data.getIndex(&first), -1);
+    BOOST_CHECK_EQUAL(data.getNumNodeEntries(), 0);
+    const int firstidx = data.getIndex(&first, TRUE);
+    const int secondidx = data.getIndex(&second, TRUE);
+    BOOST_REQUIRE(firstidx >= 0 && secondidx >= 0 && firstidx != secondidx);
+    const int parentidx = data.getParentIndex(firstidx);
+    BOOST_CHECK_EQUAL(data.getParentIndex(secondidx), parentidx);
+    data.setNodeTiming(firstidx, SbTime(1.5));
+    data.setNodeTiming(parentidx, SbTime(9.0));
+    data.setNodeFootprint(firstidx, SbProfilingData::MEMORY_SIZE, 4096);
+    data.setNodeFootprint(parentidx, SbProfilingData::MEMORY_SIZE, 128);
+    data.setNodeFlag(firstidx, SbProfilingData::GL_CACHED_FLAG, TRUE);
+    const int count = data.getNumNodeEntries();
+
+    // The last cached path is second, so first must take the lookup path.
+    BOOST_CHECK_EQUAL(data.getIndex(&first), firstidx);
+    BOOST_CHECK_EQUAL(data.getNodeTiming(&first).getValue(), 1.5);
+    BOOST_CHECK_EQUAL(data.getNodeFootprint(&first, SbProfilingData::MEMORY_SIZE), 4096);
+    BOOST_CHECK(data.getNodeFlag(&first, SbProfilingData::GL_CACHED_FLAG));
+    BOOST_CHECK_EQUAL(data.getIndex(&missing), -1);
+    BOOST_CHECK_EQUAL(data.getNodeTiming(&missing).getValue(), 0.0);
+    BOOST_CHECK_EQUAL(data.getNodeFootprint(&missing, SbProfilingData::MEMORY_SIZE), 0);
+    BOOST_CHECK(!data.getNodeFlag(&missing, SbProfilingData::GL_CACHED_FLAG));
+    BOOST_CHECK_EQUAL(data.getIndex(&prefix), parentidx);
+    BOOST_CHECK_EQUAL(data.getIndex(&second), secondidx);
+    BOOST_CHECK_EQUAL(data.getIndex(&first), firstidx);
+    BOOST_CHECK_EQUAL(data.getNumNodeEntries(), count);
+  }
+  root->unref();
+}
+
+BOOST_AUTO_TEST_CASE(path_lookup_distinguishes_parents_of_shared_nodes)
+{
+  SoSeparator * root = new SoSeparator;
+  root->ref();
+  SoSeparator * left = new SoSeparator;
+  SoSeparator * right = new SoSeparator;
+  SoSeparator * shared = new SoSeparator;
+  root->addChild(left);
+  root->addChild(right);
+  left->addChild(shared);
+  right->addChild(shared);
+  {
+    SoTempPath leftparent(2), leftpath(3), rightpath(3);
+    leftparent.setHead(root); leftparent.append(0);
+    leftpath.setHead(root); leftpath.append(0); leftpath.append(0);
+    rightpath.setHead(root); rightpath.append(1); rightpath.append(0);
+    SbProfilingData data;
+    const int parentidx = data.getIndex(&leftparent, TRUE);
+    const int rightidx = data.getIndex(&rightpath, TRUE);
+    data.setNodeTiming(rightidx, SbTime(2.5));
+    data.setNodeFootprint(rightidx, SbProfilingData::MEMORY_SIZE, 512);
+    data.setNodeFlag(rightidx, SbProfilingData::GL_CACHED_FLAG, TRUE);
+    const int count = data.getNumNodeEntries();
+
+    // left->shared was never registered, even though right->shared was.
+    BOOST_CHECK_EQUAL(data.getIndex(&leftpath), -1);
+    BOOST_CHECK_EQUAL(data.getNodeTiming(&leftpath).getValue(), 0.0);
+    BOOST_CHECK_EQUAL(data.getNodeFootprint(&leftpath, SbProfilingData::MEMORY_SIZE), 0);
+    BOOST_CHECK(!data.getNodeFlag(&leftpath, SbProfilingData::GL_CACHED_FLAG));
+    BOOST_CHECK_EQUAL(data.getNumNodeEntries(), count);
+    // Reset the fast-path cache before testing creation independently.
+    data.getIndex(&rightpath);
+    const int leftidx = data.getIndex(&leftpath, TRUE);
+    BOOST_CHECK(leftidx != rightidx);
+    BOOST_CHECK_EQUAL(data.getParentIndex(leftidx), parentidx);
+    BOOST_CHECK_EQUAL(data.getNumNodeEntries(), count + 1);
+    data.setNodeTiming(leftidx, SbTime(1.5));
+    BOOST_CHECK_EQUAL(data.getNodeTiming(&rightpath).getValue(), 2.5);
+    BOOST_CHECK_EQUAL(data.getNodeTiming(&leftpath).getValue(), 1.5);
+  }
+  root->unref();
+}
+
+#endif // COIN_TEST_SUITE

--- a/src/profiler/SbProfilingData.cpp
+++ b/src/profiler/SbProfilingData.cpp
@@ -644,7 +644,7 @@ SbProfilingData::getIndexNoCreate(const SoPath * path, int COIN_UNUSED_ARG(pathl
   int pos = samelength;
   idx = lastentrypathindexes[pos-1];
   ++pos;
-  while (pos < fullpath->getLength() && idx != -1) {
+  while (pos <= fullpath->getLength() && idx != -1) {
     idx = this->getIndexForwardNoCreate(fullpath, pos, idx);
     ++pos;
   }

--- a/testsuite/reproducers/sbprofilingdata-getindexnocreate-offbyone/README.md
+++ b/testsuite/reproducers/sbprofilingdata-getindexnocreate-offbyone/README.md
@@ -1,0 +1,52 @@
+# Profiling path lookup regression
+
+The portable regression cases are part of `CoinTests`, extracted from
+`src/profiler/SbProfilingData.cpp`. Reconfigure CMake after adding these first
+tests to the file, then build and run CTest:
+
+```sh
+cmake -S . -B /dev/shm/coin-build -DCMAKE_BUILD_TYPE=Debug
+cmake --build /dev/shm/coin-build --parallel
+ctest --test-dir /dev/shm/coin-build --output-on-failure
+```
+
+The cases cover:
+
+- Lookup through the tail after registering a sibling path, including repeated
+  references to the same node at different child indices.
+- Timing, footprint and flags from the intended entry, using explicit values
+  that differ from the parent's values.
+- An empty registry, missing paths, prefix paths, cache changes and the fact
+  that read-only queries do not create entries.
+- A node shared by two parents at the same child index. A path registered
+  under one parent must not satisfy a query under the other. Creating the
+  second entry must preserve separate ancestry and metrics.
+
+The tests use real `SoTempPath` instances (a subclass of `SoFullPath`) to
+isolate this logic fix from the invalid plain-`SoPath` downcasts addressed
+separately by PR #714. They exercise the public profiling API without a GPU,
+rendering context, environment-enabled profiler, or optional scene-graph
+features. They do not establish that those separate downcasts are safe.
+
+A standalone check for the original sibling-path case is also available:
+
+```sh
+sh testsuite/reproducers/sbprofilingdata-getindexnocreate-offbyone/run.sh /path/to/build/lib
+```
+
+The script requires a shared Coin build and its generated headers. It resolves
+relative library paths before changing directories and removes its temporary
+executable on exit. Compilation or execution failure produces a nonzero exit.
+For sanitized execution, build Coin itself with the sanitizer flags, then use:
+
+```sh
+CXX=clang++ CXXFLAGS='-fsanitize=address,undefined -fno-omit-frame-pointer' \
+  LDFLAGS='-fsanitize=address,undefined' \
+  sh testsuite/reproducers/sbprofilingdata-getindexnocreate-offbyone/run.sh /path/to/asan-build/lib
+```
+
+The assertions on returned values detect the logic defects; sanitizer silence
+alone does not. To verify regression sensitivity, reverting the forward-walk
+bound from `<=` to `<` must fail the sibling/missing-path case; omitting the
+parent-index checks must fail the shared-node case. Both checks apply to the
+actual implementation, not a rewritten copy of its algorithm.

--- a/testsuite/reproducers/sbprofilingdata-getindexnocreate-offbyone/repro.cpp
+++ b/testsuite/reproducers/sbprofilingdata-getindexnocreate-offbyone/repro.cpp
@@ -1,44 +1,18 @@
-// Reproducer/regression test for an off-by-one in
-// SbProfilingData::getIndexNoCreate() (src/profiler/SbProfilingData.cpp).
+// Regression for SbProfilingData::getIndexNoCreate() stopping before the
+// requested tail. After registering sibling paths, a lookup of the first
+// path must return its entry and metrics, not those of its parent.
 //
-// getIndexNoCreate()'s forward-walk loop condition was
-// `pos < path->getFullLength()`, one comparison short of its sibling
-// getIndexCreate()'s `pos <= path->getFullLength()`. Both functions
-// build a "lastentrypathindexes" chain from the most-recently-added
-// profiling entry's own ancestry, find how many leading path elements
-// match that chain (samelength), and then walk *forward* from there to
-// resolve/create the remaining entries down to the queried path's
-// tail. getIndexCreate()'s "<=" walks all the way to and including the
-// tail (pos going from samelength+1 up to and including getFullLength());
-// getIndexNoCreate()'s "<" stopped one short, at the tail's *parent*,
-// so the function returned the parent's index instead of the actual
-// queried node's whenever the query path diverges from the
-// last-entry's ancestry exactly at the tail (i.e. shares every node up
-// to but not including the last one).
+// Explicit values are assigned through index-based setters to test each
+// path-based getter. CoinTests additionally covers missing paths, repeated
+// child indices and nodes shared by different parents; see README.md.
 //
-// This affects every path-based *getter* that goes through
-// getIndexNoCreate(): getIndex() with create=FALSE, getNodeTiming(),
-// getNodeFootprint(), getNodeFlag(). The corresponding *setters*
-// (which use getIndexCreate(), already correct) were never affected.
-//
-// Found while verifying the Phase 8 SoPath/SoFullPath downcast UB fix
-// on the sibling branch fix/sopath-fullpath-downcast-ub: reproduced
-// byte-for-byte against the unmigrated code too, confirming it's a
-// separate, pre-existing bug unrelated to that UB category.
-//
-// This test creates two sibling paths (cube, sphere) sharing a
-// root->branch prefix and diverging at the tail -- exactly the
-// scenario above -- then queries *cube*'s index again via the
-// path-based getter (create=FALSE) right after creating *sphere*'s
-// entry (so the "last entry" chain is sphere's, and cube's query
-// diverges from it exactly at the tail). Before the fix this returned
-// branch's index (cube's parent) instead of cube's own; after the fix
-// it returns cube's own index, matching what was returned at creation
-// time.
+// Use real SoTempPath instances to avoid the separate plain-SoPath downcast
+// problem addressed by PR #714. This test checks lookup results, not whether
+// the complete profiler is free of undefined behavior.
 
 #include <cstdio>
 #include <Inventor/SoDB.h>
-#include <Inventor/SoPath.h>
+#include <Inventor/misc/SoTempPath.h>
 #include <Inventor/annex/Profiler/SbProfilingData.h>
 #include <Inventor/nodes/SoSeparator.h>
 #include <Inventor/nodes/SoCube.h>
@@ -58,12 +32,16 @@ main()
   SoSphere * sphere = new SoSphere;
   branch->addChild(sphere);
 
-  SoPath * cubepath = new SoPath(root);
+  // Real SoFullPath subclasses isolate this lookup regression from the
+  // separate SoPath downcast issue addressed by PR #714.
+  SoTempPath * cubepath = new SoTempPath(3);
+  cubepath->setHead(root);
   cubepath->append(branch);
   cubepath->append(cube);
   cubepath->ref();
 
-  SoPath * spherepath = new SoPath(root);
+  SoTempPath * spherepath = new SoTempPath(3);
+  spherepath->setHead(root);
   spherepath->append(branch);
   spherepath->append(sphere);
   spherepath->ref();
@@ -123,6 +101,7 @@ main()
   cubepath->unref();
   spherepath->unref();
   root->unref();
+  SoDB::finish();
 
   if (failures > 0) {
     fprintf(stderr, "[repro] FAIL: %d check(s) failed\n", failures);

--- a/testsuite/reproducers/sbprofilingdata-getindexnocreate-offbyone/repro.cpp
+++ b/testsuite/reproducers/sbprofilingdata-getindexnocreate-offbyone/repro.cpp
@@ -1,0 +1,133 @@
+// Reproducer/regression test for an off-by-one in
+// SbProfilingData::getIndexNoCreate() (src/profiler/SbProfilingData.cpp).
+//
+// getIndexNoCreate()'s forward-walk loop condition was
+// `pos < path->getFullLength()`, one comparison short of its sibling
+// getIndexCreate()'s `pos <= path->getFullLength()`. Both functions
+// build a "lastentrypathindexes" chain from the most-recently-added
+// profiling entry's own ancestry, find how many leading path elements
+// match that chain (samelength), and then walk *forward* from there to
+// resolve/create the remaining entries down to the queried path's
+// tail. getIndexCreate()'s "<=" walks all the way to and including the
+// tail (pos going from samelength+1 up to and including getFullLength());
+// getIndexNoCreate()'s "<" stopped one short, at the tail's *parent*,
+// so the function returned the parent's index instead of the actual
+// queried node's whenever the query path diverges from the
+// last-entry's ancestry exactly at the tail (i.e. shares every node up
+// to but not including the last one).
+//
+// This affects every path-based *getter* that goes through
+// getIndexNoCreate(): getIndex() with create=FALSE, getNodeTiming(),
+// getNodeFootprint(), getNodeFlag(). The corresponding *setters*
+// (which use getIndexCreate(), already correct) were never affected.
+//
+// Found while verifying the Phase 8 SoPath/SoFullPath downcast UB fix
+// on the sibling branch fix/sopath-fullpath-downcast-ub: reproduced
+// byte-for-byte against the unmigrated code too, confirming it's a
+// separate, pre-existing bug unrelated to that UB category.
+//
+// This test creates two sibling paths (cube, sphere) sharing a
+// root->branch prefix and diverging at the tail -- exactly the
+// scenario above -- then queries *cube*'s index again via the
+// path-based getter (create=FALSE) right after creating *sphere*'s
+// entry (so the "last entry" chain is sphere's, and cube's query
+// diverges from it exactly at the tail). Before the fix this returned
+// branch's index (cube's parent) instead of cube's own; after the fix
+// it returns cube's own index, matching what was returned at creation
+// time.
+
+#include <cstdio>
+#include <Inventor/SoDB.h>
+#include <Inventor/SoPath.h>
+#include <Inventor/annex/Profiler/SbProfilingData.h>
+#include <Inventor/nodes/SoSeparator.h>
+#include <Inventor/nodes/SoCube.h>
+#include <Inventor/nodes/SoSphere.h>
+
+int
+main()
+{
+  SoDB::init();
+
+  SoSeparator * root = new SoSeparator;
+  root->ref();
+  SoSeparator * branch = new SoSeparator;
+  root->addChild(branch);
+  SoCube * cube = new SoCube;
+  branch->addChild(cube);
+  SoSphere * sphere = new SoSphere;
+  branch->addChild(sphere);
+
+  SoPath * cubepath = new SoPath(root);
+  cubepath->append(branch);
+  cubepath->append(cube);
+  cubepath->ref();
+
+  SoPath * spherepath = new SoPath(root);
+  spherepath->append(branch);
+  spherepath->append(sphere);
+  spherepath->ref();
+
+  int failures = 0;
+
+  SbProfilingData data;
+
+  const int cubeidx = data.getIndex(cubepath, TRUE);
+  const int sphereidx = data.getIndex(spherepath, TRUE);
+  fprintf(stderr, "[repro] cubeidx=%d sphereidx=%d\n", cubeidx, sphereidx);
+  if (cubeidx < 0 || sphereidx < 0 || cubeidx == sphereidx) {
+    fprintf(stderr, "[repro] FAIL: expected two distinct, valid indices\n");
+    failures++;
+  }
+
+  // At this point the "last entry" is sphere's -- querying cube's
+  // path again (create=FALSE, so via getIndexNoCreate()) diverges
+  // from sphere's ancestry exactly at the tail (both share
+  // root->branch, differ only in the final node). This is exactly the
+  // pattern the off-by-one mishandled.
+  const int cubeidx2 = data.getIndex(cubepath, FALSE);
+  fprintf(stderr, "[repro] cubeidx2 (re-lookup after sphere) = %d\n", cubeidx2);
+  if (cubeidx2 != cubeidx) {
+    fprintf(stderr, "[repro] FAIL: expected getIndex(cubepath, FALSE) == %d, got %d "
+                    "(likely returned the parent/branch index instead)\n",
+            cubeidx, cubeidx2);
+    failures++;
+  }
+
+  // Same check via the other path-based getters, which all go through
+  // getIndexNoCreate() the same way.
+  data.setNodeTiming(cubeidx, SbTime(1.5));
+  const SbTime timing = data.getNodeTiming(cubepath);
+  fprintf(stderr, "[repro] cube timing (looked up by path) = %g\n", timing.getValue());
+  if (timing.getValue() != 1.5) {
+    fprintf(stderr, "[repro] FAIL: getNodeTiming(cubepath) didn't resolve to cube's own entry\n");
+    failures++;
+  }
+
+  data.setNodeFootprint(cubeidx, SbProfilingData::MEMORY_SIZE, 4096);
+  const size_t footprint = data.getNodeFootprint(cubepath, SbProfilingData::MEMORY_SIZE);
+  fprintf(stderr, "[repro] cube footprint (looked up by path) = %zu\n", footprint);
+  if (footprint != 4096) {
+    fprintf(stderr, "[repro] FAIL: getNodeFootprint(cubepath) didn't resolve to cube's own entry\n");
+    failures++;
+  }
+
+  data.setNodeFlag(cubeidx, SbProfilingData::GL_CACHED_FLAG, TRUE);
+  const SbBool flag = data.getNodeFlag(cubepath, SbProfilingData::GL_CACHED_FLAG);
+  fprintf(stderr, "[repro] cube GL_CACHED_FLAG (looked up by path) = %d\n", (int)flag);
+  if (!flag) {
+    fprintf(stderr, "[repro] FAIL: getNodeFlag(cubepath) didn't resolve to cube's own entry\n");
+    failures++;
+  }
+
+  cubepath->unref();
+  spherepath->unref();
+  root->unref();
+
+  if (failures > 0) {
+    fprintf(stderr, "[repro] FAIL: %d check(s) failed\n", failures);
+    return 1;
+  }
+  fprintf(stderr, "[repro] PASS\n");
+  return 0;
+}

--- a/testsuite/reproducers/sbprofilingdata-getindexnocreate-offbyone/run.sh
+++ b/testsuite/reproducers/sbprofilingdata-getindexnocreate-offbyone/run.sh
@@ -1,28 +1,19 @@
 #!/bin/sh
-# Regression test for the SbProfilingData::getIndexNoCreate() off-by-one
-# fix -- see repro.cpp for the full explanation.
-#
-#   testsuite/reproducers/sbprofilingdata-getindexnocreate-offbyone/run.sh /path/to/build/lib
-#
-# Prints PASS and exits 0 if all checks hold.
-
-CDPATH= cd "$(dirname "$0")" || exit 2
-
-LIBDIR="$1"
-if [ -z "$LIBDIR" ]; then
-  echo "usage: $0 /path/to/build/lib   (directory containing libCoin.so)" >&2
+# Standalone sibling-path check; CoinTests also covers missing and shared paths.
+set -eu
+if [ "$#" -ne 1 ]; then
+  echo "usage: $0 /path/to/build/lib" >&2
   exit 2
 fi
-
+LIBDIR=$(CDPATH= cd "$1" && pwd)
+HERE=$(CDPATH= cd "$(dirname "$0")" && pwd)
+SOURCE=$(CDPATH= cd "$HERE/../../.." && pwd)
 CXX=${CXX:-c++}
-SRCINCLUDE="$(CDPATH= cd ../../.. && pwd)/include" || exit 2
+OUT=$(mktemp -d "${TMPDIR:-/tmp}/coin-profiling-lookup.XXXXXX")
+trap 'rm -rf "$OUT"' EXIT HUP INT TERM
 
-"$CXX" -O1 -g repro.cpp -o repro -I"$SRCINCLUDE" -I"$LIBDIR/../include" -L"$LIBDIR" -lCoin || exit 2
-
+# Intentional splitting of compiler/linker flags for sanitizer builds.
+"$CXX" ${CXXFLAGS:-} -O1 -g "$HERE/repro.cpp" -o "$OUT/repro" \
+  -I"$SOURCE/include" -I"$LIBDIR/../include" -L"$LIBDIR" ${LDFLAGS:-} -lCoin
 export LD_LIBRARY_PATH="$LIBDIR${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
-./repro
-status=$?
-if [ "$status" -ne 0 ]; then
-  echo "=== FAIL: repro exited with status $status ===" >&2
-  exit "$status"
-fi
+"$OUT/repro"

--- a/testsuite/reproducers/sbprofilingdata-getindexnocreate-offbyone/run.sh
+++ b/testsuite/reproducers/sbprofilingdata-getindexnocreate-offbyone/run.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+# Regression test for the SbProfilingData::getIndexNoCreate() off-by-one
+# fix -- see repro.cpp for the full explanation.
+#
+#   testsuite/reproducers/sbprofilingdata-getindexnocreate-offbyone/run.sh /path/to/build/lib
+#
+# Prints PASS and exits 0 if all checks hold.
+
+CDPATH= cd "$(dirname "$0")" || exit 2
+
+LIBDIR="$1"
+if [ -z "$LIBDIR" ]; then
+  echo "usage: $0 /path/to/build/lib   (directory containing libCoin.so)" >&2
+  exit 2
+fi
+
+CXX=${CXX:-c++}
+SRCINCLUDE="$(CDPATH= cd ../../.. && pwd)/include" || exit 2
+
+"$CXX" -O1 -g repro.cpp -o repro -I"$SRCINCLUDE" -I"$LIBDIR/../include" -L"$LIBDIR" -lCoin || exit 2
+
+export LD_LIBRARY_PATH="$LIBDIR${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+./repro
+status=$?
+if [ "$status" -ne 0 ]; then
+  echo "=== FAIL: repro exited with status $status ===" >&2
+  exit "$status"
+fi


### PR DESCRIPTION
Walk through the path tail in getIndexNoCreate instead of stopping at its parent. Match parentidx as well as node/child identity in both forward helpers, preventing paths under different parents from sharing the wrong profiling entry.

Add public-API CoinTests cases and a standalone reproducer for sibling paths, missing entries, and shared descendants. Expected results are checked independently of the lookup being tested.

## Validation

The distributed changes were validated together in `lab/all-fixes-integration`, with Clang Debug instrumentation on both Coin and C++ test drivers: `-fsanitize=address,undefined,function -fno-omit-frame-pointer`, `ASAN_OPTIONS=detect_leaks=1`, `UBSAN_OPTIONS=halt_on_error=1`, without suppressions. All 8 CTest entries passed (342 CoinTests / 83,759 checks plus seven profiler modes); 31 additional checks passed, including actual rendering, events and the historical-header client. EGL and SpiderMonkey checks were inconclusive.

This is **integration evidence**, not a claim that this isolated PR includes every companion fix or passes the full sanitizer matrix by itself. Global cleanup, STL, test-fixture and GL record fixes are distributed across the related PRs. Windows/macOS and all optional configurations were not rerun for this update. The final per-PR diff passed `git diff --check`.
