### PR TITLE
Skip identity-transform matrix element updates in SoScale/SoRotation/SoRotationXYZ

### DIFF
--- a/src/nodes/SoRotation.cpp
+++ b/src/nodes/SoRotation.cpp
@@ -134,8 +134,17 @@ void
 SoRotation::doAction(SoAction * action)
 {
   if (!this->rotation.isIgnored()) {
-    SoModelMatrixElement::rotateBy(action->getState(), this,
-                                   this->rotation.getValue());
+    const SbRotation & rot = this->rotation.getValue();
+    // Skip the matrix element update entirely for an identity rotation
+    // -- same "no-op transform contributes no GL/matrix work"
+    // optimization SoTransform::doAction() got in issue #534, applied
+    // to this sibling node. isIgnored() is a separate, orthogonal
+    // check (an SoField connection/override flag) and is preserved
+    // above exactly as before; this adds a second, independent check
+    // on the field's *value*. Exact comparison on purpose.
+    if (rot != SbRotation::identity()) {
+      SoModelMatrixElement::rotateBy(action->getState(), this, rot);
+    }
   }
 }
 

--- a/src/nodes/SoRotationXYZ.cpp
+++ b/src/nodes/SoRotationXYZ.cpp
@@ -131,6 +131,15 @@ SoRotationXYZ::initClass(void)
 void
 SoRotationXYZ::doAction(SoAction * action)
 {
+  // Skip the matrix element update entirely for an identity rotation --
+  // same "no-op transform contributes no GL/matrix work" optimization
+  // SoTransform::doAction() got in issue #534, applied to this sibling
+  // node. angle == 0.0f is identity regardless of which axis field
+  // selects, so this exact-zero case alone already covers it -- no
+  // need to also construct rotvec/SbRotation just to compare against
+  // SbRotation::identity(). Exact comparison on purpose.
+  if (this->angle.getValue() == 0.0f) return;
+
   SbVec3f rotvec;
   if (this->getVector(rotvec)) {
     SoModelMatrixElement::rotateBy(action->getState(), this,

--- a/src/nodes/SoScale.cpp
+++ b/src/nodes/SoScale.cpp
@@ -119,8 +119,17 @@ SoScale::initClass(void)
 void
 SoScale::doAction(SoAction * action)
 {
-  SoModelMatrixElement::scaleBy(action->getState(), this,
-                                this->scaleFactor.getValue());
+  const SbVec3f & sf = this->scaleFactor.getValue();
+  // Skip the matrix element update entirely for an identity scale --
+  // same "no-op transform contributes no GL/matrix work" optimization
+  // SoTransform::doAction() got in issue #534, applied to this sibling
+  // node. Exact comparison on purpose: this is a cheap-and-safe
+  // optimization for the (very common, e.g. CAD-export placeholder
+  // nodes) exact-identity case, not an attempt to snap near-identity
+  // scales to identity.
+  if (sf != SbVec3f(1.0f, 1.0f, 1.0f)) {
+    SoModelMatrixElement::scaleBy(action->getState(), this, sf);
+  }
 }
 
 // Doc in superclass.

--- a/src/nodes/SoScale.cpp
+++ b/src/nodes/SoScale.cpp
@@ -183,3 +183,18 @@ SoScale::getPrimitiveCount(SoGetPrimitiveCountAction *action)
 {
   SoScale::doAction((SoAction*)action);
 }
+
+#ifdef COIN_TEST_SUITE
+#include <IdentityTransformCacheTest.h>
+
+static void identity_transform_cache_check(bool result, const char * message)
+{
+  BOOST_CHECK_MESSAGE(result, message);
+}
+
+BOOST_AUTO_TEST_CASE(identity_transform_cache_transitions)
+{
+  for (int kind = 0; kind < 3; ++kind)
+    IdentityTransformCacheTest::run(kind, identity_transform_cache_check);
+}
+#endif // COIN_TEST_SUITE

--- a/testsuite/IdentityTransformCacheTest.h
+++ b/testsuite/IdentityTransformCacheTest.h
@@ -1,0 +1,102 @@
+#ifndef COIN_IDENTITY_TRANSFORM_CACHE_TEST_H
+#define COIN_IDENTITY_TRANSFORM_CACHE_TEST_H
+
+#include <Inventor/actions/SoGetBoundingBoxAction.h>
+#include <Inventor/actions/SoGetMatrixAction.h>
+#include <Inventor/nodes/SoCallback.h>
+#include <Inventor/nodes/SoCube.h>
+#include <Inventor/nodes/SoRotation.h>
+#include <Inventor/nodes/SoRotationXYZ.h>
+#include <Inventor/nodes/SoScale.h>
+#include <Inventor/nodes/SoSeparator.h>
+#include <Inventor/SbViewportRegion.h>
+
+// Shared by CoinTests and the standalone driver. No GL context is needed;
+// these checks cover matrix traversal and bounding-box caches, not GL caches.
+namespace IdentityTransformCacheTest {
+typedef void Check(bool, const char *);
+
+inline void countBBox(void * data, SoAction * action)
+{
+  if (action->isOfType(SoGetBoundingBoxAction::getClassTypeId()))
+    ++*static_cast<int *>(data);
+}
+
+inline bool close(const SbVec3f & a, const SbVec3f & b)
+{
+  return (a - b).length() < 1.0e-5f;
+}
+
+inline void run(int kind, Check * check)
+{
+  SoSeparator * root = new SoSeparator;
+  root->ref();
+  // Set once: assigning this field again would itself invalidate the cache.
+  root->boundingBoxCaching = SoSeparator::ON;
+  SoNode * transform;
+  if (kind == 0) transform = new SoScale;
+  else if (kind == 1) transform = new SoRotation;
+  else transform = new SoRotationXYZ;
+  root->addChild(transform);
+
+  int traversals = 0;
+  SoCallback * counter = new SoCallback;
+  counter->setCallback(countBBox, &traversals);
+  root->addChild(counter);
+  SoCube * cube = new SoCube;
+  cube->width = 2.0f;
+  cube->height = 4.0f;
+  cube->depth = 6.0f;
+  root->addChild(cube);
+
+  // Each changed value must rebuild the cache, then an unchanged repeat
+  // must reuse it. A 2x4x6 box distinguishes a stale Z-rotation result.
+  for (int phase = 0; phase < 3; ++phase) {
+    const bool changed = phase == 1;
+    const float angle = changed ? 1.57079632679489661923f : 0.0f;
+    if (kind == 0)
+      static_cast<SoScale *>(transform)->scaleFactor =
+        changed ? SbVec3f(2, 2, 2) : SbVec3f(1, 1, 1);
+    else if (kind == 1)
+      static_cast<SoRotation *>(transform)->rotation =
+        SbRotation(SbVec3f(0, 0, 1), angle);
+    else {
+      SoRotationXYZ * rotation = static_cast<SoRotationXYZ *>(transform);
+      rotation->axis = SoRotationXYZ::Z;
+      rotation->angle = angle;
+    }
+
+    SbVec3f extent(1, 2, 3);
+    SbMatrix expected = SbMatrix::identity();
+    if (changed && kind == 0) {
+      extent = SbVec3f(2, 4, 6);
+      expected[0][0] = expected[1][1] = expected[2][2] = 2.0f;
+    }
+    else if (changed) {
+      extent = SbVec3f(2, 1, 3);
+      // Independently known row-vector matrix for a quarter-turn about Z.
+      expected[0][0] = expected[1][1] = 0.0f;
+      expected[0][1] = 1.0f;
+      expected[1][0] = -1.0f;
+    }
+
+    SoGetMatrixAction matrixAction(SbViewportRegion(100, 100));
+    matrixAction.apply(transform);
+    check(matrixAction.getMatrix().equals(expected, 1.0e-5f),
+          "matrix matches independent expected transform");
+
+    for (int repeat = 0; repeat < 2; ++repeat) {
+      SoGetBoundingBoxAction bboxAction(SbViewportRegion(100, 100));
+      bboxAction.apply(root);
+      const SbBox3f & box = bboxAction.getBoundingBox();
+      check(close(box.getMin(), -extent) && close(box.getMax(), extent),
+            "bounding box matches independent extents");
+      check(traversals == phase + 1,
+            repeat == 0 ? "mutation rebuilds bounding-box cache" :
+                          "unchanged traversal reuses bounding-box cache");
+    }
+  }
+  root->unref();
+}
+}
+#endif

--- a/testsuite/reproducers/identity-transform-node-cache-check/README.md
+++ b/testsuite/reproducers/identity-transform-node-cache-check/README.md
@@ -1,0 +1,36 @@
+# Identity transform cache checks
+
+The shared scenario in `testsuite/IdentityTransformCacheTest.h` runs in
+`CoinTests` as `SoScale_TestSuite/identity_transform_cache_transitions`. No rendering
+context or optional dependency is needed. The standalone driver runs the same
+45 assertions and calls `SoDB::finish()` after destroying its scene and actions.
+
+From the repository root, with a configured and built Coin tree:
+
+```sh
+sh testsuite/reproducers/identity-transform-node-cache-check/run.sh /path/to/build/lib
+```
+
+For a Clang ASan/UBSan build, instrument both Coin and the driver:
+
+```sh
+CXX=clang++ \
+CXXFLAGS='-O0 -g -fsanitize=address,undefined -fno-omit-frame-pointer' \
+LDFLAGS='-fsanitize=address,undefined' \
+ASAN_OPTIONS=detect_leaks=1 \
+sh testsuite/reproducers/identity-transform-node-cache-check/run.sh /path/to/sanitized-build/lib
+```
+
+The script uses Unix library paths; the portable scenario itself also runs
+through the regular CoinTests target on other platforms.
+
+For scale and both rotation nodes, the scenario checks identity, a non-identity
+value, and identity again. Bounding-box caching is enabled once. A traversal
+counter verifies one rebuild after each change and reuse on an unchanged repeat.
+A 2x4x6 box changes extents under the tested quarter-turn about Z, so an old box
+cannot pass the rotation checks. Expected matrices and extents are specified
+independently of the transform accessors.
+
+These checks exercise matrix and bounding-box actions. They do not execute
+GL rendering, validate render caches, reproduce issue #534's visual symptom,
+or measure the number of matrix-element updates avoided by the optimization.

--- a/testsuite/reproducers/identity-transform-node-cache-check/repro.cpp
+++ b/testsuite/reproducers/identity-transform-node-cache-check/repro.cpp
@@ -1,0 +1,236 @@
+// Verification repro for the SoScale/SoRotation/SoRotationXYZ identity
+// optimization (matching SoTransform's issue #534 fix: skip the
+// SoModelMatrixElement update entirely when the node's value is
+// exactly identity).
+//
+// SoModelMatrixElement::scaleBy()/rotateBy() (and mult()/translateBy())
+// call elem->addNodeId(node) as their last step -- registering the node
+// as a cache dependency for whatever bbox/render cache is currently
+// being built. Skipping the call for an identity value also skips that
+// registration. This is not a new pattern introduced here:
+// SoTranslation::doAction() has skipped translateBy() (and therefore
+// addNodeId()) for a zero translation since long before this session,
+// and SoTransform::doAction() does the same for mult() since the #534
+// fix. But it deserves its own empirical check for these three sibling
+// nodes rather than resting on precedent alone: if skipped
+// addNodeId() ever let a bbox/render cache go stale, the specific
+// failure mode would be exactly "identity -> change to non-identity ->
+// change back to identity, after a cache was already built for the
+// identity state" -- a cache built while the node contributed nothing
+// might not know to invalidate when the node's value changes.
+//
+// This repro drives that exact sequence for each of the three nodes,
+// checking both SoGetMatrixAction's accumulated matrix and
+// SoGetBoundingBoxAction's bounding box (which has its own dependency
+// cache, SoBoundingBoxCache) at each step:
+//
+//   1. identity value      -> matrix/bbox must match the "no node at
+//                              all" baseline exactly.
+//   2. non-identity value  -> matrix/bbox must reflect the change.
+//   3. back to identity    -> matrix/bbox must match step 1 again, even
+//                              though a bbox cache was already built
+//                              once for the identity state in step 1,
+//                              then invalidated and rebuilt for step 2.
+//
+// See run.sh in this directory for how to build and run this against a
+// given libCoin build.
+
+#include <cstdio>
+#include <cstring>
+#include <cmath>
+#include <Inventor/SoDB.h>
+#include <Inventor/actions/SoGetMatrixAction.h>
+#include <Inventor/actions/SoGetBoundingBoxAction.h>
+#include <Inventor/nodes/SoSeparator.h>
+#include <Inventor/nodes/SoCube.h>
+#include <Inventor/nodes/SoScale.h>
+#include <Inventor/nodes/SoRotation.h>
+#include <Inventor/nodes/SoRotationXYZ.h>
+#include <Inventor/SbViewportRegion.h>
+#include <Inventor/SbBox3f.h>
+
+static int failures = 0;
+
+static void
+checkMatrix(const char * label, const SbMatrix & got, const SbMatrix & want)
+{
+  if (got != want) {
+    fprintf(stderr, "[repro] FAIL (%s): matrix mismatch\n", label);
+    failures++;
+  }
+  else {
+    fprintf(stderr, "[repro] ok   (%s): matrix matches\n", label);
+  }
+}
+
+static SbBool
+approxEqual(const SbVec3f & a, const SbVec3f & b)
+{
+  // Small tolerance here only: this compares bbox extents derived from
+  // cos()/sin() of a 90-degree rotation, which is not exactly 0/1 in
+  // floating point (unlike the identity checks in the production code
+  // under test, which compare exact field values with no trig
+  // involved -- those stay exact, per instructions).
+  const float eps = 1.0e-5f;
+  return (a - b).length() < eps;
+}
+
+static void
+checkBBox(const char * label, const SbBox3f & got, const SbBox3f & want)
+{
+  if (!approxEqual(got.getMin(), want.getMin()) ||
+      !approxEqual(got.getMax(), want.getMax())) {
+    fprintf(stderr, "[repro] FAIL (%s): bbox mismatch: got [%g %g %g]-[%g %g %g], want [%g %g %g]-[%g %g %g]\n",
+            label,
+            got.getMin()[0], got.getMin()[1], got.getMin()[2],
+            got.getMax()[0], got.getMax()[1], got.getMax()[2],
+            want.getMin()[0], want.getMin()[1], want.getMin()[2],
+            want.getMax()[0], want.getMax()[1], want.getMax()[2]);
+    failures++;
+  }
+  else {
+    fprintf(stderr, "[repro] ok   (%s): bbox matches\n", label);
+  }
+}
+
+static SbMatrix
+getMatrix(SoSeparator * root, SoNode * tail)
+{
+  SoGetMatrixAction ma(SbViewportRegion(100, 100));
+  SoPath * p = new SoPath(root);
+  p->ref();
+  p->append(tail);
+  ma.apply(p);
+  p->unref();
+  return ma.getMatrix();
+}
+
+static SbBox3f
+getBBox(SoSeparator * root, SbBool cachingon)
+{
+  root->boundingBoxCaching = cachingon ? SoSeparator::ON : SoSeparator::OFF;
+  SoGetBoundingBoxAction ba(SbViewportRegion(100, 100));
+  ba.apply(root);
+  return ba.getBoundingBox();
+}
+
+// Exercises identity -> non-identity -> identity for one transform-kind
+// child inserted before a fixed SoCube, checking matrix + bbox at each
+// step against a baseline scene with no transform node at all (for the
+// identity steps) or an equivalent explicit-matrix scene (for the
+// non-identity step). Uses caching (ON) throughout, so the bbox
+// action's SoBoundingBoxCache is actually exercised across the
+// transitions, not bypassed.
+static void
+runSequence(const char * kind)
+{
+  fprintf(stderr, "\n[repro] === %s ===\n", kind);
+
+  SoSeparator * root = new SoSeparator;
+  root->ref();
+  root->renderCaching = SoSeparator::ON;
+  root->boundingBoxCaching = SoSeparator::ON;
+
+  SoNode * xform = NULL;
+  if (strcmp(kind, "scale") == 0) {
+    SoScale * s = new SoScale;
+    s->scaleFactor.setValue(1.0f, 1.0f, 1.0f); // identity
+    xform = s;
+  }
+  else if (strcmp(kind, "rotation") == 0) {
+    SoRotation * r = new SoRotation;
+    r->rotation.setValue(SbVec3f(0.0f, 0.0f, 1.0f), 0.0f); // identity
+    xform = r;
+  }
+  else { // rotationxyz
+    SoRotationXYZ * r = new SoRotationXYZ;
+    r->axis = SoRotationXYZ::Z;
+    r->angle.setValue(0.0f); // identity
+    xform = r;
+  }
+  root->addChild(xform);
+
+  SoCube * cube = new SoCube;
+  cube->width = 2.0f;
+  cube->height = 2.0f;
+  cube->depth = 2.0f;
+  root->addChild(cube);
+
+  // Step 1: identity. Baseline: matrix must be identity, bbox must be
+  // the cube's own untransformed box.
+  SbMatrix m1 = getMatrix(root, cube);
+  checkMatrix("step1 identity: matrix == identity", m1, SbMatrix::identity());
+  SbBox3f b1 = getBBox(root, TRUE);
+  SbBox3f wantb1(-1.0f, -1.0f, -1.0f, 1.0f, 1.0f, 1.0f);
+  checkBBox("step1 identity: bbox == unit cube", b1, wantb1);
+
+  // Step 2: mutate to non-identity. This must invalidate whatever bbox
+  // cache step 1 built (the interesting case if addNodeId() being
+  // skipped in step 1 ever mattered: this node was never registered as
+  // a dependency of that cache).
+  SbMatrix wantm2;
+  SbBox3f wantb2;
+  if (strcmp(kind, "scale") == 0) {
+    static_cast<SoScale *>(xform)->scaleFactor.setValue(2.0f, 2.0f, 2.0f);
+    wantm2 = SbMatrix::identity();
+    wantm2[0][0] = 2.0f; wantm2[1][1] = 2.0f; wantm2[2][2] = 2.0f;
+    wantb2.setBounds(SbVec3f(-2.0f, -2.0f, -2.0f), SbVec3f(2.0f, 2.0f, 2.0f));
+  }
+  else if (strcmp(kind, "rotation") == 0) {
+    SbRotation rot(SbVec3f(0.0f, 0.0f, 1.0f), (float)(M_PI / 2.0)); // 90 deg about Z
+    static_cast<SoRotation *>(xform)->rotation.setValue(rot);
+    rot.getValue(wantm2);
+    // A 90-degree rotation of a symmetric 2x2x2 cube about its own
+    // center still bounds to the same box (edge lengths swap X/Y, but
+    // the cube is symmetric) -- so re-use wantb1 here, this step
+    // mainly exercises the matrix + cache-invalidation path.
+    wantb2 = wantb1;
+  }
+  else {
+    SoRotationXYZ * rxyz = static_cast<SoRotationXYZ *>(xform);
+    rxyz->angle.setValue((float)(M_PI / 2.0));
+    SbRotation rot(SbVec3f(0.0f, 0.0f, 1.0f), (float)(M_PI / 2.0));
+    rot.getValue(wantm2);
+    wantb2 = wantb1; // same reasoning as the "rotation" case above
+  }
+  SbMatrix m2 = getMatrix(root, cube);
+  checkMatrix("step2 non-identity: matrix reflects change", m2, wantm2);
+  SbBox3f b2 = getBBox(root, TRUE);
+  checkBBox("step2 non-identity: bbox reflects change", b2, wantb2);
+
+  // Step 3: back to identity. The bbox cache from step 2 (built for the
+  // non-identity value) must be correctly invalidated and recomputed
+  // -- this is the actual "after creating caches" case for the
+  // identity-skip optimization itself, since a real GL/bbox cache now
+  // exists and this transition exercises re-entering the skipped path.
+  if (strcmp(kind, "scale") == 0) {
+    static_cast<SoScale *>(xform)->scaleFactor.setValue(1.0f, 1.0f, 1.0f);
+  }
+  else if (strcmp(kind, "rotation") == 0) {
+    static_cast<SoRotation *>(xform)->rotation.setValue(SbVec3f(0.0f, 0.0f, 1.0f), 0.0f);
+  }
+  else {
+    static_cast<SoRotationXYZ *>(xform)->angle.setValue(0.0f);
+  }
+  SbMatrix m3 = getMatrix(root, cube);
+  checkMatrix("step3 back to identity: matrix == identity", m3, SbMatrix::identity());
+  SbBox3f b3 = getBBox(root, TRUE);
+  checkBBox("step3 back to identity: bbox == unit cube", b3, wantb1);
+
+  root->unref();
+}
+
+int main()
+{
+  SoDB::init();
+  runSequence("scale");
+  runSequence("rotation");
+  runSequence("rotationxyz");
+
+  if (failures > 0) {
+    fprintf(stderr, "\n[repro] FAIL: %d check(s) failed\n", failures);
+    return 1;
+  }
+  fprintf(stderr, "\n[repro] PASS: all checks passed\n");
+  return 0;
+}

--- a/testsuite/reproducers/identity-transform-node-cache-check/repro.cpp
+++ b/testsuite/reproducers/identity-transform-node-cache-check/repro.cpp
@@ -1,236 +1,26 @@
-// Verification repro for the SoScale/SoRotation/SoRotationXYZ identity
-// optimization (matching SoTransform's issue #534 fix: skip the
-// SoModelMatrixElement update entirely when the node's value is
-// exactly identity).
-//
-// SoModelMatrixElement::scaleBy()/rotateBy() (and mult()/translateBy())
-// call elem->addNodeId(node) as their last step -- registering the node
-// as a cache dependency for whatever bbox/render cache is currently
-// being built. Skipping the call for an identity value also skips that
-// registration. This is not a new pattern introduced here:
-// SoTranslation::doAction() has skipped translateBy() (and therefore
-// addNodeId()) for a zero translation since long before this session,
-// and SoTransform::doAction() does the same for mult() since the #534
-// fix. But it deserves its own empirical check for these three sibling
-// nodes rather than resting on precedent alone: if skipped
-// addNodeId() ever let a bbox/render cache go stale, the specific
-// failure mode would be exactly "identity -> change to non-identity ->
-// change back to identity, after a cache was already built for the
-// identity state" -- a cache built while the node contributed nothing
-// might not know to invalidate when the node's value changes.
-//
-// This repro drives that exact sequence for each of the three nodes,
-// checking both SoGetMatrixAction's accumulated matrix and
-// SoGetBoundingBoxAction's bounding box (which has its own dependency
-// cache, SoBoundingBoxCache) at each step:
-//
-//   1. identity value      -> matrix/bbox must match the "no node at
-//                              all" baseline exactly.
-//   2. non-identity value  -> matrix/bbox must reflect the change.
-//   3. back to identity    -> matrix/bbox must match step 1 again, even
-//                              though a bbox cache was already built
-//                              once for the identity state in step 1,
-//                              then invalidated and rebuilt for step 2.
-//
-// See run.sh in this directory for how to build and run this against a
-// given libCoin build.
-
+// Matrix and bounding-box cache checks shared with CoinTests.
+// See run.sh for invocation. This driver does not exercise GL render caches.
 #include <cstdio>
-#include <cstring>
-#include <cmath>
 #include <Inventor/SoDB.h>
-#include <Inventor/actions/SoGetMatrixAction.h>
-#include <Inventor/actions/SoGetBoundingBoxAction.h>
-#include <Inventor/nodes/SoSeparator.h>
-#include <Inventor/nodes/SoCube.h>
-#include <Inventor/nodes/SoScale.h>
-#include <Inventor/nodes/SoRotation.h>
-#include <Inventor/nodes/SoRotationXYZ.h>
-#include <Inventor/SbViewportRegion.h>
-#include <Inventor/SbBox3f.h>
+#include "../../IdentityTransformCacheTest.h"
 
 static int failures = 0;
-
-static void
-checkMatrix(const char * label, const SbMatrix & got, const SbMatrix & want)
+static void check(bool result, const char * message)
 {
-  if (got != want) {
-    fprintf(stderr, "[repro] FAIL (%s): matrix mismatch\n", label);
-    failures++;
+  if (!result) {
+    fprintf(stderr, "FAIL: %s\n", message);
+    ++failures;
   }
-  else {
-    fprintf(stderr, "[repro] ok   (%s): matrix matches\n", label);
-  }
-}
-
-static SbBool
-approxEqual(const SbVec3f & a, const SbVec3f & b)
-{
-  // Small tolerance here only: this compares bbox extents derived from
-  // cos()/sin() of a 90-degree rotation, which is not exactly 0/1 in
-  // floating point (unlike the identity checks in the production code
-  // under test, which compare exact field values with no trig
-  // involved -- those stay exact, per instructions).
-  const float eps = 1.0e-5f;
-  return (a - b).length() < eps;
-}
-
-static void
-checkBBox(const char * label, const SbBox3f & got, const SbBox3f & want)
-{
-  if (!approxEqual(got.getMin(), want.getMin()) ||
-      !approxEqual(got.getMax(), want.getMax())) {
-    fprintf(stderr, "[repro] FAIL (%s): bbox mismatch: got [%g %g %g]-[%g %g %g], want [%g %g %g]-[%g %g %g]\n",
-            label,
-            got.getMin()[0], got.getMin()[1], got.getMin()[2],
-            got.getMax()[0], got.getMax()[1], got.getMax()[2],
-            want.getMin()[0], want.getMin()[1], want.getMin()[2],
-            want.getMax()[0], want.getMax()[1], want.getMax()[2]);
-    failures++;
-  }
-  else {
-    fprintf(stderr, "[repro] ok   (%s): bbox matches\n", label);
-  }
-}
-
-static SbMatrix
-getMatrix(SoSeparator * root, SoNode * tail)
-{
-  SoGetMatrixAction ma(SbViewportRegion(100, 100));
-  SoPath * p = new SoPath(root);
-  p->ref();
-  p->append(tail);
-  ma.apply(p);
-  p->unref();
-  return ma.getMatrix();
-}
-
-static SbBox3f
-getBBox(SoSeparator * root, SbBool cachingon)
-{
-  root->boundingBoxCaching = cachingon ? SoSeparator::ON : SoSeparator::OFF;
-  SoGetBoundingBoxAction ba(SbViewportRegion(100, 100));
-  ba.apply(root);
-  return ba.getBoundingBox();
-}
-
-// Exercises identity -> non-identity -> identity for one transform-kind
-// child inserted before a fixed SoCube, checking matrix + bbox at each
-// step against a baseline scene with no transform node at all (for the
-// identity steps) or an equivalent explicit-matrix scene (for the
-// non-identity step). Uses caching (ON) throughout, so the bbox
-// action's SoBoundingBoxCache is actually exercised across the
-// transitions, not bypassed.
-static void
-runSequence(const char * kind)
-{
-  fprintf(stderr, "\n[repro] === %s ===\n", kind);
-
-  SoSeparator * root = new SoSeparator;
-  root->ref();
-  root->renderCaching = SoSeparator::ON;
-  root->boundingBoxCaching = SoSeparator::ON;
-
-  SoNode * xform = NULL;
-  if (strcmp(kind, "scale") == 0) {
-    SoScale * s = new SoScale;
-    s->scaleFactor.setValue(1.0f, 1.0f, 1.0f); // identity
-    xform = s;
-  }
-  else if (strcmp(kind, "rotation") == 0) {
-    SoRotation * r = new SoRotation;
-    r->rotation.setValue(SbVec3f(0.0f, 0.0f, 1.0f), 0.0f); // identity
-    xform = r;
-  }
-  else { // rotationxyz
-    SoRotationXYZ * r = new SoRotationXYZ;
-    r->axis = SoRotationXYZ::Z;
-    r->angle.setValue(0.0f); // identity
-    xform = r;
-  }
-  root->addChild(xform);
-
-  SoCube * cube = new SoCube;
-  cube->width = 2.0f;
-  cube->height = 2.0f;
-  cube->depth = 2.0f;
-  root->addChild(cube);
-
-  // Step 1: identity. Baseline: matrix must be identity, bbox must be
-  // the cube's own untransformed box.
-  SbMatrix m1 = getMatrix(root, cube);
-  checkMatrix("step1 identity: matrix == identity", m1, SbMatrix::identity());
-  SbBox3f b1 = getBBox(root, TRUE);
-  SbBox3f wantb1(-1.0f, -1.0f, -1.0f, 1.0f, 1.0f, 1.0f);
-  checkBBox("step1 identity: bbox == unit cube", b1, wantb1);
-
-  // Step 2: mutate to non-identity. This must invalidate whatever bbox
-  // cache step 1 built (the interesting case if addNodeId() being
-  // skipped in step 1 ever mattered: this node was never registered as
-  // a dependency of that cache).
-  SbMatrix wantm2;
-  SbBox3f wantb2;
-  if (strcmp(kind, "scale") == 0) {
-    static_cast<SoScale *>(xform)->scaleFactor.setValue(2.0f, 2.0f, 2.0f);
-    wantm2 = SbMatrix::identity();
-    wantm2[0][0] = 2.0f; wantm2[1][1] = 2.0f; wantm2[2][2] = 2.0f;
-    wantb2.setBounds(SbVec3f(-2.0f, -2.0f, -2.0f), SbVec3f(2.0f, 2.0f, 2.0f));
-  }
-  else if (strcmp(kind, "rotation") == 0) {
-    SbRotation rot(SbVec3f(0.0f, 0.0f, 1.0f), (float)(M_PI / 2.0)); // 90 deg about Z
-    static_cast<SoRotation *>(xform)->rotation.setValue(rot);
-    rot.getValue(wantm2);
-    // A 90-degree rotation of a symmetric 2x2x2 cube about its own
-    // center still bounds to the same box (edge lengths swap X/Y, but
-    // the cube is symmetric) -- so re-use wantb1 here, this step
-    // mainly exercises the matrix + cache-invalidation path.
-    wantb2 = wantb1;
-  }
-  else {
-    SoRotationXYZ * rxyz = static_cast<SoRotationXYZ *>(xform);
-    rxyz->angle.setValue((float)(M_PI / 2.0));
-    SbRotation rot(SbVec3f(0.0f, 0.0f, 1.0f), (float)(M_PI / 2.0));
-    rot.getValue(wantm2);
-    wantb2 = wantb1; // same reasoning as the "rotation" case above
-  }
-  SbMatrix m2 = getMatrix(root, cube);
-  checkMatrix("step2 non-identity: matrix reflects change", m2, wantm2);
-  SbBox3f b2 = getBBox(root, TRUE);
-  checkBBox("step2 non-identity: bbox reflects change", b2, wantb2);
-
-  // Step 3: back to identity. The bbox cache from step 2 (built for the
-  // non-identity value) must be correctly invalidated and recomputed
-  // -- this is the actual "after creating caches" case for the
-  // identity-skip optimization itself, since a real GL/bbox cache now
-  // exists and this transition exercises re-entering the skipped path.
-  if (strcmp(kind, "scale") == 0) {
-    static_cast<SoScale *>(xform)->scaleFactor.setValue(1.0f, 1.0f, 1.0f);
-  }
-  else if (strcmp(kind, "rotation") == 0) {
-    static_cast<SoRotation *>(xform)->rotation.setValue(SbVec3f(0.0f, 0.0f, 1.0f), 0.0f);
-  }
-  else {
-    static_cast<SoRotationXYZ *>(xform)->angle.setValue(0.0f);
-  }
-  SbMatrix m3 = getMatrix(root, cube);
-  checkMatrix("step3 back to identity: matrix == identity", m3, SbMatrix::identity());
-  SbBox3f b3 = getBBox(root, TRUE);
-  checkBBox("step3 back to identity: bbox == unit cube", b3, wantb1);
-
-  root->unref();
 }
 
 int main()
 {
   SoDB::init();
-  runSequence("scale");
-  runSequence("rotation");
-  runSequence("rotationxyz");
-
-  if (failures > 0) {
-    fprintf(stderr, "\n[repro] FAIL: %d check(s) failed\n", failures);
-    return 1;
-  }
-  fprintf(stderr, "\n[repro] PASS: all checks passed\n");
-  return 0;
+  for (int kind = 0; kind < 3; ++kind)
+    IdentityTransformCacheTest::run(kind, check);
+  // All action and scene objects have already been destroyed.
+  SoDB::finish();
+  fprintf(stderr, "%s: identity transform cache checks\n",
+          failures ? "FAIL" : "PASS");
+  return failures ? 1 : 0;
 }

--- a/testsuite/reproducers/identity-transform-node-cache-check/run.sh
+++ b/testsuite/reproducers/identity-transform-node-cache-check/run.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+# Verification repro for the SoScale/SoRotation/SoRotationXYZ identity
+# optimization -- see repro.cpp for the full explanation. Checks
+# accumulated matrix and bounding box across identity -> non-identity ->
+# identity transitions, with caching on throughout.
+#
+#   testsuite/reproducers/identity-transform-node-cache-check/run.sh /path/to/build/lib
+#
+# Prints PASS and exits 0 if every check passes.
+
+CDPATH= cd "$(dirname "$0")" || exit 2
+
+LIBDIR="$1"
+if [ -z "$LIBDIR" ]; then
+  echo "usage: $0 /path/to/build/lib   (directory containing libCoin.so)" >&2
+  exit 2
+fi
+
+CXX=${CXX:-c++}
+# The current directory is already the reproducer directory.
+SRCINCLUDE="$(CDPATH= cd ../../.. && pwd)/include" || exit 2
+
+"$CXX" -O1 -g repro.cpp -o repro -I"$SRCINCLUDE" -I"$LIBDIR/../include" -L"$LIBDIR" -lCoin || exit 2
+
+export LD_LIBRARY_PATH="$LIBDIR${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+./repro
+status=$?
+if [ "$status" -ne 0 ]; then
+  echo "=== FAIL: repro exited with status $status ===" >&2
+  exit "$status"
+fi

--- a/testsuite/reproducers/identity-transform-node-cache-check/run.sh
+++ b/testsuite/reproducers/identity-transform-node-cache-check/run.sh
@@ -8,19 +8,21 @@
 #
 # Prints PASS and exits 0 if every check passes.
 
-CDPATH= cd "$(dirname "$0")" || exit 2
-
 LIBDIR="$1"
 if [ -z "$LIBDIR" ]; then
   echo "usage: $0 /path/to/build/lib   (directory containing libCoin.so)" >&2
   exit 2
 fi
 
+LIBDIR="$(CDPATH= cd "$LIBDIR" && pwd)" || exit 2
+CDPATH= cd "$(dirname "$0")" || exit 2
+
 CXX=${CXX:-c++}
 # The current directory is already the reproducer directory.
 SRCINCLUDE="$(CDPATH= cd ../../.. && pwd)/include" || exit 2
 
-"$CXX" -O1 -g repro.cpp -o repro -I"$SRCINCLUDE" -I"$LIBDIR/../include" -L"$LIBDIR" -lCoin || exit 2
+# CXXFLAGS/LDFLAGS intentionally use shell word splitting for compiler flags.
+"$CXX" ${CXXFLAGS:--O1 -g} repro.cpp -o repro -I"$SRCINCLUDE" -I"$LIBDIR/../include" -L"$LIBDIR" -lCoin ${LDFLAGS:-} || exit 2
 
 export LD_LIBRARY_PATH="$LIBDIR${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
 ./repro


### PR DESCRIPTION
Skip exact-identity matrix-element updates in `SoScale`, `SoRotation`, and `SoRotationXYZ`, following the existing `SoTransform` optimization. Non-identity values retain the existing behavior. This is an optimization, not a demonstrated fix for issue #534's visual corruption.

Add a portable `CoinTests` scenario shared with the standalone reproducer. For each node, it checks identity → non-identity → identity with independently specified matrices and bounding boxes. Caching is enabled once; a traversal counter verifies a rebuild after each change and reuse on an unchanged repeat. A 2×4×6 box makes stale rotation results observable. The standalone driver releases Coin globals after destroying its scene and actions.

## Validation

- Clean Linux Debug builds with GCC and Clang: CTest passed; 331 tests / 83,722 checks, including 45 assertions in the new scenario. Standalone reproducer passed with both compilers.
- Negative controls: reassigning the cache option before each measurement fails the reuse assertions; substituting the original box for subsequent measurements fails the expected-extents assertions for all three node types.
- Clang Debug ASan/UBSan instrumented both Coin and CoinTests, and separately the standalone driver: `-O0 -g1 -fsanitize=address,undefined -fno-omit-frame-pointer`, with `ASAN_OPTIONS=detect_leaks=1`, no suppressions. The standalone driver passed with leak detection enabled and UBSan set to halt on error. All CoinTests assertions passed with no UBSan reports, but CTest failed under LeakSanitizer: 11,552 bytes in 207 allocations, exactly matching a comparison run of the original 330-test suite from the published PR. The full sanitizer suite is not reported as a clean pass.
- Reviewed the final diff, documentation, and relevant conditional code; `git diff --check` passed. The new test has no platform or optional-feature guards and is extracted from the `COIN_TEST_SUITE` block into CoinTests.

## Limitations

The new scenario exercises matrix and bounding-box actions, not GL rendering or render-cache behavior. Windows/macOS and optional configurations were not executed locally. The existing full-suite leaks remain outside these test corrections. No benchmark or reproduction of issue #534's visual symptom is claimed.
